### PR TITLE
fix: add lacking features to iota-sdk dependency at wallet swift binding

### DIFF
--- a/sdk/src/wallet/bindings/swift/Cargo.toml
+++ b/sdk/src/wallet/bindings/swift/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "staticlib" ]      # Creates dynamic lib
 doc = false
 
 [dependencies]
-iota-sdk = { path = "../../../..", features = [ "wallet", "tls", "message_interface", "events", "rocksdb" ] }
+iota-sdk = { path = "../../../..", features = [ "wallet", "tls", "message_interface", "events", "rocksdb", "stronghold", "storage", "participation" ] }
 
 futures =  { version = "0.3.26", default-features = false }
 once_cell = { version = "1.17.1", default-features = false }


### PR DESCRIPTION
# Description of change

This PR adds the lacking features to iota-sdk dependency on `Cargo.toml` at swift wallet binding, paring with the java wallet binding. 
Without this change the Firefly app on iOS does not work.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
