### PR TITLE
Remove bad output constructors

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AddressGenerationOptions` in favor of `GenerateAddressOptions`, which now contains the `internal` flag;
 - `types::block::DtoError`, `client::Error::BlockDto` and `wallet::Error::BlockDto`;
+- `BasicOutput`, `AliasOutput`, `FoundryOutput`, `NftOutput` - `new_with_amount` and `new_with_minimum_storage_deposit` functions;
 
 ## 0.2.0 - 2023-04-17
 

--- a/sdk/src/types/block/output/alias.rs
+++ b/sdk/src/types/block/output/alias.rs
@@ -354,23 +354,6 @@ impl AliasOutput {
     /// The set of allowed immutable [`Feature`]s for an [`AliasOutput`].
     pub const ALLOWED_IMMUTABLE_FEATURES: FeatureFlags = FeatureFlags::ISSUER.union(FeatureFlags::METADATA);
 
-    /// Creates a new [`AliasOutput`] with a provided amount.
-    #[inline(always)]
-    pub fn new_with_amount(amount: u64, alias_id: AliasId, token_supply: u64) -> Result<Self, Error> {
-        AliasOutputBuilder::new_with_amount(amount, alias_id).finish(token_supply)
-    }
-
-    /// Creates a new [`AliasOutput`] with a provided rent structure.
-    /// The amount will be set to the minimum storage deposit.
-    #[inline(always)]
-    pub fn new_with_minimum_storage_deposit(
-        alias_id: AliasId,
-        rent_structure: RentStructure,
-        token_supply: u64,
-    ) -> Result<Self, Error> {
-        AliasOutputBuilder::new_with_minimum_storage_deposit(rent_structure, alias_id).finish(token_supply)
-    }
-
     /// Creates a new [`AliasOutputBuilder`] with a provided amount.
     #[inline(always)]
     pub fn build_with_amount(amount: u64, alias_id: AliasId) -> AliasOutputBuilder {

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -221,19 +221,6 @@ impl BasicOutput {
         .union(FeatureFlags::METADATA)
         .union(FeatureFlags::TAG);
 
-    /// Creates a new [`BasicOutput`] with a provided amount.
-    #[inline(always)]
-    pub fn new_with_amount(amount: u64, token_supply: u64) -> Result<Self, Error> {
-        BasicOutputBuilder::new_with_amount(amount).finish(token_supply)
-    }
-
-    /// Creates a new [`BasicOutput`] with a provided rent structure.
-    /// The amount will be set to the minimum storage deposit.
-    #[inline(always)]
-    pub fn new_with_minimum_storage_deposit(rent_structure: RentStructure, token_supply: u64) -> Result<Self, Error> {
-        BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure).finish(token_supply)
-    }
-
     /// Creates a new [`BasicOutputBuilder`] with a provided amount.
     #[inline(always)]
     pub fn build_with_amount(amount: u64) -> BasicOutputBuilder {

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -285,30 +285,6 @@ impl FoundryOutput {
     /// The set of allowed immutable [`Feature`]s for a [`FoundryOutput`].
     pub const ALLOWED_IMMUTABLE_FEATURES: FeatureFlags = FeatureFlags::METADATA;
 
-    /// Creates a new [`FoundryOutput`] with a provided amount.
-    #[inline(always)]
-    pub fn new_with_amount(
-        amount: u64,
-        serial_number: u32,
-        token_scheme: TokenScheme,
-        token_supply: u64,
-    ) -> Result<Self, Error> {
-        FoundryOutputBuilder::new_with_amount(amount, serial_number, token_scheme).finish(token_supply)
-    }
-
-    /// Creates a new [`FoundryOutput`] with a provided rent structure.
-    /// The amount will be set to the minimum storage deposit.
-    #[inline(always)]
-    pub fn new_with_minimum_storage_deposit(
-        serial_number: u32,
-        token_scheme: TokenScheme,
-        rent_structure: RentStructure,
-        token_supply: u64,
-    ) -> Result<Self, Error> {
-        FoundryOutputBuilder::new_with_minimum_storage_deposit(rent_structure, serial_number, token_scheme)
-            .finish(token_supply)
-    }
-
     /// Creates a new [`FoundryOutputBuilder`] with a provided amount.
     #[inline(always)]
     pub fn build_with_amount(amount: u64, serial_number: u32, token_scheme: TokenScheme) -> FoundryOutputBuilder {

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -269,23 +269,6 @@ impl NftOutput {
     /// The set of allowed immutable [`Feature`]s for an [`NftOutput`].
     pub const ALLOWED_IMMUTABLE_FEATURES: FeatureFlags = FeatureFlags::ISSUER.union(FeatureFlags::METADATA);
 
-    /// Creates a new [`NftOutput`] with a provided amount.
-    #[inline(always)]
-    pub fn new_with_amount(amount: u64, nft_id: NftId, token_supply: u64) -> Result<Self, Error> {
-        NftOutputBuilder::new_with_amount(amount, nft_id).finish(token_supply)
-    }
-
-    /// Creates a new [`NftOutput`] with a provided rent structure.
-    /// The amount will be set to the minimum storage deposit.
-    #[inline(always)]
-    pub fn new_with_minimum_storage_deposit(
-        nft_id: NftId,
-        rent_structure: RentStructure,
-        token_supply: u64,
-    ) -> Result<Self, Error> {
-        NftOutputBuilder::new_with_minimum_storage_deposit(rent_structure, nft_id).finish(token_supply)
-    }
-
     /// Creates a new [`NftOutputBuilder`] with a provided amount.
     #[inline(always)]
     pub fn build_with_amount(amount: u64, nft_id: NftId) -> NftOutputBuilder {


### PR DESCRIPTION
# Description of change

There are constructors in the output types that always fail, so this removes them.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (breaking)
