### PR TITLE
Fix account alias usage in Python getting started

### DIFF
--- a/bindings/python/examples/wallet/getting-started.py
+++ b/bindings/python/examples/wallet/getting-started.py
@@ -37,8 +37,8 @@ mnemonic = Utils.generate_mnemonic()
 wallet.store_mnemonic(mnemonic)
 
 # Create an account.
-wallet.create_account('Alice')
+wallet.create_account(ACCOUNT_ALIAS)
 
 # Get the first address and print it.
-address = wallet.get_account('Alice').addresses()[0]
+address = wallet.get_account(ACCOUNT_ALIAS).addresses()[0]
 print(f'Address:\n{address["address"]}\n')


### PR DESCRIPTION
# Description of change

Uses the `ACCOUNT_ALIAS` constant, instead of a hardcoded value.

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
