### PR TITLE
Add stronghold getter

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FilterOptions::{alias_ids, foundry_ids, nft_ids}` fields;
 - `Account::{unspent_alias_output, unspent_foundry_output, unspent_nft_output}` methods;
-- `StrongholdAdapter::get_stronghold` method;
+- `StrongholdAdapter::inner` method;
 
 ### Removed
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FilterOptions::{alias_ids, foundry_ids, nft_ids}` fields;
 - `Account::{unspent_alias_output, unspent_foundry_output, unspent_nft_output}` methods;
+- `StrongholdAdapter::get_stronghold` method;
 
 ### Removed
 

--- a/sdk/src/client/stronghold/mod.rs
+++ b/sdk/src/client/stronghold/mod.rs
@@ -60,7 +60,10 @@ use std::{
 use derive_builder::Builder;
 use iota_stronghold::{KeyProvider, SnapshotPath, Stronghold};
 use log::{debug, error, warn};
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, MutexGuard},
+    task::JoinHandle,
+};
 use zeroize::Zeroizing;
 
 use self::common::PRIVATE_DATA_CLIENT_PATH;
@@ -512,6 +515,11 @@ impl StrongholdAdapter {
         self.stronghold.lock().await.clear()?;
 
         Ok(())
+    }
+
+    /// Acquire the stronghold lock.
+    pub async fn get_stronghold(&self) -> MutexGuard<'_, Stronghold> {
+        self.stronghold.lock().await
     }
 }
 

--- a/sdk/src/client/stronghold/mod.rs
+++ b/sdk/src/client/stronghold/mod.rs
@@ -518,7 +518,7 @@ impl StrongholdAdapter {
     }
 
     /// Acquire the stronghold lock.
-    pub async fn get_stronghold(&self) -> MutexGuard<'_, Stronghold> {
+    pub async fn inner(&self) -> MutexGuard<'_, Stronghold> {
         self.stronghold.lock().await
     }
 }


### PR DESCRIPTION
# Description of change

Adds a stronghold getter to enable access to the inner stronghold instance required by the identity library.
See https://github.com/iotaledger/identity.rs/pull/1157

Feel free to change the method name/documentation.

## Type of change

Choose a type of change, and delete any options that are not relevant.
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Method is used in https://github.com/iotaledger/identity.rs/pull/1157

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
