### PR TITLE
Capacitorjs update Pod file to exclude arm64 simulator

### DIFF
--- a/sdk/src/wallet/bindings/capacitorjs/ios/Podfile
+++ b/sdk/src/wallet/bindings/capacitorjs/ios/Podfile
@@ -13,3 +13,9 @@ end
 target 'PluginTests' do
   capacitor_pods
 end
+
+post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+  end
+end


### PR DESCRIPTION
# Description of change

Fix needed to run Firefly inside the simulator when runs natively on XCode with processors M1 / M2 but the simulated app runs still under Intel. 
Removing the arm64 architecture for the pods and project settings fixed the issue.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
