### PR TITLE
Fix nodejs send examples

### DIFF
--- a/sdk/src/wallet/bindings/nodejs/examples/4c-send-micro-transaction.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/4c-send-micro-transaction.js
@@ -16,15 +16,15 @@ async function run() {
             'rms1qrrv7flg6lz5cssvzv2lsdt8c673khad060l4quev6q09tkm9mgtupgf0h0';
         const amount = '1000';
 
-        const response = await account.sendAmount([
-            {
+        const response = await account.sendAmount(
+            [{
                 address,
                 amount,
-            },
+            }],
             {
                 allowMicroAmount: true,
             }
-        ]);
+        );
 
         console.log(response);
 

--- a/sdk/src/wallet/bindings/nodejs/examples/7-events.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/7-events.js
@@ -23,16 +23,16 @@ async function run() {
         await manager.listen(['TransactionProgress'], callback);
 
         // send transaction
-        await account.sendAmount([
-            {
+        await account.sendAmount(
+            [{
                 address:
                     'rms1qph3f6y3ps7zccucatf70y37kz7udzp94aefg6mzxdgpa5xxerg9u4s0xyz',
                 amount: '1000',
-            },
+            }],
             {
                 allowMicroAmount: true,
             }
-        ]);
+        );
 
         // provide event type to remove only event listeners of this type
         manager.clearListeners(['TransactionProgress']);


### PR DESCRIPTION
# Description of change

Some node examples were broken because of incorrect formatting in the `sendAmount` calls that use the new `allowMicroAmount` option.

## Links to any relevant issues
- Closes #234 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)