### PR TITLE
Allow 2 retries for tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,4 +53,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: nextest
-          args: run --all-features --no-fail-fast --cargo-profile ci --test-threads "num-cpus"
+          args: run --all-features --no-fail-fast --cargo-profile ci --test-threads "num-cpus" --retries 2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,6 +60,7 @@ jobs:
           --all-features 
           --run-ignored all
           --test-threads "num-cpus"
+          --retries 2
 
       - name: Tear down private tangle
         if: always()

--- a/.github/workflows/private-tangle-tests.yml
+++ b/.github/workflows/private-tangle-tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: nextest
-          args: run --tests --all-features --no-fail-fast --run-ignored ignored-only --hide-progress-bar --cargo-profile ci
+          args: run --tests --all-features --no-fail-fast --run-ignored ignored-only --cargo-profile ci --retries 2
 
       - name: Tear down private tangle
         if: always()


### PR DESCRIPTION
# Description of change

This allows two retries for all the CI tests, so that flaky tests won't necessarily ruin an entire test run.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)