### PR TITLE
feat(cli)!: use clap to read env vars

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 iota-sdk = { path = "../sdk", default-features = false, features = [ "wallet", "tls", "storage", "rocksdb", "stronghold", "participation" ] }
 
-clap = { version = "4.2.0", default-features = false, features = [ "std", "color", "help", "usage", "error-context", "suggestions", "derive" ] }
+clap = { version = "4.2.0", default-features = false, features = [ "std", "color", "help", "usage", "error-context", "suggestions", "derive", "env" ] }
 dialoguer = { version = "0.10.3", default-features = false, features = [ "history", "password", "completion" ] }
 fern-logger = { version = "0.5.0", default-features = false }
 humantime = { version = "2.1.0", default-features = false }

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -15,6 +15,7 @@ use crate::{error::Error, helper::get_password, println_log_info};
 const DEFAULT_NODE_URL: &str = "https://api.testnet.shimmer.network";
 const DEFAULT_WALLET_DATABASE_PATH: &str = "./stardust-cli-wallet-db";
 const DEFAULT_STRONGHOLD_SNAPSHOT_PATH: &str = "./stardust-cli-wallet.stronghold";
+const DEFAULT_LOG_LEVEL: &str = "debug";
 
 #[derive(Debug, Clone, Parser)]
 #[command(author, version, about, long_about = None, propagate_version = true)]
@@ -28,7 +29,7 @@ pub struct WalletCli {
     /// Set the account to enter.
     pub account: Option<String>,
     /// Set the log level.
-    #[arg(short, long, default_value = "Info")]
+    #[arg(short, long, default_value = DEFAULT_LOG_LEVEL)]
     pub log_level: LevelFilter,
     #[command(subcommand)]
     pub command: Option<WalletCommand>,

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -12,14 +12,26 @@ use log::LevelFilter;
 
 use crate::{error::Error, helper::get_password, println_log_info};
 
+const DEFAULT_NODE_URL: &str = "https://api.testnet.shimmer.network";
+const DEFAULT_WALLET_DATABASE_PATH: &str = "./stardust-cli-wallet-db";
+const DEFAULT_STRONGHOLD_SNAPSHOT_PATH: &str = "./stardust-cli-wallet.stronghold";
+
 #[derive(Debug, Clone, Parser)]
 #[command(author, version, about, long_about = None, propagate_version = true)]
 pub struct WalletCli {
-    #[command(subcommand)]
-    pub command: Option<WalletCommand>,
+    /// Set the path to the wallet database.
+    #[arg(long, value_name = "PATH", env = "WALLET_DATABASE_PATH", default_value = DEFAULT_WALLET_DATABASE_PATH)]
+    pub wallet_db_path: String,
+    /// Set the path to the stronghold snapshot file.
+    #[arg(long, value_name = "PATH", env = "STRONGHOLD_SNAPSHOT_PATH", default_value = DEFAULT_STRONGHOLD_SNAPSHOT_PATH)]
+    pub stronghold_snapshot_path: String,
+    /// Set the account to enter.
     pub account: Option<String>,
+    /// Set the log level.
     #[arg(short, long)]
     pub log_level: Option<LevelFilter>,
+    #[command(subcommand)]
+    pub command: Option<WalletCommand>,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -59,9 +71,9 @@ pub struct InitParameters {
     /// Mnemonic, randomly generated if not provided.
     #[arg(short, long)]
     pub mnemonic: Option<String>,
-    /// Node URL, "https://api.testnet.shimmer.network" if not provided.
-    #[arg(short, long)]
-    pub node: Option<String>,
+    /// Set the node to connect to with this wallet.
+    #[arg(short, long, value_name = "URL", env = "NODE_URL", default_value = DEFAULT_NODE_URL)]
+    pub node_url: String,
     /// Coin type, SHIMMER_COIN_TYPE (4219) if not provided.
     #[arg(short, long)]
     pub coin_type: Option<u32>,
@@ -90,14 +102,7 @@ pub async fn init_command(
 ) -> Result<Wallet, Error> {
     let wallet = Wallet::builder()
         .with_secret_manager(secret_manager)
-        .with_client_options(
-            ClientOptions::new().with_node(
-                parameters
-                    .node
-                    .as_deref()
-                    .unwrap_or("https://api.testnet.shimmer.network"),
-            )?,
-        )
+        .with_client_options(ClientOptions::new().with_node(parameters.node_url.as_str())?)
         .with_storage_path(&storage_path)
         .with_coin_type(parameters.coin_type.unwrap_or(SHIMMER_COIN_TYPE))
         .finish()

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -28,8 +28,8 @@ pub struct WalletCli {
     /// Set the account to enter.
     pub account: Option<String>,
     /// Set the log level.
-    #[arg(short, long)]
-    pub log_level: Option<LevelFilter>,
+    #[arg(short, long, default_value = "Info")]
+    pub log_level: LevelFilter,
     #[command(subcommand)]
     pub command: Option<WalletCommand>,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,7 +11,6 @@ mod wallet;
 
 use clap::Parser;
 use fern_logger::{LoggerConfigBuilder, LoggerOutputConfigBuilder};
-use log::LevelFilter;
 
 use self::{command::wallet::WalletCli, error::Error, helper::pick_account, wallet::new_wallet};
 
@@ -32,14 +31,9 @@ macro_rules! println_log_error {
 }
 
 fn logger_init(cli: &WalletCli) -> Result<(), Error> {
-    let level_filter = if let Some(log_level) = cli.log_level {
-        log_level
-    } else {
-        LevelFilter::Debug
-    };
     let archive = LoggerOutputConfigBuilder::default()
         .name("archive.log")
-        .level_filter(level_filter)
+        .level_filter(cli.log_level)
         .target_exclusions(&["rustls"])
         .color_enabled(false);
     let config = LoggerConfigBuilder::default().with_output(archive).finish();

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1,8 +1,6 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env::var_os;
-
 use iota_sdk::{
     client::secret::{stronghold::StrongholdSecretManager, SecretManager},
     wallet::Wallet,
@@ -24,11 +22,8 @@ pub async fn new_wallet(cli: WalletCli) -> Result<(Option<Wallet>, Option<String
         return Ok((None, None));
     }
 
-    let storage_path = var_os("WALLET_DATABASE_PATH").map_or_else(
-        || "./stardust-cli-wallet-db".to_string(),
-        |os_str| os_str.into_string().expect("invalid WALLET_DATABASE_PATH"),
-    );
-    let snapshot_path = std::path::Path::new("./stardust-cli-wallet.stronghold");
+    let storage_path = cli.wallet_db_path;
+    let snapshot_path = std::path::Path::new(&cli.stronghold_snapshot_path);
     let snapshot_exists = snapshot_path.exists();
     let password = if let Some(WalletCommand::Restore { .. }) = &cli.command {
         get_password("Stronghold password", false)?

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -7,13 +7,13 @@ It is responsible for the creation and management of the wallet and its accounts
 
 You can run `./wallet --help` to print all available CLI commands, arguments, and options. The available options are listed in the table below:
 
-| Name                         | Description | Default | Environment Variable | Example |
-| ---------------------------- | ----------- | -------------------- | --- | --- |
-| `--wallet-db-path`           | Sets the path to the wallet database | `./stardust-cli-wallet-db` | `WALLET_DATABASE_PATH` | `/path/to/wallet-db` |
-| `--stronghold-snapshot-path` | Sets the path to the Stronghold snapshot file | `./stardust-cli-wallet.stronghold` | `STRONGHOLD_SNAPSHOT_PATH`| `/path/to/stronghold-snapshot` |
-| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | `debug` | ✘ | `trace` |
-| `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ | ✘ | ✘ |
-| `--version` (`-V`)           | Shows the current version | ✘ | ✘ | ✘ |
+| Name                         | Description                                                    | Default                            | Environment Variable      | Example                        |
+| ---------------------------- | -------------------------------------------------------------- | ---------------------------------- | ------------------------- | ------------------------------ |
+| `--wallet-db-path`           | Sets the path to the wallet database                           | `./stardust-cli-wallet-db`         | `WALLET_DATABASE_PATH`    | `/path/to/wallet-db`           |
+| `--stronghold-snapshot-path` | Sets the path to the Stronghold snapshot file                  | `./stardust-cli-wallet.stronghold` | `STRONGHOLD_SNAPSHOT_PATH`| `/path/to/stronghold-snapshot` |
+| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | `debug`                            | ✘                         | `trace`                        |
+| `--help` (`-h`)              | Shows all available commands, arguments and options            | ✘                                  | ✘                         | ✘                              |
+| `--version` (`-V`)           | Shows the current version                                      | ✘                                  | ✘                         | ✘                              |
 
 ## Usage Examples
 
@@ -81,11 +81,11 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 #### Options
 
-| Name                 | Description    | Default    | Environment Variable | Example |
-| -------------------- | -------------- |----------- |----------------------| ------- |
-| `--mnemonic` (`-m`)  | Initialises a wallet from an existing mnemonic | ✘ | ✘ |"aunt middle impose ..." |
-| `--node-url` (`-n`)  | Sets the node to connect to | https://api.testnet.shimmer.network | `NODE_URL` | http://localhost:14265 |
-| `--coin-type` (`-c`) | Sets the coin type associated with the wallet  | 4219 (=Shimmer) | ✘ | 4218(=IOTA) |
+| Name                 | Description                                    | Default                             | Environment Variable | Example                 |
+| -------------------- | ---------------------------------------------- |------------------------------------ |----------------------| ----------------------- |
+| `--mnemonic` (`-m`)  | Initialises a wallet from an existing mnemonic | ✘                                   | ✘                    |"aunt middle impose ..." |
+| `--node-url` (`-n`)  | Sets the node to connect to                    | https://api.testnet.shimmer.network | `NODE_URL`           | http://localhost:14265  |
+| `--coin-type` (`-c`) | Sets the coin type associated with the wallet  | 4219 (=Shimmer)                     | ✘                    | 4218(=IOTA)             |
 
 #### Examples
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -17,9 +17,9 @@ Displays the wallet interface usage and exits.
 | ---------------------------- | ----------- | -------------------- | --- | --- |
 | `--wallet-db-path`           | Sets the path to the wallet database | `./stardust-cli-wallet-db` | `WALLET_DATABASE_PATH` | `/path/to/wallet-db` |
 | `--stronghold-snapshot-path` | Sets the path to the Stronghold snapshot file | `./stardust-cli-wallet.stronghold` | `STRONGHOLD_SNAPSHOT_PATH`| `/path/to/stronghold-snapshot` |
-| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | `info` | ✘ | `debug` |
-| `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ | ✘ | TODO |
-| `--version` (`-V`)           | Shows the current version | ✘ | ✘ | TODO |
+| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | `debug` | ✘ | `trace` |
+| `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ | ✘ | ✘ |
+| `--version` (`-V`)           | Shows the current version | ✘ | ✘ | ✘ |
 
 ### `./wallet`
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -5,13 +5,7 @@ execution.
 
 It is responsible for the creation and management of the wallet and its accounts.
 
-## Commands
-
-### `./wallet --help`
-
-Displays the wallet interface usage and exits.
-
-#### Options
+You can run `./wallet --help` to print all available CLI commands, arguments, and options. The available options are listed in the table below:
 
 | Name                         | Description | Default | Environment Variable | Example |
 | ---------------------------- | ----------- | -------------------- | --- | --- |
@@ -20,6 +14,8 @@ Displays the wallet interface usage and exits.
 | `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | `debug` | ✘ | `trace` |
 | `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ | ✘ | ✘ |
 | `--version` (`-V`)           | Shows the current version | ✘ | ✘ | ✘ |
+
+## Usage Examples
 
 ### `./wallet`
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -84,7 +84,7 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 | Name                 | Description    | Default    | Environment Variable | Example |
 | -------------------- | -------------- |----------- |----------------------| ------- |
 | `--mnemonic` (`-m`)  | Initialises a wallet from an existing mnemonic | ✘ | ✘ |"aunt middle impose ..." |
-| `--node_url` (`-n`)  | Sets the node to connect to | https://api.testnet.shimmer.network | `NODE_URL` | http://localhost:14265 |
+| `--node-url` (`-n`)  | Sets the node to connect to | https://api.testnet.shimmer.network | `NODE_URL` | http://localhost:14265 |
 | `--coin-type` (`-c`) | Sets the coin type associated with the wallet  | 4219 (=Shimmer) | ✘ | 4218(=IOTA) |
 
 #### Examples

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -7,7 +7,7 @@ It is responsible for the creation and management of the wallet and its accounts
 
 ## Commands
 
-### `./wallet help`
+### `./wallet --help`
 
 Displays the wallet interface usage and exits.
 
@@ -73,12 +73,6 @@ Changes the stronghold password.
 Change the stronghold password.
 ```sh
 ./wallet change-password
-```
-
-#### Example
-
-```sh
-./wallet help
 ```
 
 ### `./wallet init`

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -7,6 +7,20 @@ It is responsible for the creation and management of the wallet and its accounts
 
 ## Commands
 
+### `./wallet help`
+
+Displays the wallet interface usage and exits.
+
+#### Options
+
+| Name                         | Description | Environment Variable | 
+| ---------------------------- | ----------- | -------------------- |
+| `--wallet-db-path`           | Sets the path to the wallet database | `WALLET_DATABASE_PATH` |
+| `--stronghold-snapshot-path` | Sets the path to the Stronghold snapshot file | `STRONGHOLD_SNAPSHOT_PATH`|
+| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | ✘ |
+| `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ |
+| `--version` (`-V`)           | Shows the current version | ✘ |
+
 ### `./wallet`
 
 Starts the wallet without a specified account:
@@ -61,10 +75,6 @@ Change the stronghold password.
 ./wallet change-password
 ```
 
-### `./wallet help`
-
-Displays the wallet interface usage and exits.
-
 #### Example
 
 ```sh
@@ -79,13 +89,13 @@ The wallet can only be initialised once.
 
 When just initialised, the wallet has no account yet, use the `new` command to create one.
 
-#### Parameters
+#### Options
 
-| Name        | Optional    | Default                             | Example                                                                                                                                                                             |
-| ----------- | ----------- |------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mnemonic`  | ✓           | Randomly generated                  | "aunt middle impose faith ramp kid olive good practice motor grab ready group episode oven matrix silver rhythm avocado assume humble tiger shiver hurt" (DO NOT USE THIS MNEMONIC) |
-| `node_url`      | ✓           | https://api.testnet.shimmer.network | http://localhost:14265                                                                                                                                                              |
-| `coin-type` | ✓           | 4219 (=Shimmer)                     | 4218 (=IOTA)                                                                                                                                                                        |
+| Name                 | Description    | Default    | Environment Variable | Example |
+| -------------------- | -------------- |----------- |----------------------| ------- |
+| `--mnemonic` (`-m`)  | Generates a random mnemonic | ✘ | ✘ |"aunt middle impose ..." |
+| `--node_url` (`-n`)  | Sets the node to connect to | https://api.testnet.shimmer.network | `NODE_URL` | http://localhost:14265 |
+| `--coin-type` (`-c`) | Sets the coin type associated with the wallet  | 4219 (=Shimmer) | ✘ | 4218(=IOTA) |
 
 #### Examples
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -84,7 +84,7 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 | Name        | Optional    | Default                             | Example                                                                                                                                                                             |
 | ----------- | ----------- |------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mnemonic`  | ✓           | Randomly generated                  | "aunt middle impose faith ramp kid olive good practice motor grab ready group episode oven matrix silver rhythm avocado assume humble tiger shiver hurt" (DO NOT USE THIS MNEMONIC) |
-| `node`      | ✓           | https://api.testnet.shimmer.network | http://localhost:14265                                                                                                                                                              |
+| `node_url`      | ✓           | https://api.testnet.shimmer.network | http://localhost:14265                                                                                                                                                              |
 | `coin-type` | ✓           | 4219 (=Shimmer)                     | 4218 (=IOTA)                                                                                                                                                                        |
 
 #### Examples

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -13,13 +13,13 @@ Displays the wallet interface usage and exits.
 
 #### Options
 
-| Name                         | Description | Environment Variable | 
-| ---------------------------- | ----------- | -------------------- |
-| `--wallet-db-path`           | Sets the path to the wallet database | `WALLET_DATABASE_PATH` |
-| `--stronghold-snapshot-path` | Sets the path to the Stronghold snapshot file | `STRONGHOLD_SNAPSHOT_PATH`|
-| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | ✘ |
-| `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ |
-| `--version` (`-V`)           | Shows the current version | ✘ |
+| Name                         | Description | Default | Environment Variable | Example |
+| ---------------------------- | ----------- | -------------------- | --- | --- |
+| `--wallet-db-path`           | Sets the path to the wallet database | `./stardust-cli-wallet-db` | `WALLET_DATABASE_PATH` | `/path/to/wallet-db` |
+| `--stronghold-snapshot-path` | Sets the path to the Stronghold snapshot file | `./stardust-cli-wallet.stronghold` | `STRONGHOLD_SNAPSHOT_PATH`| `/path/to/stronghold-snapshot` |
+| `--log-level` (`-l`)         | Sets the log verbosity level (error, warn, info, debug, trace) | `info` | ✘ | `debug` |
+| `--help` (`-h`)              | Shows all available commands, arguments and options  | ✘ | ✘ | TODO |
+| `--version` (`-V`)           | Shows the current version | ✘ | ✘ | TODO |
 
 ### `./wallet`
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -93,7 +93,7 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 | Name                 | Description    | Default    | Environment Variable | Example |
 | -------------------- | -------------- |----------- |----------------------| ------- |
-| `--mnemonic` (`-m`)  | Generates a random mnemonic | ✘ | ✘ |"aunt middle impose ..." |
+| `--mnemonic` (`-m`)  | Initialises a wallet from an existing mnemonic | ✘ | ✘ |"aunt middle impose ..." |
 | `--node_url` (`-n`)  | Sets the node to connect to | https://api.testnet.shimmer.network | `NODE_URL` | http://localhost:14265 |
 | `--coin-type` (`-c`) | Sets the coin type associated with the wallet  | 4219 (=Shimmer) | ✘ | 4218(=IOTA) |
 

--- a/sdk/examples/client/00_generate_mnemonic.rs
+++ b/sdk/examples/client/00_generate_mnemonic.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example generate_mnemonic --release
+//! TODO: Example description
+//!
+//! `cargo run --example generate_mnemonic --release`
 
 use iota_sdk::client::{Client, Result};
 

--- a/sdk/examples/client/01_generate_addresses.rs
+++ b/sdk/examples/client/01_generate_addresses.rs
@@ -3,7 +3,7 @@
 
 //! TODO: Example description
 //!
-//! `cargo run --example generate_addresses --release -- [NODE URL]`
+//! `cargo run --example generate_addresses --release -- <NODE_URL>`
 
 use iota_sdk::client::{api::GetAddressesBuilder, secret::SecretManager, Client, Result};
 

--- a/sdk/examples/client/01_generate_addresses.rs
+++ b/sdk/examples/client/01_generate_addresses.rs
@@ -3,7 +3,7 @@
 
 //! TODO: Example description
 //!
-//! `cargo run --example generate_addresses --release -- <NODE_URL>`
+//! `cargo run --example generate_addresses --release -- [NODE_URL]`
 
 use iota_sdk::client::{api::GetAddressesBuilder, secret::SecretManager, Client, Result};
 

--- a/sdk/examples/client/07_mqtt.rs
+++ b/sdk/examples/client/07_mqtt.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+//! TODO: Example description
+//!
 //! cargo run --example 07_mqtt --features=mqtt --release
 
 use std::sync::{mpsc::channel, Arc, Mutex};

--- a/sdk/examples/client/client_config.rs
+++ b/sdk/examples/client/client_config.rs
@@ -1,8 +1,9 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example client_config --release
 //! In this example we will create a client from a JSON config.
+//! 
+//! `cargo run --example client_config --release`
 
 use iota_sdk::client::{Client, Result};
 

--- a/sdk/examples/client/node_api_indexer/00_get_basic_outputs.rs
+++ b/sdk/examples/client/node_api_indexer/00_get_basic_outputs.rs
@@ -4,7 +4,7 @@
 //! TODO: <insert example description> by calling
 //! `GET api/indexer/v1/outputs/basic`.
 //!
-//! `cargo run --example node_api_indexer_get_basic_outputs --release -- [NODE URL] [ADDRESS]`.
+//! `cargo run --example node_api_indexer_get_basic_outputs --release -- <NODE_URL> <ADDRESS>`.
 
 use iota_sdk::client::{node_api::indexer::query_parameters::QueryParameter, Client, Result};
 

--- a/sdk/examples/client/node_api_indexer/00_get_basic_outputs.rs
+++ b/sdk/examples/client/node_api_indexer/00_get_basic_outputs.rs
@@ -4,7 +4,7 @@
 //! TODO: <insert example description> by calling
 //! `GET api/indexer/v1/outputs/basic`.
 //!
-//! `cargo run --example node_api_indexer_get_basic_outputs --release -- <NODE_URL> <ADDRESS>`.
+//! `cargo run --example node_api_indexer_get_basic_outputs --release -- [NODE_URL] [ADDRESS]`.
 
 use iota_sdk::client::{node_api::indexer::query_parameters::QueryParameter, Client, Result};
 

--- a/sdk/examples/client/tagged_data_to_utf8.rs
+++ b/sdk/examples/client/tagged_data_to_utf8.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example tagged_data_to_utf8 --release
 //! In this example we will UTF-8 encode the tag and the data of an `TaggedDataPayload`.
+//! 
+//! `cargo run --example tagged_data_to_utf8 --release`
 
 use iota_sdk::client::{block::payload::TaggedDataPayload, Client, Result};
 

--- a/sdk/examples/wallet/04_get_balance.rs
+++ b/sdk/examples/wallet/04_get_balance.rs
@@ -3,7 +3,7 @@
 
 //! In this example we sync the account and get the balance.
 //! Rename `.env.example` to `.env` first.
-//! 
+//!
 //! `cargo run --example get_balance --release`
 
 use iota_sdk::wallet::{Result, Wallet};

--- a/sdk/examples/wallet/04_get_balance.rs
+++ b/sdk/examples/wallet/04_get_balance.rs
@@ -1,9 +1,10 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example get_balance --release
-// In this example we sync the account and get the balance
-// Rename `.env.example` to `.env` first
+//! In this example we sync the account and get the balance.
+//! Rename `.env.example` to `.env` first.
+//! 
+//! `cargo run --example get_balance --release`
 
 use iota_sdk::wallet::{Result, Wallet};
 

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! In this example we check if an output has only an address unlock condition and that the address is from the account.
-//! 
+//!
 //! `cargo run --example check_unlock_conditions --release`
 
 use iota_sdk::{

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -1,8 +1,9 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example check_unlock_conditions --release
-// In this example we check if an output has only an address unlock condition and that the address is from the account.
+//! In this example we check if an output has only an address unlock condition and that the address is from the account.
+//! 
+//! `cargo run --example check_unlock_conditions --release`
 
 use iota_sdk::{
     types::block::output::{unlock_condition::AddressUnlockCondition, BasicOutputBuilder, UnlockCondition},

--- a/sdk/examples/wallet/logger.rs
+++ b/sdk/examples/wallet/logger.rs
@@ -1,7 +1,9 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! cargo run --example logger --release
+//! TODO: Example description
+//!
+//! `cargo run --example logger --release`
 
 use std::time::Instant;
 

--- a/sdk/examples/wallet/offline_signing/3_send_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/3_send_transaction.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! In this example we send the signed transaction in a block.
-//! 
+//!
 //! `cargo run --example 3_send_transaction --release`.
 
 use std::{fs::File, io::prelude::*, path::Path};

--- a/sdk/examples/wallet/offline_signing/3_send_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/3_send_transaction.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! In this example we send the signed transaction in a block.
+//! 
 //! `cargo run --example 3_send_transaction --release`.
 
 use std::{fs::File, io::prelude::*, path::Path};


### PR DESCRIPTION
# Description of change

This PR adds CLI options and environments variables to set the wallet db file path, the Stronghold snapshot file path, and the node url.

## Links to any relevant issues

Closes #161 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
