### PR TITLE
CLI: log panics

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,6 +31,10 @@ macro_rules! println_log_error {
 }
 
 fn logger_init(cli: &WalletCli) -> Result<(), Error> {
+    std::panic::set_hook(Box::new(move |panic_info| {
+        println_log_error!("{panic_info}");
+    }));
+
     let archive = LoggerOutputConfigBuilder::default()
         .name("archive.log")
         .level_filter(cli.log_level)


### PR DESCRIPTION
# Description of change

Small PR to log panics as errors. This way - if users send us such files the location of where the panic occurred is already included.

## Links to any relevant issues

Closes #315 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas