### PR TITLE
Use Vec<u32> instead of Chain for InputSigningDataDto

### DIFF
--- a/bindings/core/src/method/secret_manager.rs
+++ b/bindings/core/src/method/secret_manager.rs
@@ -1,7 +1,6 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::keys::slip10::Chain;
 use derivative::Derivative;
 use iota_sdk::client::api::{GetAddressesBuilderOptions, PreparedTransactionDataDto};
 use serde::{Deserialize, Serialize};
@@ -28,16 +27,16 @@ pub enum SecretManagerMethod {
     #[serde(rename_all = "camelCase")]
     SignatureUnlock {
         /// Transaction Essence Hash
-        transaction_essence_hash: Vec<u8>,
+        transaction_essence_hash: String,
         /// Chain to sign the essence hash with
-        chain: Chain,
+        chain: Vec<u32>,
     },
     /// Signs a message with an Ed25519 private key.
     SignEd25519 {
         /// The message to sign, hex encoded String
         message: String,
         /// Chain to sign the essence hash with
-        chain: Chain,
+        chain: Vec<u32>,
     },
     /// Sign a transaction
     #[serde(rename_all = "camelCase")]

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -1,12 +1,13 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use crypto::keys::slip10::Chain;
 use iota_sdk::{
     client::{
         api::{GetAddressesBuilder, PreparedTransactionData},
         secret::{SecretManage, SecretManager},
     },
-    types::block::{payload::dto::PayloadDto, signature::dto::Ed25519SignatureDto, unlock::Unlock, Error},
+    types::block::{payload::dto::PayloadDto, signature::dto::Ed25519SignatureDto, unlock::Unlock},
 };
 
 use crate::{method::SecretManagerMethod, response::Response, Result};
@@ -46,19 +47,18 @@ pub(crate) async fn call_secret_manager_method_internal(
             transaction_essence_hash,
             chain,
         } => {
-            let transaction_essence_hash: [u8; 32] = transaction_essence_hash
-                .try_into()
-                .map_err(|_| Error::InvalidField("expected 32 bytes for transactionEssenceHash"))?;
-
+            let transaction_essence_hash: [u8; 32] = prefix_hex::decode(transaction_essence_hash)?;
             let unlock: Unlock = secret_manager
-                .signature_unlock(&transaction_essence_hash, &chain)
+                .signature_unlock(&transaction_essence_hash, &Chain::from_u32_hardened(chain))
                 .await?;
 
             Response::SignatureUnlock((&unlock).into())
         }
         SecretManagerMethod::SignEd25519 { message, chain } => {
             let msg: Vec<u8> = prefix_hex::decode(message)?;
-            let signature = secret_manager.sign_ed25519(&msg, &chain).await?;
+            let signature = secret_manager
+                .sign_ed25519(&msg, &Chain::from_u32_hardened(chain))
+                .await?;
             Response::Ed25519Signature(Ed25519SignatureDto::from(&signature))
         }
         #[cfg(feature = "stronghold")]

--- a/bindings/nodejs/lib/client/Client.ts
+++ b/bindings/nodejs/lib/client/Client.ts
@@ -35,6 +35,7 @@ import type {
     ITreasury,
     INodeInfoProtocol,
     UnlockTypes,
+    HexEncodedString,
 } from '@iota/types';
 import type { INodeInfoWrapper } from '../../types/client/nodeInfo';
 import { SecretManagerType } from '../../types/secretManager/secretManager';
@@ -273,9 +274,7 @@ export class Client {
      */
     async signatureUnlock(
         secretManager: SecretManagerType,
-        // Uses `Array<number>` instead of `Uint8Array` because the latter serializes
-        // as an object rather than an array, which results in errors with serde.
-        transactionEssenceHash: Array<number>,
+        transactionEssenceHash: HexEncodedString,
         chain: IBip32Chain,
     ): Promise<UnlockTypes> {
         const response = await this.methodHandler.callMethod({

--- a/bindings/nodejs/lib/secretManager/SecretManager.ts
+++ b/bindings/nodejs/lib/secretManager/SecretManager.ts
@@ -72,9 +72,7 @@ export class SecretManager {
      * Create a signature unlock using the provided `secretManager`.
      */
     async signatureUnlock(
-        // Uses `Array<number>` instead of `Uint8Array` because the latter serializes
-        // as an object rather than an array, which results in errors with serde.
-        transactionEssenceHash: Array<number>,
+        transactionEssenceHash: HexEncodedString,
         chain: IBip32Chain,
     ): Promise<UnlockTypes> {
         const response = await this.methodHandler.callMethod({

--- a/bindings/nodejs/tests/client/offlineSigningExamples.spec.ts
+++ b/bindings/nodejs/tests/client/offlineSigningExamples.spec.ts
@@ -102,7 +102,7 @@ describe('Offline signing examples', () => {
         }
 
         const unlock = await new SecretManager(secretManager).signatureUnlock(
-            hexToBytes(txEssenceHash),
+            txEssenceHash,
             preparedTx.inputsData[0].chain,
         );
 
@@ -118,15 +118,3 @@ describe('Offline signing examples', () => {
         });
     });
 });
-
-// Convert a hex string to a byte array
-function hexToBytes(hex: string) {
-    // Remove hex prefix if existent
-    if (hex.startsWith('0x')) {
-        hex = hex.slice(2);
-    }
-    const bytes = [];
-    for (let c = 0; c < hex.length; c += 2)
-        bytes.push(parseInt(hex.substr(c, 2), 16));
-    return bytes;
-}

--- a/bindings/nodejs/tests/client/utilityMethods.spec.ts
+++ b/bindings/nodejs/tests/client/utilityMethods.spec.ts
@@ -116,7 +116,7 @@ describe('Client utility methods', () => {
         const message = '0x494f5441';
         const signature = await new SecretManager(secretManager).signEd25519(
             message,
-            // HD-Wallet type, IOTA coin type, first account, first public address
+            // HD-Wallet type, IOTA coin type, first account, public, first address
             [44, 4218, 0, 0, 0],
         );
 

--- a/bindings/nodejs/tests/client/utilityMethods.spec.ts
+++ b/bindings/nodejs/tests/client/utilityMethods.spec.ts
@@ -116,14 +116,8 @@ describe('Client utility methods', () => {
         const message = '0x494f5441';
         const signature = await new SecretManager(secretManager).signEd25519(
             message,
-            // [44, 4218, 0, 0, 0] IOTA coin type, first account, first public address
-            [
-                { hardened: true, bs: [128, 0, 0, 44] },
-                { hardened: true, bs: [128, 0, 16, 123] },
-                { hardened: true, bs: [128, 0, 0, 0] },
-                { hardened: true, bs: [128, 0, 0, 0] },
-                { hardened: true, bs: [128, 0, 0, 0] },
-            ],
+            // HD-Wallet type, IOTA coin type, first account, first public address
+            [44, 4218, 0, 0, 0],
         );
 
         const bech32Address = Utils.hexPublicKeyToBech32Address(

--- a/bindings/nodejs/tests/fixtures/sigUnlockPreparedTx.json
+++ b/bindings/nodejs/tests/fixtures/sigUnlockPreparedTx.json
@@ -64,26 +64,11 @@
                 "ledgerIndex": 3527507
             },
             "chain": [
-                {
-                    "hardened": true,
-                    "bs": [128, 0, 0, 44]
-                },
-                {
-                    "hardened": true,
-                    "bs": [128, 0, 16, 123]
-                },
-                {
-                    "hardened": true,
-                    "bs": [128, 0, 0, 0]
-                },
-                {
-                    "hardened": true,
-                    "bs": [128, 0, 0, 0]
-                },
-                {
-                    "hardened": true,
-                    "bs": [128, 0, 0, 0]
-                }
+                44,
+                4219,
+                0,
+                0,
+                0
             ],
             "bech32Address": "rms1qz0krpgy6xj6p7dkrg9x37uy08yr3n3fau02cdm7qalg7ynqcswywncmd9p"
         }
@@ -103,26 +88,11 @@
             ]
         },
         "chain": [
-            {
-                "hardened": true,
-                "bs": [128, 0, 0, 44]
-            },
-            {
-                "hardened": true,
-                "bs": [128, 0, 16, 123]
-            },
-            {
-                "hardened": true,
-                "bs": [128, 0, 0, 0]
-            },
-            {
-                "hardened": true,
-                "bs": [128, 0, 0, 0]
-            },
-            {
-                "hardened": true,
-                "bs": [128, 0, 0, 0]
-            }
+            44,
+            4219,
+            0,
+            0,
+            0
         ],
         "address": {
             "type": 0,

--- a/bindings/nodejs/types/client/bridge/client.ts
+++ b/bindings/nodejs/types/client/bridge/client.ts
@@ -1,4 +1,4 @@
-import type { IBlock, PayloadTypes } from '@iota/types';
+import type { HexEncodedString, IBlock, PayloadTypes } from '@iota/types';
 import type { SecretManagerType } from '../../secretManager/secretManager';
 import type { IGenerateAddressesOptions } from '../generateAddressesOptions';
 import type { IBuildBlockOptions } from '../buildBlockOptions';
@@ -125,7 +125,7 @@ export interface __SignatureUnlockMethod__ {
     name: 'signatureUnlock';
     data: {
         secretManager: SecretManagerType;
-        transactionEssenceHash: Array<number>;
+        transactionEssenceHash: HexEncodedString;
         chain: IBip32Chain;
     };
 }

--- a/bindings/nodejs/types/client/preparedTransactionData.ts
+++ b/bindings/nodejs/types/client/preparedTransactionData.ts
@@ -59,12 +59,7 @@ export interface IRemainder {
     address: AddressTypes;
 }
 
-export interface ISegment {
-    hardened: boolean;
-    bs: number[];
-}
-
 /**
  * BIP 32 chain.
  */
-export type IBip32Chain = ISegment[];
+export type IBip32Chain = number[];

--- a/bindings/nodejs/types/secretManager/bridge/secretManager.ts
+++ b/bindings/nodejs/types/secretManager/bridge/secretManager.ts
@@ -22,7 +22,7 @@ export interface __SignTransactionMethod__ {
 export interface __SignatureUnlockMethod__ {
     name: 'signatureUnlock';
     data: {
-        transactionEssenceHash: Array<number>;
+        transactionEssenceHash: HexEncodedString;
         chain: IBip32Chain;
     };
 }

--- a/bindings/python/tests/test_offline.py
+++ b/bindings/python/tests/test_offline.py
@@ -33,28 +33,26 @@ def test_mnemonic_address_generation():
 
 
 def test_sign_verify_ed25519():
-    secret_manager = MnemonicSecretManager(Utils.generate_mnemonic())
+    secret_manager = MnemonicSecretManager(
+        "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast")
     message = utf8_to_hex('IOTA')
 
     secret_manager = SecretManager(secret_manager)
     signature = secret_manager.sign_ed25519(
         message,
-        # [44, 4218, 0, 0, 0] IOTA coin type, first account, first public address
-        [
-            {'hardened': True, 'bs': [128, 0, 0, 44]},
-            {'hardened': True, 'bs': [128, 0, 16, 123]},
-            {'hardened': True, 'bs': [128, 0, 0, 0]},
-            {'hardened': True, 'bs': [128, 0, 0, 0]},
-            {'hardened': True, 'bs': [128, 0, 0, 0]},
-        ],
+        # HD-Wallet type, IOTA coin type, first account, first public address
+        [44, 4218, 0, 0, 0],
     )
+    assert signature['signature'] == '0x72bf2bc8fbc5dc56d657d7de8afa5208be1db025851e81031c754b371c7a29ce9f352d12df8207f9163316f81f59eb7725e5c0e4f3228e71ffe3764a9de6b10e'
 
     bech32_address = client.hex_public_key_to_bech32_address(
         signature['publicKey'],
-        'rms',
+        'iota',
     )
+    assert bech32_address == 'iota1qpg2xkj66wwgn8p2ggnp7p582gj8g6p79us5hve2tsudzpsr2ap4skprwjg'
 
     pub_key_hash = Utils.bech32_to_hex(bech32_address)
+    assert pub_key_hash == '0x50a35a5ad39c899c2a42261f0687522474683e2f214bb32a5c38d10603574358'
 
     valid_signature = Utils.verify_ed25519_signature(
         signature,

--- a/bindings/python/tests/test_offline.py
+++ b/bindings/python/tests/test_offline.py
@@ -40,7 +40,7 @@ def test_sign_verify_ed25519():
     secret_manager = SecretManager(secret_manager)
     signature = secret_manager.sign_ed25519(
         message,
-        # HD-Wallet type, IOTA coin type, first account, first public address
+        # HD-Wallet type, IOTA coin type, first account, public, first address
         [44, 4218, 0, 0, 0],
     )
     assert signature['signature'] == '0x72bf2bc8fbc5dc56d657d7de8afa5208be1db025851e81031c754b371c7a29ce9f352d12df8207f9163316f81f59eb7725e5c0e4f3228e71ffe3764a9de6b10e'

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -49,9 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Account::read` and `write` now accessible via `details` and `details_mut`;
 - `Wallet::emit_test_event` no longer returns a `Result`;
 - `AccountBuilder::new` now takes a wallet;
-
-### Changed
-
 - `InputSigningDataDto::chain` is now `Vec<u32>` instead of `Chain`;
 
 ### Removed

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -50,11 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Wallet::emit_test_event` no longer returns a `Result`;
 - `AccountBuilder::new` now takes a wallet;
 
+### Changed
+
+- `InputSigningDataDto::chain` is now `Vec<u32>` instead of `Chain`;
+
 ### Removed
 
 - `FilterOptions`'s `Hash` derivation;
 - `client_without_tls` feature in favor of separate `client` and `tls` features;
 - `IncreaseNativeTokenSupplyOptions`;
+- `HARDENED` const;
 
 ## 0.3.0 - 2023-05-02
 

--- a/sdk/src/client/secret/types.rs
+++ b/sdk/src/client/secret/types.rs
@@ -200,6 +200,7 @@ impl From<&InputSigningData> for InputSigningDataDto {
                 chain
                     .segments()
                     .iter()
+                    // TODO: get the value direct when https://github.com/iotaledger/crypto.rs/issues/192 is done
                     .map(|seg| u32::from_be_bytes(seg.bs()) & !Segment::HARDEN_MASK)
                     .collect::<Vec<u32>>()
             }),

--- a/sdk/src/client/secret/types.rs
+++ b/sdk/src/client/secret/types.rs
@@ -3,7 +3,7 @@
 
 //! Miscellaneous types for secret managers.
 
-use crypto::keys::slip10::Chain;
+use crypto::keys::slip10::{Chain, Segment};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "stronghold")]
 use zeroize::ZeroizeOnDrop;
@@ -169,23 +169,24 @@ pub struct InputSigningDataDto {
     /// The output metadata
     pub output_metadata: OutputMetadataDto,
     /// The chain derived from seed, only for ed25519 addresses
-    pub chain: Option<Chain>,
+    pub chain: Option<Vec<u32>>,
 }
 
+#[allow(missing_docs)]
 impl InputSigningData {
-    pub(crate) fn try_from_dto(input: &InputSigningDataDto, token_supply: u64) -> Result<Self> {
+    pub fn try_from_dto(input: &InputSigningDataDto, token_supply: u64) -> Result<Self> {
         Ok(Self {
             output: Output::try_from_dto(&input.output, token_supply)?,
             output_metadata: OutputMetadata::try_from(&input.output_metadata)?,
-            chain: input.chain.clone(),
+            chain: input.chain.clone().map(Chain::from_u32_hardened),
         })
     }
 
-    pub(crate) fn try_from_dto_unverified(input: &InputSigningDataDto) -> Result<Self> {
+    pub fn try_from_dto_unverified(input: &InputSigningDataDto) -> Result<Self> {
         Ok(Self {
             output: Output::try_from_dto_unverified(&input.output)?,
             output_metadata: OutputMetadata::try_from(&input.output_metadata)?,
-            chain: input.chain.clone(),
+            chain: input.chain.clone().map(Chain::from_u32_hardened),
         })
     }
 }
@@ -195,7 +196,13 @@ impl From<&InputSigningData> for InputSigningDataDto {
         Self {
             output: OutputDto::from(&input.output),
             output_metadata: OutputMetadataDto::from(&input.output_metadata),
-            chain: input.chain.clone(),
+            chain: input.chain.as_ref().map(|chain| {
+                chain
+                    .segments()
+                    .iter()
+                    .map(|seg| u32::from_be_bytes(seg.bs()) ^ Segment::HARDEN_MASK)
+                    .collect::<Vec<u32>>()
+            }),
         }
     }
 }

--- a/sdk/src/client/secret/types.rs
+++ b/sdk/src/client/secret/types.rs
@@ -200,7 +200,7 @@ impl From<&InputSigningData> for InputSigningDataDto {
                 chain
                     .segments()
                     .iter()
-                    .map(|seg| u32::from_be_bytes(seg.bs()) ^ Segment::HARDEN_MASK)
+                    .map(|seg| u32::from_be_bytes(seg.bs()) & !Segment::HARDEN_MASK)
                     .collect::<Vec<u32>>()
             }),
         }

--- a/sdk/src/wallet/account/operations/syncing/outputs.rs
+++ b/sdk/src/wallet/account/operations/syncing/outputs.rs
@@ -5,7 +5,7 @@ use crypto::keys::slip10::Chain;
 use instant::Instant;
 
 use crate::{
-    client::Client,
+    client::{constants::HD_WALLET_TYPE, Client},
     types::{
         api::core::response::OutputWithMetadataResponse,
         block::{
@@ -46,7 +46,7 @@ impl Account {
 
             // 44 is for BIP 44 (HD wallets) and 4218 is the registered index for IOTA https://github.com/satoshilabs/slips/blob/master/slip-0044.md
             let chain = Chain::from_u32_hardened(vec![
-                44,
+                HD_WALLET_TYPE,
                 account_details.coin_type,
                 account_details.index,
                 associated_address.internal as u32,

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -20,7 +20,7 @@ pub use self::{
     },
 };
 use crate::{
-    client::secret::types::InputSigningData,
+    client::{constants::HD_WALLET_TYPE, secret::types::InputSigningData},
     types::{
         api::core::response::OutputWithMetadataResponse,
         block::{
@@ -93,7 +93,7 @@ impl OutputData {
                 .find(|a| a.address.inner == unlock_address)
             {
                 Some(Chain::from_u32_hardened(vec![
-                    44,
+                    HD_WALLET_TYPE,
                     account.coin_type,
                     account.index,
                     address.internal as u32,

--- a/sdk/tests/client/input_signing_data.rs
+++ b/sdk/tests/client/input_signing_data.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use crypto::keys::slip10::Chain;
+use iota_sdk::{
+    client::{
+        constants::{HD_WALLET_TYPE, SHIMMER_COIN_TYPE},
+        secret::types::{InputSigningData, InputSigningDataDto},
+    },
+    types::block::{
+        address::Address,
+        output::{unlock_condition::AddressUnlockCondition, BasicOutput, OutputId, OutputMetadata},
+        protocol::protocol_parameters,
+        BlockId,
+    },
+};
+
+#[test]
+fn input_signing_data_conversion() {
+    let protocol_parameters = protocol_parameters();
+
+    let bip32_chain = vec![HD_WALLET_TYPE, SHIMMER_COIN_TYPE, 0, 0, 0];
+
+    let output = BasicOutput::build_with_amount(1_000_000)
+        .add_unlock_condition(AddressUnlockCondition::new(
+            Address::try_from_bech32("rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy").unwrap(),
+        ))
+        .finish_output(protocol_parameters.token_supply())
+        .unwrap();
+
+    let input_signing_data = InputSigningData {
+        output,
+        output_metadata: OutputMetadata::new(
+            BlockId::from_str("0xedf5f572c58ddf4b4f9567d82bf96689cc68b730df796d822b4b9fb643f5efda").unwrap(),
+            OutputId::from_str("0xbce525324af12eda02bf7927e92cea3a8e8322d0f41966271443e6c3b245a4400000").unwrap(),
+            false,
+            None,
+            None,
+            None,
+            0,
+            0,
+            0,
+        ),
+        chain: Some(Chain::from_u32_hardened(bip32_chain.clone())),
+    };
+
+    let input_signing_data_dto = InputSigningDataDto::from(&input_signing_data);
+    assert_eq!(input_signing_data_dto.chain.as_ref(), Some(&bip32_chain));
+
+    let restored_input_signing_data =
+        InputSigningData::try_from_dto(&input_signing_data_dto, protocol_parameters.token_supply()).unwrap();
+    assert_eq!(input_signing_data, restored_input_signing_data);
+
+    let input_signing_data_dto_str = r#"{"output":{"type":3,"amount":"1000000","unlockConditions":[{"type":0,"address":{"type":0,"pubKeyHash":"0x7ffec9e1233204d9c6dce6812b1539ee96af691ca2e4d9065daa85907d33e5d3"}}]},"outputMetadata":{"blockId":"0xedf5f572c58ddf4b4f9567d82bf96689cc68b730df796d822b4b9fb643f5efda","transactionId":"0xbce525324af12eda02bf7927e92cea3a8e8322d0f41966271443e6c3b245a440","outputIndex":0,"isSpent":false,"milestoneIndexBooked":0,"milestoneTimestampBooked":0,"ledgerIndex":0},"chain":[44,4219,0,0,0]}"#;
+    assert_eq!(
+        serde_json::to_string(&input_signing_data_dto).unwrap(),
+        input_signing_data_dto_str
+    );
+
+    let restored_input_signing_data_dto =
+        serde_json::from_str::<InputSigningDataDto>(input_signing_data_dto_str).unwrap();
+    assert_eq!(restored_input_signing_data_dto.chain.as_ref(), Some(&bip32_chain));
+
+    let restored_input_signing_data =
+        InputSigningData::try_from_dto(&restored_input_signing_data_dto, protocol_parameters.token_supply()).unwrap();
+    assert!(restored_input_signing_data.output.is_basic());
+    assert_eq!(
+        restored_input_signing_data.chain,
+        Some(Chain::from_u32_hardened(bip32_chain))
+    );
+}

--- a/sdk/tests/client/mod.rs
+++ b/sdk/tests/client/mod.rs
@@ -6,6 +6,7 @@ mod client_builder;
 mod common;
 mod error;
 mod input_selection;
+mod input_signing_data;
 mod message_interface;
 mod mnemonic;
 #[cfg(feature = "mqtt")]


### PR DESCRIPTION
# Description of change

Use Vec<u32> instead of Chain for InputSigningDataDto
Use Segment::HARDEN_MASK instead of own HARDENED const

## Links to any relevant issues

Fixes #242 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Tests

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
