### PR TITLE
Fix Capacitor return value on error messages

### DIFF
--- a/sdk/src/wallet/bindings/capacitorjs/android/src/main/java/org/iota/IotaWalletMobile/IotaWalletMobile.java
+++ b/sdk/src/wallet/bindings/capacitorjs/android/src/main/java/org/iota/IotaWalletMobile/IotaWalletMobile.java
@@ -135,8 +135,12 @@ public class IotaWalletMobile extends Plugin {
             }
             call.resolve(ret);
         } catch (Exception ex) {
-            call.reject(ex.getMessage() + Arrays.toString(ex.getStackTrace()));
-            Log.d("sendMessage Error", ex.getMessage() + Arrays.toString(ex.getStackTrace()));
+            JSObject ret = new JSObject();
+            JsonObject clientResponse = new JsonObject();
+            clientResponse.addProperty("type", "error");
+            clientResponse.addProperty("payload", ex.getMessage());
+            ret.put("result", clientResponse.toString());
+            call.resolve(ret);
         }
     }
 

--- a/sdk/src/wallet/bindings/capacitorjs/src/lib/bindings.ts
+++ b/sdk/src/wallet/bindings/capacitorjs/src/lib/bindings.ts
@@ -13,6 +13,9 @@ const {
 
 const sendMessageAsync = async (message: string, handler: number): Promise<string> => {
     const { result } = await sendMessage({ message, handler })
+    if (JSON.parse(result)?.type === 'error') {
+        return Promise.reject(result)
+    }
     return result
 }
 


### PR DESCRIPTION
# Description of change

Currently, the Capacitor plugin does not reject a promise if an error message is received from the wallet, causing different issues. 

- In the Java plugin, when an error message is received, the return value of `sendMessage` was modified with the expected JSON object to be received by the TypeScript API. This behavior is paired now with Swift side.
- In the `binding.ts` file, a promise rejection has been added to the received errors.

Fixes:
https://github.com/iotaledger/firefly/issues/6517

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
