### PR TITLE
Fix required type on Capacitor plugin 

### DIFF
--- a/wallet/bindings/capacitorjs/android/src/main/java/org/iota/IotaWalletMobile/IotaWalletMobile.java
+++ b/wallet/bindings/capacitorjs/android/src/main/java/org/iota/IotaWalletMobile/IotaWalletMobile.java
@@ -94,8 +94,8 @@ public class IotaWalletMobile extends Plugin {
             Integer messageHandlerPointer = 1;
             ret.put("messageHandler", messageHandlerPointer);
             call.resolve(ret);
-        } catch (Exception e) {
-            call.reject(ex.getMessage() + Arrays.toString(ex.getStackTrace()))
+        } catch (Exception ex) {
+            call.reject(ex.getMessage() + Arrays.toString(ex.getStackTrace()));
         }
     }
 

--- a/wallet/bindings/capacitorjs/src/definitions.ts
+++ b/wallet/bindings/capacitorjs/src/definitions.ts
@@ -3,6 +3,7 @@
 
 import type { EventType, AccountManagerOptions } from './types';
 export interface IotaWalletMobileTypes {
+    initLogger(path: string): Promise<void>;
     messageHandlerNew(messageOptions: AccountManagerOptions): Promise<{
         messageHandler: number;
     }>;


### PR DESCRIPTION
# Description of change

There was an unintended error with latest moment commit deleting a required type. Currently there is an error at install the plugin.
This PR reverts needed `initLogger` at `definitions.ts`

There is also this issue to complete implementation of `initLogger` on Android / iOS: https://github.com/iotaledger/iota-sdk/issues/78


## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
