### PR TITLE
Add base coin balance to addresses overview

### DIFF
--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -798,11 +798,40 @@ async fn print_address(account_handle: &AccountHandle, address: &AccountAddress)
     }
 
     let addresses = account_handle.addresses_with_unspent_outputs().await?;
+    let current_time = iota_sdk::utils::unix_timestamp_now().as_secs() as u32;
 
     if let Ok(index) = addresses.binary_search_by_key(&(address.key_index(), address.internal()), |a| {
         (a.key_index(), a.internal())
     }) {
-        log = format!("{log}\nOutputs: {:#?}", addresses[index].output_ids());
+        let mut address_amount = 0;
+        for output_id in addresses[index].output_ids() {
+            if let Some(output_data) = account_handle.get_output(output_id).await {
+                // Output might be associated with the address, but can't unlocked by it, so we check that here
+                let (required_address, _) =
+                    output_data
+                        .output
+                        .required_and_unlocked_address(current_time, output_id, None)?;
+                if *address.address().as_ref() == required_address {
+                    let unlock_conditions = output_data
+                        .output
+                        .unlock_conditions()
+                        .expect("output must have unlock conditions");
+
+                    if let Some(sdr) = unlock_conditions.storage_deposit_return() {
+                        address_amount += output_data.output.amount() - sdr.amount();
+                    } else {
+                        address_amount += output_data.output.amount();
+                    }
+                }
+            }
+        }
+        log = format!(
+            "{log}\nBase coin amount: {}\nOutputs: {:#?}",
+            address_amount,
+            addresses[index].output_ids()
+        );
+    } else {
+        log = format!("{log}\nBase coin amount: 0\nOutputs: []");
     }
 
     println_log_info!("{log}");

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -826,12 +826,12 @@ async fn print_address(account_handle: &AccountHandle, address: &AccountAddress)
             }
         }
         log = format!(
-            "{log}\nBase coin amount: {}\nOutputs: {:#?}",
-            address_amount,
-            addresses[index].output_ids()
+            "{log}\nOutputs: {:#?}\nBase coin amount: {}",
+            addresses[index].output_ids(),
+            address_amount
         );
     } else {
-        log = format!("{log}\nBase coin amount: 0\nOutputs: []");
+        log = format!("{log}\nOutputs: []\nBase coin amount: 0");
     }
 
     println_log_info!("{log}");

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -826,12 +826,12 @@ async fn print_address(account_handle: &AccountHandle, address: &AccountAddress)
             }
         }
         log = format!(
-            "{log}\nOutputs: {:#?}\nBase coin amount: {}",
+            "{log}\nOutputs: {:#?}\nBase coin amount: {}\n",
             addresses[index].output_ids(),
             address_amount
         );
     } else {
-        log = format!("{log}\nOutputs: []\nBase coin amount: 0");
+        log = format!("{log}\nOutputs: []\nBase coin amount: 0\n");
     }
 
     println_log_info!("{log}");


### PR DESCRIPTION
# Description of change

Add base coin balance to addresses overview

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/103

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running `addresses` command, output looks like
```
Account "Alice": addresses
Address 0: rms1qrtwg3g596lt9dcfsa5ddgqph728g06khacl8mklcpjnvvf4zyhrv3lzzfj
Outputs: [
    OutputId(0x4d056688d489ac92025cc080ef4c7602bb64da40910dc3ede9aed230defdb1780000),
]
Base coin amount: 1000000000

Address 1: rms1qrhz7aqmzvz4efs6ulpz2lxzhqly86s07tg2lxcvpvhgjklgp9ymj996ze4
Outputs: []
Base coin amount: 0

Account "Alice": 
```

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
