### PR TITLE
feat(cli)!: interactive mnemonic import

### DIFF
--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -14,10 +14,10 @@ use crate::{
     println_log_info,
 };
 
-const DEFAULT_NODE_URL: &str = "https://api.testnet.shimmer.network";
-const DEFAULT_WALLET_DATABASE_PATH: &str = "./stardust-cli-wallet-db";
-const DEFAULT_STRONGHOLD_SNAPSHOT_PATH: &str = "./stardust-cli-wallet.stronghold";
 const DEFAULT_LOG_LEVEL: &str = "debug";
+const DEFAULT_NODE_URL: &str = "https://api.testnet.shimmer.network";
+const DEFAULT_STRONGHOLD_SNAPSHOT_PATH: &str = "./stardust-cli-wallet.stronghold";
+const DEFAULT_WALLET_DATABASE_PATH: &str = "./stardust-cli-wallet-db";
 
 #[derive(Debug, Clone, Parser)]
 #[command(author, version, about, long_about = None, propagate_version = true)]
@@ -69,17 +69,28 @@ pub enum WalletCommand {
     Sync,
 }
 
-#[derive(Debug, Default, Clone, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct InitParameters {
-    /// Set the path to a file containing the Mnemonic, randomly generated or interactively received if not provided.
-    #[arg(short, long)]
+    /// Set the path to a file containing mnemonics. If empty, a mnemonic has to be entered or will be randomly
+    /// generated.
+    #[arg(short, long, value_name = "PATH")]
     pub mnemonic_file_path: Option<String>,
     /// Set the node to connect to with this wallet.
     #[arg(short, long, value_name = "URL", env = "NODE_URL", default_value = DEFAULT_NODE_URL)]
     pub node_url: String,
     /// Coin type, SHIMMER_COIN_TYPE (4219) if not provided.
-    #[arg(short, long)]
-    pub coin_type: Option<u32>,
+    #[arg(short, long, default_value_t = SHIMMER_COIN_TYPE)]
+    pub coin_type: u32,
+}
+
+impl Default for InitParameters {
+    fn default() -> Self {
+        Self {
+            mnemonic_file_path: None,
+            node_url: DEFAULT_NODE_URL.to_string(),
+            coin_type: SHIMMER_COIN_TYPE,
+        }
+    }
 }
 
 pub async fn backup_command(wallet: &Wallet, path: String, password: &str) -> Result<(), Error> {
@@ -107,7 +118,7 @@ pub async fn init_command(
         .with_secret_manager(secret_manager)
         .with_client_options(ClientOptions::new().with_node(parameters.node_url.as_str())?)
         .with_storage_path(&storage_path)
-        .with_coin_type(parameters.coin_type.unwrap_or(SHIMMER_COIN_TYPE))
+        .with_coin_type(parameters.coin_type)
         .finish()
         .await?;
 
@@ -121,7 +132,6 @@ pub async fn init_command(
     } else {
         panic!("cli-wallet only supports Stronghold-backed secret managers at the moment.");
     }
-    println_log_info!("Mnemonic stored successfully");
 
     Ok(wallet)
 }

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chrono::{DateTime, NaiveDateTime, Utc};
-use dialoguer::{console::Term, theme::ColorfulTheme, Password, Select};
+use dialoguer::{console::Term, theme::ColorfulTheme, Input, Password, Select};
 use iota_sdk::wallet::Wallet;
-use tokio::{fs::OpenOptions, io::AsyncWriteExt};
+use tokio::{
+    fs::OpenOptions,
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+};
 
-use crate::{error::Error, println_log_info};
+use crate::{error::Error, println_log_error, println_log_info};
 
 // TODO: make this configurable via the CLI to allow for more secure locations (e.g. encrypted usb drives etc)
 const MNEMONIC_FILE_NAME: &str = "mnemonic.txt";
@@ -57,6 +60,31 @@ pub async fn bytes_from_hex_or_file(hex: Option<String>, file: Option<String>) -
     })
 }
 
+pub async fn enter_or_generate_mnemonic() -> Result<String, Error> {
+    let choices = [
+        "I want to generate a new mnemonic",
+        "I want to enter a mnemonic",
+        "I want to import a mnemonic from a file",
+    ];
+    let selected_choice = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select how to import a mnemonic")
+        .items(&choices)
+        .default(0)
+        .interact_on(&Term::stderr())
+        // TODO: signal Abort
+        .unwrap_or(0);
+    println_log_info!("{}", choices[selected_choice]);
+
+    let mnemnonic = match selected_choice {
+        0 => generate_mnemonic().await?,
+        1 => enter_mnemonic()?,
+        2 => import_mnemonic(MNEMONIC_FILE_NAME).await?,
+        _ => unreachable!(),
+    };
+
+    Ok(mnemnonic)
+}
+
 pub async fn generate_mnemonic() -> Result<String, Error> {
     let mnemonic = iota_sdk::client::generate_mnemonic()?;
     println_log_info!("Mnemonic has been generated.");
@@ -88,11 +116,69 @@ pub async fn generate_mnemonic() -> Result<String, Error> {
     Ok(mnemonic)
 }
 
+pub fn enter_mnemonic() -> Result<String, Error> {
+    loop {
+        let input = Input::<String>::new()
+            .with_prompt("Enter your mnemonic")
+            .interact_text()?;
+        if !valid_mnemonic_input(&input) {
+            println_log_error!(
+                "Invalid mnemonic. Please enter a 24-word mnemonic consisting of ASCII characters only."
+            );
+        } else {
+            return Ok(input);
+        }
+    }
+}
+
+pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
+    let mut mnemonics = read_mnemonics_from_file(path).await?;
+    if mnemonics.is_empty() {
+        println_log_info!("No valid mnemonics found in '{path}'.");
+        // TODO: what error should we return?
+        Err(Error::Miscellaneous("No valid mnemonics found".to_string()))
+    } else if mnemonics.len() == 1 {
+        Ok(mnemonics.swap_remove(0))
+    } else {
+        println!("Found {} mnemonics.", mnemonics.len());
+        let n = mnemonics.len() - 1;
+        let selected = loop {
+            let input = Input::<usize>::new()
+                .with_prompt(format!("Select a mnemonic in the range [0..{n}]"))
+                .interact_text()?;
+            if (0..=n).contains(&input) {
+                break input;
+            } else {
+                println!("Invalid choice. Please select a valid mnemonic from the range [0..{n}].");
+            }
+        };
+        Ok(mnemonics.swap_remove(selected))
+    }
+}
+
 async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error> {
     let mut file = OpenOptions::new().create(true).append(true).open(path).await?;
     file.write_all(format!("{mnemonic}\n").as_bytes()).await?;
 
     Ok(())
+}
+
+async fn read_mnemonics_from_file(path: &str) -> Result<Vec<String>, Error> {
+    let file = OpenOptions::new().read(true).open(path).await?;
+    let mut lines = BufReader::new(file).lines();
+    let mut mnemonics = Vec::new();
+    while let Some(line) = lines.next_line().await? {
+        if valid_mnemonic_input(&line) {
+            mnemonics.push(line.trim().to_string());
+        }
+    }
+
+    Ok(mnemonics)
+}
+
+fn valid_mnemonic_input(input: &str) -> bool {
+    let words = input.trim().split(' ').collect::<Vec<_>>();
+    input.is_ascii() && words.len() == 24
 }
 
 /// Converts a unix timestamp in milliseconds to a DateTime<Utc>

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -141,7 +141,7 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
                 println!("Invalid choice. Please pick a valid mnemonic by its index in the range [1..{n}].");
             }
         };
-        Ok(mnemonics.swap_remove(selected_index))
+        Ok(mnemonics.swap_remove(selected_index - 1))
     }
 }
 

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -130,15 +130,15 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
         Ok(mnemonics.swap_remove(0))
     } else {
         println!("Found {} mnemonics.", mnemonics.len());
-        let n = mnemonics.len() - 1;
+        let n = mnemonics.len();
         let selected_index = loop {
             let input = Input::<usize>::new()
-                .with_prompt(format!("Pick a mnemonic by its index in the range [0..{n}]"))
+                .with_prompt(format!("Pick a mnemonic by its line index in the file ([1..{n}])"))
                 .interact_text()?;
-            if (0..=n).contains(&input) {
+            if (1..=n).contains(&input) {
                 break input;
             } else {
-                println!("Invalid choice. Please pick a valid mnemonic by its index in the range [0..{n}].");
+                println!("Invalid choice. Please pick a valid mnemonic by its index in the range [1..{n}].");
             }
         };
         Ok(mnemonics.swap_remove(selected_index))

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -156,10 +156,18 @@ async fn read_mnemonics_from_file(path: &str) -> Result<Vec<String>, Error> {
     let file = OpenOptions::new().read(true).open(path).await?;
     let mut lines = BufReader::new(file).lines();
     let mut mnemonics = Vec::new();
+    let mut line_index = 1;
     while let Some(line) = lines.next_line().await? {
-        if verify_mnemonic(&line).is_ok() {
-            mnemonics.push(line.trim().to_string());
+        // we allow surrounding whitespace in the file
+        let trimmed = line.trim();
+        if verify_mnemonic(trimmed).is_ok() {
+            mnemonics.push(trimmed.to_string());
+        } else {
+            return Err(Error::Miscellaneous(format!(
+                "Invalid mnemonic in file '{path}' at line '{line_index}'."
+            )));
         }
+        line_index += 1;
     }
 
     Ok(mnemonics)


### PR DESCRIPTION
# Description of change

New way of importing mnemonics. Instead of providing a mnemonic via CLI option directly (which is a potential leak of secrets!), we use this CLI field to optionally provide a path to a file holding one or many mnemonics. Since this file can live on an encrypted device (encrypted files themselves are not yet {or ever} supported) this can be considered a bit more secure. Other options to provide a mnenomic is to generate one (as before) or to enter one interactively (new).

Due to the change of the CLI parameter this is a BREAKING CHANGE.

## Links to any relevant issues

Closes #239 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Ran the tests.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that new and existing unit tests pass locally with my changes
