### PR TITLE
fix(cli): enter account by providing account ~~name~~ alias

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -48,10 +48,10 @@ fn logger_init(cli: &WalletCli) -> Result<(), Error> {
 }
 
 async fn run(cli: WalletCli) -> Result<(), Error> {
-    let (wallet, account) = new_wallet(cli.clone()).await?;
+    let (wallet, account) = new_wallet(cli).await?;
 
     if let Some(wallet) = wallet {
-        if let Some(account) = cli.account.or(account) {
+        if let Some(account) = account {
             account::account_prompt(wallet.get_account(account).await?).await?;
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,7 +12,7 @@ mod wallet;
 use clap::Parser;
 use fern_logger::{LoggerConfigBuilder, LoggerOutputConfigBuilder};
 
-use self::{command::wallet::WalletCli, error::Error, helper::pick_account, wallet::new_wallet};
+use self::{command::wallet::WalletCli, error::Error, wallet::new_wallet};
 
 #[macro_export]
 macro_rules! println_log_info {
@@ -51,13 +51,8 @@ async fn run(cli: WalletCli) -> Result<(), Error> {
     let (wallet, account) = new_wallet(cli.clone()).await?;
 
     if let Some(wallet) = wallet {
-        match cli.account.or(account) {
-            Some(account) => account::account_prompt(wallet.get_account(account).await?).await?,
-            None => {
-                if let Some(account) = pick_account(&wallet).await? {
-                    account::account_prompt(account).await?;
-                }
-            }
+        if let Some(account) = cli.account.or(account) {
+            account::account_prompt(wallet.get_account(account).await?).await?;
         }
     }
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -60,6 +60,8 @@ pub async fn new_wallet(cli: WalletCli) -> Result<(Option<Wallet>, Option<String
                 let wallet = unlock_wallet(storage_path, snapshot_path, &password).await?;
                 if wallet.get_accounts().await?.is_empty() {
                     create_initial_account(wallet).await?
+                } else if let Some(alias) = cli.account {
+                    (Some(wallet), Some(alias))
                 } else if let Some(account) = pick_account(&wallet).await? {
                     let alias = account.alias().await;
                     (Some(wallet), Some(alias))


### PR DESCRIPTION
# Description of change

It wasn't possible anymore to quickly enter an account in the CLI wallet. Instead it would print a select input anyway.

## Links to any relevant issues

None

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

by running the CLI wallet
