### PR TITLE
Fix send parameters

### DIFF
--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -141,6 +141,11 @@ pub async fn account_prompt_internal(
                     expiration,
                     allow_micro_amount,
                 } => {
+                    let allow_micro_amount = if return_address.is_some() || expiration.is_some() {
+                        true
+                    } else {
+                        allow_micro_amount
+                    };
                     send_command(
                         &account_handle,
                         address,

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -153,14 +153,16 @@ pub enum AccountCommand {
         /// Bech32 encoded return address, to which the storage deposit will be returned if one is necessary
         /// given the provided amount. If a storage deposit is needed and a return address is not provided, it will
         /// default to the first address of the account.
+        #[arg(long)]
         return_address: Option<String>,
         /// Expiration in seconds, after which the output will be available for the sender again, if not spent by the
         /// receiver already. The expiration will only be used if one is necessary given the provided amount. If an
         /// expiration is needed but not provided, it will default to one day.
+        #[arg(long)]
         expiration: Option<humantime::Duration>,
         /// Whether to send micro amounts. This will automatically add Storage Deposit Return and Expiration unlock
-        /// conditions if necessary.
-        #[arg(default_value_t = false)]
+        /// conditions if necessary. This flag is implied by the existence of a return address or expiration.
+        #[arg(long, default_value_t = false)]
         allow_micro_amount: bool,
     },
     /// Send native tokens.


### PR DESCRIPTION
# Description of change

The send CLI command accidentally used positional params instead of flags for micro amount config. This fixes that.

## Links to any relevant issues

- Closes #250

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran the command with `--help`
