### PR TITLE
Add ignore_if_bech32_mismatch to restore_backup()

### DIFF
--- a/.changes/restore-backup-bech32Hrp.md
+++ b/.changes/restore-backup-bech32Hrp.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Add an optional ignoreIfBech32Mismatch field to `restoreBackup()`.

--- a/bindings/core/src/method/wallet.rs
+++ b/bindings/core/src/method/wallet.rs
@@ -107,7 +107,10 @@ pub enum WalletMethod {
     /// mnemonic was stored, it will be gone.
     /// if ignore_if_coin_type_mismatch.is_some(), client options will not be restored
     /// if ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored if
-    /// the cointype doesn't match Expected response: [`Ok`](crate::Response::Ok)
+    /// the cointype doesn't match
+    /// if ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no accounts
+    /// will be restored.
+    /// Expected response: [`Ok`](crate::Response::Ok)
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
     #[serde(rename_all = "camelCase")]
@@ -117,7 +120,12 @@ pub enum WalletMethod {
         /// Stronghold file password.
         #[derivative(Debug(format_with = "OmittedDebug::omitted_fmt"))]
         password: String,
+        /// If ignore_if_coin_type_mismatch.is_some(), client options will not be restored.
+        /// If ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored
+        /// if the cointype doesn't match.
         ignore_if_coin_type_mismatch: Option<bool>,
+        /// If ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no
+        /// accounts will be restored.
         ignore_if_bech32_mismatch: Option<String>,
     },
     /// Removes the latest account (account with the largest account index).

--- a/bindings/core/src/method/wallet.rs
+++ b/bindings/core/src/method/wallet.rs
@@ -118,6 +118,7 @@ pub enum WalletMethod {
         #[derivative(Debug(format_with = "OmittedDebug::omitted_fmt"))]
         password: String,
         ignore_if_coin_type_mismatch: Option<bool>,
+        ignore_if_bech32_mismatch: Option<String>,
     },
     /// Removes the latest account (account with the largest account index).
     /// Expected response: [`Ok`](crate::Response::Ok)

--- a/bindings/core/src/method_handler/wallet.rs
+++ b/bindings/core/src/method_handler/wallet.rs
@@ -110,9 +110,15 @@ pub(crate) async fn call_wallet_method_internal(wallet: &Wallet, method: WalletM
             source,
             password,
             ignore_if_coin_type_mismatch,
+            ignore_if_bech32_mismatch,
         } => {
             wallet
-                .restore_backup(source, password, ignore_if_coin_type_mismatch)
+                .restore_backup(
+                    source,
+                    password,
+                    ignore_if_coin_type_mismatch,
+                    ignore_if_bech32_mismatch.as_deref(),
+                )
                 .await?;
             Response::Ok
         }

--- a/bindings/nodejs/lib/wallet/Wallet.ts
+++ b/bindings/nodejs/lib/wallet/Wallet.ts
@@ -252,6 +252,7 @@ export class Wallet {
         source: string,
         password: string,
         ignoreIfCoinTypeMismatch?: boolean,
+        ignoreIfBech32Mismatch?: string,
     ): Promise<void> {
         await this.methodHandler.callMethod({
             name: 'restoreBackup',
@@ -259,6 +260,7 @@ export class Wallet {
                 source,
                 password,
                 ignoreIfCoinTypeMismatch,
+                ignoreIfBech32Mismatch,
             },
         });
     }

--- a/bindings/nodejs/lib/wallet/Wallet.ts
+++ b/bindings/nodejs/lib/wallet/Wallet.ts
@@ -247,6 +247,8 @@ export class Wallet {
      * stored, it will be gone.
      * if ignore_if_coin_type_mismatch is provided client options will not be restored
      * if ignore_if_coin_type_mismatch == true, client options coin type and accounts will not be restored if the cointype doesn't match
+     * if ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no accounts
+     * will be restored.
      */
     async restoreBackup(
         source: string,

--- a/bindings/nodejs/types/wallet/bridge/wallet.ts
+++ b/bindings/nodejs/types/wallet/bridge/wallet.ts
@@ -93,6 +93,7 @@ export type __RestoreBackupMethod__ = {
         source: string;
         password: string;
         ignoreIfCoinTypeMismatch?: boolean;
+        ignoreIfBech32Mismatch?: string;
     };
 };
 

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -186,7 +186,7 @@ pub async fn restore_command(storage_path: &Path, snapshot_path: &Path, backup_p
         .finish()
         .await?;
 
-    wallet.restore_backup(backup_path.into(), password, None).await?;
+    wallet.restore_backup(backup_path.into(), password, None, None).await?;
 
     Ok(wallet)
 }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Account::{unspent_alias_output, unspent_foundry_output, unspent_nft_output}` methods;
 - `StrongholdAdapter::inner` method;
 - `OutputMetadata::set_spent` method;
+- `ignore_if_bech32_mismatch` parameter to `Wallet::restore_backup()`;
 
 ### Changed
 

--- a/sdk/src/wallet/bindings/nodejs/lib/Account.ts
+++ b/sdk/src/wallet/bindings/nodejs/lib/Account.ts
@@ -349,9 +349,7 @@ export class Account {
      * @param options Options for address generation.
      * @returns The address.
      */
-    async generateAddress(
-        options?: GenerateAddressOptions,
-    ): Promise<Address> {
+    async generateAddress(options?: GenerateAddressOptions): Promise<Address> {
         const addresses = await this.generateAddresses(1, options);
         return addresses[0];
     }
@@ -1070,7 +1068,7 @@ export class Account {
      * Sync the account by fetching new information from the nodes.
      * Will also retry pending transactions if necessary.
      * A custom default can be set using setDefaultSyncOptions.
-     * 
+     *
      * @param options Optional synchronization options.
      * @returns The account balance.
      */

--- a/sdk/src/wallet/bindings/nodejs/lib/AccountManager.ts
+++ b/sdk/src/wallet/bindings/nodejs/lib/AccountManager.ts
@@ -287,11 +287,14 @@ export class AccountManager {
      * stored, it will be gone.
      * if ignore_if_coin_type_mismatch is provided client options will not be restored
      * if ignore_if_coin_type_mismatch == true, client options coin type and accounts will not be restored if the cointype doesn't match
+     * if ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no accounts
+     * will be restored.
      */
     async restoreBackup(
         source: string,
         password: string,
         ignoreIfCoinTypeMismatch?: boolean,
+        ignoreIfBech32Mismatch?: string,
     ): Promise<void> {
         await this.messageHandler.sendMessage({
             cmd: 'restoreBackup',
@@ -299,6 +302,7 @@ export class AccountManager {
                 source,
                 password,
                 ignoreIfCoinTypeMismatch,
+                ignoreIfBech32Mismatch,
             },
         });
     }

--- a/sdk/src/wallet/bindings/nodejs/types/bridge/accountManager.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/bridge/accountManager.ts
@@ -116,6 +116,7 @@ export type __RestoreBackupMessage__ = {
         source: string;
         password: string;
         ignoreIfCoinTypeMismatch?: boolean;
+        ignoreIfBech32Mismatch?: string;
     };
 };
 

--- a/sdk/src/wallet/message_interface/message.rs
+++ b/sdk/src/wallet/message_interface/message.rs
@@ -101,7 +101,10 @@ pub enum Message {
     /// mnemonic was stored, it will be gone.
     /// if ignore_if_coin_type_mismatch.is_some(), client options will not be restored
     /// if ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored if
-    /// the cointype doesn't match Expected response: [`Ok`](crate::wallet::message_interface::Response::Ok)
+    /// the cointype doesn't match
+    /// if ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no accounts
+    /// will be restored.
+    /// Expected response: [`Ok`](crate::wallet::message_interface::Response::Ok)
     #[cfg(feature = "stronghold")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
     #[serde(rename_all = "camelCase")]
@@ -110,7 +113,12 @@ pub enum Message {
         source: PathBuf,
         /// Stronghold file password.
         password: String,
+        /// If ignore_if_coin_type_mismatch.is_some(), client options will not be restored.
+        /// If ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored
+        /// if the cointype doesn't match.
         ignore_if_coin_type_mismatch: Option<bool>,
+        /// If ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no
+        /// accounts will be restored.
         ignore_if_bech32_mismatch: Option<String>,
     },
     /// Removes the latest account (account with the largest account index).

--- a/sdk/src/wallet/message_interface/message.rs
+++ b/sdk/src/wallet/message_interface/message.rs
@@ -111,6 +111,7 @@ pub enum Message {
         /// Stronghold file password.
         password: String,
         ignore_if_coin_type_mismatch: Option<bool>,
+        ignore_if_bech32_mismatch: Option<String>,
     },
     /// Removes the latest account (account with the largest account index).
     /// Expected response: [`Ok`](crate::wallet::message_interface::Response::Ok)
@@ -259,9 +260,10 @@ impl Debug for Message {
                 source,
                 password: _,
                 ignore_if_coin_type_mismatch,
+                ignore_if_bech32_mismatch,
             } => write!(
                 f,
-                "RestoreBackup{{ source: {source:?}, password: <ommited>, ignore_if_coin_type_mismatch: {ignore_if_coin_type_mismatch:?} }}"
+                "RestoreBackup{{ source: {source:?}, password: <ommited>, ignore_if_coin_type_mismatch: {ignore_if_coin_type_mismatch:?}, ignore_if_bech32_mismatch: {ignore_if_bech32_mismatch:?} }}"
             ),
             Self::GenerateMnemonic => write!(f, "GenerateMnemonic"),
             Self::VerifyMnemonic { mnemonic: _ } => write!(f, "VerifyMnemonic{{ mnemonic: <omitted> }}"),

--- a/sdk/src/wallet/message_interface/message_handler.rs
+++ b/sdk/src/wallet/message_interface/message_handler.rs
@@ -216,10 +216,16 @@ impl WalletMessageHandler {
                 source,
                 password,
                 ignore_if_coin_type_mismatch,
+                ignore_if_bech32_mismatch,
             } => {
                 convert_async_panics(|| async {
-                    self.restore_backup(source.to_path_buf(), password, ignore_if_coin_type_mismatch)
-                        .await
+                    self.restore_backup(
+                        source.to_path_buf(),
+                        password,
+                        ignore_if_coin_type_mismatch,
+                        ignore_if_bech32_mismatch.as_deref(),
+                    )
+                    .await
                 })
                 .await
             }
@@ -389,9 +395,15 @@ impl WalletMessageHandler {
         backup_path: PathBuf,
         stronghold_password: String,
         ignore_if_coin_type_mismatch: Option<bool>,
+        ignore_if_bech32_mismatch: Option<&str>,
     ) -> Result<Response> {
         self.wallet
-            .restore_backup(backup_path, stronghold_password, ignore_if_coin_type_mismatch)
+            .restore_backup(
+                backup_path,
+                stronghold_password,
+                ignore_if_coin_type_mismatch,
+                ignore_if_bech32_mismatch,
+            )
             .await?;
         Ok(Response::Ok(()))
     }

--- a/sdk/src/wallet/wallet/operations/stronghold_backup/mod.rs
+++ b/sdk/src/wallet/wallet/operations/stronghold_backup/mod.rs
@@ -61,11 +61,14 @@ impl Wallet {
     /// if ignore_if_coin_type_mismatch.is_some(), client options will not be restored
     /// if ignore_if_coin_type_mismatch == Some(true), client options coin type and accounts will not be restored if the
     /// coin type doesn't match
+    /// if ignore_if_bech32_hrp_mismatch == Some("rms"), but addresses have something different like "smr", no accounts
+    /// will be restored.
     pub async fn restore_backup(
         &self,
         backup_path: PathBuf,
         mut stronghold_password: String,
         ignore_if_coin_type_mismatch: Option<bool>,
+        ignore_if_bech32_hrp_mismatch: Option<&str>,
     ) -> crate::wallet::Result<()> {
         log::debug!("[restore_backup] loading stronghold backup");
 
@@ -146,22 +149,37 @@ impl Wallet {
 
         if !ignore_backup_values {
             if let Some(read_accounts) = read_accounts {
-                let client = self.client_options.read().await.clone().finish()?;
+                let restore_accounts = ignore_if_bech32_hrp_mismatch.map_or(true, |expected_bech32_hrp| {
+                    // Only restore if bech32 hrps match
+                    read_accounts.first().map_or(true, |account| {
+                        account
+                            .public_addresses
+                            .first()
+                            .expect("account needs to have a public address")
+                            .address()
+                            .hrp()
+                            == expected_bech32_hrp
+                    })
+                });
 
-                let restored_account = try_join_all(read_accounts.into_iter().map(|a| {
-                    Account::new(
-                        a,
-                        client.clone(),
-                        self.secret_manager.clone(),
-                        #[cfg(feature = "events")]
-                        self.event_emitter.clone(),
-                        #[cfg(feature = "storage")]
-                        self.storage_manager.clone(),
-                    )
-                    .boxed()
-                }))
-                .await?;
-                *accounts = restored_account;
+                if restore_accounts {
+                    let client = self.client_options.read().await.clone().finish()?;
+
+                    let restored_account = try_join_all(read_accounts.into_iter().map(|a| {
+                        Account::new(
+                            a,
+                            client.clone(),
+                            self.secret_manager.clone(),
+                            #[cfg(feature = "events")]
+                            self.event_emitter.clone(),
+                            #[cfg(feature = "storage")]
+                            self.storage_manager.clone(),
+                        )
+                        .boxed()
+                    }))
+                    .await?;
+                    *accounts = restored_account;
+                }
             }
         }
 

--- a/sdk/tests/wallet/backup_restore.rs
+++ b/sdk/tests/wallet/backup_restore.rs
@@ -442,7 +442,6 @@ async fn backup_and_restore_different_coin_type_dont_ignore() -> Result<()> {
 
 #[tokio::test]
 #[cfg(all(feature = "stronghold", feature = "storage"))]
-// Backup and restore with Stronghold
 async fn backup_and_restore_bech32_hrp_mismatch() -> Result<()> {
     let storage_path = "test-storage/backup_and_restore_bech32_hrp_mismatch";
     setup(storage_path)?;


### PR DESCRIPTION
# Description of change

Add ignore_if_bech32_mismatch to restore_backup()

## Links to any relevant issues

Fixes #87 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Added test, with a modified nodejs example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
