### PR TITLE
fix: remove importsNotUsedAsValues TS option

### DIFF
--- a/sdk/src/client/bindings/nodejs/examples/tsconfig.json
+++ b/sdk/src/client/bindings/nodejs/examples/tsconfig.json
@@ -5,7 +5,6 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "node",
-        "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "removeComments": true,
         "skipLibCheck": true,

--- a/sdk/src/client/bindings/nodejs/tsconfig.json
+++ b/sdk/src/client/bindings/nodejs/tsconfig.json
@@ -7,7 +7,6 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "node",
-        "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "preserveConstEnums": true,
         "resolveJsonModule": true,

--- a/sdk/src/client/bindings/wasm/tsconfig.base.json
+++ b/sdk/src/client/bindings/wasm/tsconfig.base.json
@@ -5,7 +5,6 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "node",
-        "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "preserveConstEnums": true,
         "resolveJsonModule": true,

--- a/sdk/src/wallet/bindings/nodejs/package-lock.json
+++ b/sdk/src/wallet/bindings/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iota/wallet",
-  "version": "2.0.3-rc.27",
+  "version": "2.0.3-rc.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@iota/wallet",
-      "version": "2.0.3-rc.27",
+      "version": "2.0.3-rc.30",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/sdk/src/wallet/bindings/nodejs/tsconfig.json
+++ b/sdk/src/wallet/bindings/nodejs/tsconfig.json
@@ -8,7 +8,6 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "node",
-        "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "removeComments": false,
         "preserveConstEnums": true,

--- a/sdk/src/wallet/bindings/wasm/tsconfig.base.json
+++ b/sdk/src/wallet/bindings/wasm/tsconfig.base.json
@@ -5,7 +5,6 @@
         "sourceMap": true,
         "strict": true,
         "moduleResolution": "node",
-        "importsNotUsedAsValues": "error",
         "noImplicitAny": true,
         "preserveConstEnums": true,
         "resolveJsonModule": true,


### PR DESCRIPTION
# Description of change

With the advent of TS 5.0, the `importsNotUsedAsValues` option is removed.
It is deprecated in favour of [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax).
At the moment, there is no need to include this flag, since it would require us to explicitely think about adding `import type` to every type import to mitigate side-effects cause by imports. Without the flag set, TS automatically drops type imports when transpiling to JS.


More info: https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues

## Links to any relevant issues

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
