### PR TITLE
fix(types): allow enum debug impls to respect format configs

### DIFF
--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -44,9 +44,9 @@ pub enum Address {
 impl core::fmt::Debug for Address {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Ed25519(address) => write!(f, "{address:?}"),
-            Self::Alias(address) => write!(f, "{address:?}"),
-            Self::Nft(address) => write!(f, "{address:?}"),
+            Self::Ed25519(address) => address.fmt(f),
+            Self::Alias(address) => address.fmt(f),
+            Self::Nft(address) => address.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/input/mod.rs
+++ b/sdk/src/types/block/input/mod.rs
@@ -41,8 +41,8 @@ pub enum Input {
 impl core::fmt::Debug for Input {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Utxo(input) => write!(f, "{input:?}"),
-            Self::Treasury(input) => write!(f, "{input:?}"),
+            Self::Utxo(input) => input.fmt(f),
+            Self::Treasury(input) => input.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/output/chain_id.rs
+++ b/sdk/src/types/block/output/chain_id.rs
@@ -19,11 +19,13 @@ pub enum ChainId {
 
 impl core::fmt::Debug for ChainId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut formatter = f.debug_tuple("ChainId");
         match self {
-            Self::Alias(id) => write!(f, "ChainId({id:?})"),
-            Self::Foundry(id) => write!(f, "ChainId({id:?})"),
-            Self::Nft(id) => write!(f, "ChainId({id:?})"),
-        }
+            Self::Alias(id) => formatter.field(id),
+            Self::Foundry(id) => formatter.field(id),
+            Self::Nft(id) => formatter.field(id),
+        };
+        formatter.finish()
     }
 }
 

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -44,10 +44,10 @@ pub enum Feature {
 impl core::fmt::Debug for Feature {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Sender(feature) => write!(f, "{feature:?}"),
-            Self::Issuer(feature) => write!(f, "{feature:?}"),
-            Self::Metadata(feature) => write!(f, "{feature:?}"),
-            Self::Tag(feature) => write!(f, "{feature:?}"),
+            Self::Sender(feature) => feature.fmt(f),
+            Self::Issuer(feature) => feature.fmt(f),
+            Self::Metadata(feature) => feature.fmt(f),
+            Self::Tag(feature) => feature.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -106,11 +106,11 @@ pub enum Output {
 impl core::fmt::Debug for Output {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Treasury(output) => write!(f, "{output:?}"),
-            Self::Basic(output) => write!(f, "{output:?}"),
-            Self::Alias(output) => write!(f, "{output:?}"),
-            Self::Foundry(output) => write!(f, "{output:?}"),
-            Self::Nft(output) => write!(f, "{output:?}"),
+            Self::Treasury(output) => output.fmt(f),
+            Self::Basic(output) => output.fmt(f),
+            Self::Alias(output) => output.fmt(f),
+            Self::Foundry(output) => output.fmt(f),
+            Self::Nft(output) => output.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/output/token_scheme/mod.rs
+++ b/sdk/src/types/block/output/token_scheme/mod.rs
@@ -20,7 +20,7 @@ pub enum TokenScheme {
 impl core::fmt::Debug for TokenScheme {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Simple(scheme) => write!(f, "{scheme:?}"),
+            Self::Simple(scheme) => scheme.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -58,13 +58,13 @@ pub enum UnlockCondition {
 impl core::fmt::Debug for UnlockCondition {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Address(unlock_condition) => write!(f, "{unlock_condition:?}"),
-            Self::StorageDepositReturn(unlock_condition) => write!(f, "{unlock_condition:?}"),
-            Self::Timelock(unlock_condition) => write!(f, "{unlock_condition:?}"),
-            Self::Expiration(unlock_condition) => write!(f, "{unlock_condition:?}"),
-            Self::StateControllerAddress(unlock_condition) => write!(f, "{unlock_condition:?}"),
-            Self::GovernorAddress(unlock_condition) => write!(f, "{unlock_condition:?}"),
-            Self::ImmutableAliasAddress(unlock_condition) => write!(f, "{unlock_condition:?}"),
+            Self::Address(unlock_condition) => unlock_condition.fmt(f),
+            Self::StorageDepositReturn(unlock_condition) => unlock_condition.fmt(f),
+            Self::Timelock(unlock_condition) => unlock_condition.fmt(f),
+            Self::Expiration(unlock_condition) => unlock_condition.fmt(f),
+            Self::StateControllerAddress(unlock_condition) => unlock_condition.fmt(f),
+            Self::GovernorAddress(unlock_condition) => unlock_condition.fmt(f),
+            Self::ImmutableAliasAddress(unlock_condition) => unlock_condition.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/payload/mod.rs
+++ b/sdk/src/types/block/payload/mod.rs
@@ -52,10 +52,10 @@ pub enum Payload {
 impl core::fmt::Debug for Payload {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Transaction(payload) => write!(f, "{payload:?}"),
-            Self::Milestone(payload) => write!(f, "{payload:?}"),
-            Self::TreasuryTransaction(payload) => write!(f, "{payload:?}"),
-            Self::TaggedData(payload) => write!(f, "{payload:?}"),
+            Self::Transaction(payload) => payload.fmt(f),
+            Self::Milestone(payload) => payload.fmt(f),
+            Self::TreasuryTransaction(payload) => payload.fmt(f),
+            Self::TaggedData(payload) => payload.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/signature/mod.rs
+++ b/sdk/src/types/block/signature/mod.rs
@@ -30,7 +30,7 @@ pub enum Signature {
 impl core::fmt::Debug for Signature {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Ed25519(signature) => write!(f, "{signature:?}"),
+            Self::Ed25519(signature) => signature.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/unlock/mod.rs
+++ b/sdk/src/types/block/unlock/mod.rs
@@ -57,10 +57,10 @@ pub enum Unlock {
 impl core::fmt::Debug for Unlock {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Signature(unlock) => write!(f, "{unlock:?}"),
-            Self::Reference(unlock) => write!(f, "{unlock:?}"),
-            Self::Alias(unlock) => write!(f, "{unlock:?}"),
-            Self::Nft(unlock) => write!(f, "{unlock:?}"),
+            Self::Signature(unlock) => unlock.fmt(f),
+            Self::Reference(unlock) => unlock.fmt(f),
+            Self::Alias(unlock) => unlock.fmt(f),
+            Self::Nft(unlock) => unlock.fmt(f),
         }
     }
 }


### PR DESCRIPTION
# Description of change

The debug impls from #158 do not respect formatter configs.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
