### PR TITLE
Reuse client instead of creating a new one

### DIFF
--- a/sdk/src/wallet/account/builder.rs
+++ b/sdk/src/wallet/account/builder.rs
@@ -110,7 +110,10 @@ impl AccountBuilder {
             }
         }
 
-        let client = self.client_options.read().await.clone().finish().await?;
+        let client = match accounts.first() {
+            Some(account) => account.client.clone(),
+            None => self.client_options.read().await.clone().finish().await?,
+        };
 
         // If addresses are provided we will use them directly without the additional checks, because then we assume
         // that it's for offline signing and the secretManager can't be used

--- a/sdk/src/wallet/wallet/builder.rs
+++ b/sdk/src/wallet/wallet/builder.rs
@@ -182,13 +182,6 @@ impl WalletBuilder {
         #[cfg(feature = "storage")]
         storage_manager.lock().await.save_wallet_data(&self).await?;
 
-        let client = self
-            .client_options
-            .clone()
-            .ok_or(crate::wallet::Error::MissingParameter("client_options"))?
-            .finish()
-            .await?;
-
         #[cfg(feature = "events")]
         let event_emitter = Arc::new(tokio::sync::Mutex::new(EventEmitter::new()));
 
@@ -201,10 +194,23 @@ impl WalletBuilder {
         unlock_unused_inputs(&mut accounts)?;
         #[cfg(not(feature = "storage"))]
         let accounts = Vec::new();
+        // Client is only required if there are existing accounts
+        let client = if accounts.is_empty() {
+            None
+        } else {
+            Some(
+                self.client_options
+                    .clone()
+                    .ok_or(crate::wallet::Error::MissingParameter("client_options"))?
+                    .finish()
+                    .await?,
+            )
+        };
         let mut accounts: Vec<Account> = try_join_all(accounts.into_iter().map(|a| {
             Account::new(
                 a,
-                client.clone(),
+                // Safe to unwrap because we create the client if accounts aren't empty
+                client.as_ref().expect("client must exists").clone(),
                 self.secret_manager
                     .clone()
                     .expect("secret_manager needs to be provided"),
@@ -221,7 +227,10 @@ impl WalletBuilder {
         // In the other case it was loaded from the database and addresses are up to date.
         if new_provided_client_options {
             for account in accounts.iter_mut() {
-                account.update_account_with_new_client(client.clone()).await?;
+                // Safe to unwrap because we create the client if accounts aren't empty
+                account
+                    .update_account_with_new_client(client.as_ref().expect("client must exists").clone())
+                    .await?;
             }
         }
 

--- a/sdk/src/wallet/wallet/builder.rs
+++ b/sdk/src/wallet/wallet/builder.rs
@@ -210,7 +210,7 @@ impl WalletBuilder {
             Account::new(
                 a,
                 // Safe to unwrap because we create the client if accounts aren't empty
-                client.as_ref().expect("client must exists").clone(),
+                client.as_ref().expect("client must exist").clone(),
                 self.secret_manager
                     .clone()
                     .expect("secret_manager needs to be provided"),
@@ -229,7 +229,7 @@ impl WalletBuilder {
             for account in accounts.iter_mut() {
                 // Safe to unwrap because we create the client if accounts aren't empty
                 account
-                    .update_account_with_new_client(client.as_ref().expect("client must exists").clone())
+                    .update_account_with_new_client(client.as_ref().expect("client must exist").clone())
                     .await?;
             }
         }


### PR DESCRIPTION
# Description of change

Reuse client instead of creating a new one (or don't create one at all if not required)

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running an example which created multiple accounts and with a log in `impl Drop for SyncHandle {`, before this change multiple SyncHandle got dropped, with it only one

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
