### PR TITLE
CLI: Maintain history order

### DIFF
--- a/cli/src/account_history.rs
+++ b/cli/src/account_history.rs
@@ -27,17 +27,27 @@ impl<T: ToString> History<T> for AccountHistory {
     fn write(&mut self, val: &T) {
         let entry = val.to_string();
 
-        if let Some(command) = self.history.front() {
-            // If the last used command is the same, dont add it
-            if command == &entry {
-                return;
+        // If the last used command is the same, dont change anything
+        if matches!(self.history.front(), Some(command) if command == &entry) {
+            return;
+        }
+
+        // We only need to check size if we dont remove an item
+        match self.history.binary_search(&entry) {
+            Ok(index) => {
+                // Remove the old command
+                self.history.remove(index);
+            }
+            Err(_) => {
+                // We have not used this command
+                if self.history.len() == self.max {
+                    // Remove the oldest used command
+                    self.history.pop_back();
+                }
             }
         }
 
-        if self.history.len() == self.max {
-            self.history.pop_back();
-        }
-
+        // Add command as most recent used
         self.history.push_front(entry);
     }
 }

--- a/cli/src/account_history.rs
+++ b/cli/src/account_history.rs
@@ -27,7 +27,7 @@ impl<T: ToString> History<T> for AccountHistory {
     fn write(&mut self, val: &T) {
         let entry = val.to_string();
 
-        // If the last used command is the same, dont change anything
+        // If the last used command is the same, don't change anything
         if matches!(self.history.front(), Some(command) if command == &entry) {
             return;
         }

--- a/cli/src/account_history.rs
+++ b/cli/src/account_history.rs
@@ -32,7 +32,7 @@ impl<T: ToString> History<T> for AccountHistory {
             return;
         }
 
-        // We only need to check size if we dont remove an item
+        // Check if we have used this command before
         match self.history.iter().position(|e| e == &entry) {
             Some(index) => {
                 // Remove the old command

--- a/cli/src/account_history.rs
+++ b/cli/src/account_history.rs
@@ -33,12 +33,12 @@ impl<T: ToString> History<T> for AccountHistory {
         }
 
         // We only need to check size if we dont remove an item
-        match self.history.binary_search(&entry) {
-            Ok(index) => {
+        match self.history.iter().position(|e| e == &entry) {
+            Some(index) => {
                 // Remove the old command
                 self.history.remove(index);
             }
-            Err(_) => {
+            None => {
                 // We have not used this command
                 if self.history.len() == self.max {
                     // Remove the oldest used command

--- a/cli/src/account_history.rs
+++ b/cli/src/account_history.rs
@@ -26,12 +26,18 @@ impl<T: ToString> History<T> for AccountHistory {
 
     fn write(&mut self, val: &T) {
         let entry = val.to_string();
-        if self.history.contains(&entry) {
-            return;
+
+        if let Some(command) = self.history.front() {
+            // If the last used command is the same, dont add it
+            if command == &entry {
+                return;
+            }
         }
+
         if self.history.len() == self.max {
             self.history.pop_back();
         }
+
         self.history.push_front(entry);
     }
 }


### PR DESCRIPTION
# Description of change

Turns the order of 
```
$ balance
$ sync
$ balance
$ sync
```

into
```
$ balance
$ sync
```
---------------------

Turns the order of 
```
$ balance
$ sync
$ sync
$ sync
```

into 
```
$ balance
$ sync
```

## Links to any relevant issues

fixes #157

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

ran the examples in the cli

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
