### PR TITLE
fix(cli): read environment at start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ version = "1.0.0-rc.2"
 dependencies = [
  "clap",
  "dialoguer",
+ "dotenvy",
  "fern-logger",
  "humantime",
  "iota-sdk",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ iota-sdk = { path = "../sdk", default-features = false, features = [ "wallet", "
 
 clap = { version = "4.2.0", default-features = false, features = [ "std", "color", "help", "usage", "error-context", "suggestions", "derive", "env" ] }
 dialoguer = { version = "0.10.3", default-features = false, features = [ "history", "password", "completion" ] }
+dotenvy = { version = "0.15.7", default-features = false }
 fern-logger = { version = "0.5.0", default-features = false }
 humantime = { version = "2.1.0", default-features = false }
 log = { version = "0.4.17", default-features = false }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,6 +62,8 @@ async fn run(cli: WalletCli) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() {
+    dotenvy::dotenv().ok();
+
     let cli = match WalletCli::try_parse() {
         Ok(cli) => cli,
         Err(e) => {


### PR DESCRIPTION
# Description of change

Actually reads the environment variables - if available - into the CLI at start.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Review suggestions

- Create a `.env` file if you haven't already and set `WALLET_DATABASE_PATH` and `STRONGHOLD_SNAPSHOT_PATH`
- Run `cargo run --all-features -- help` and see if the environment variables have been correctly loaded
