### PR TITLE
Use RwLock instead of Mutex for event_emitter

### DIFF
--- a/sdk/src/wallet/wallet/builder.rs
+++ b/sdk/src/wallet/wallet/builder.rs
@@ -183,7 +183,7 @@ impl WalletBuilder {
         storage_manager.save_wallet_data(&self).await?;
 
         #[cfg(feature = "events")]
-        let event_emitter = tokio::sync::Mutex::new(EventEmitter::new());
+        let event_emitter = tokio::sync::RwLock::new(EventEmitter::new());
 
         #[cfg(feature = "storage")]
         let mut accounts = storage_manager.get_accounts().await?;

--- a/sdk/src/wallet/wallet/mod.rs
+++ b/sdk/src/wallet/wallet/mod.rs
@@ -64,7 +64,7 @@ pub struct WalletInner {
     pub(crate) coin_type: AtomicU32,
     pub(crate) secret_manager: Arc<RwLock<SecretManager>>,
     #[cfg(feature = "events")]
-    pub(crate) event_emitter: tokio::sync::Mutex<EventEmitter>,
+    pub(crate) event_emitter: tokio::sync::RwLock<EventEmitter>,
     #[cfg(feature = "storage")]
     pub(crate) storage_options: StorageOptions,
     #[cfg(feature = "storage")]
@@ -162,7 +162,7 @@ impl WalletInner {
     where
         F: Fn(&Event) + 'static + Clone + Send + Sync,
     {
-        let mut emitter = self.event_emitter.lock().await;
+        let mut emitter = self.event_emitter.write().await;
         emitter.on(events, handler);
     }
 
@@ -170,7 +170,7 @@ impl WalletInner {
     #[cfg(feature = "events")]
     #[cfg_attr(docsrs, doc(cfg(feature = "events")))]
     pub async fn clear_listeners(&self, events: Vec<WalletEventType>) {
-        let mut emitter = self.event_emitter.lock().await;
+        let mut emitter = self.event_emitter.write().await;
         emitter.clear(events);
     }
 
@@ -187,7 +187,7 @@ impl WalletInner {
 
     #[cfg(feature = "events")]
     pub(crate) async fn emit(&self, account_index: u32, event: crate::wallet::events::types::WalletEvent) {
-        self.event_emitter.lock().await.emit(account_index, event);
+        self.event_emitter.read().await.emit(account_index, event);
     }
 
     /// Helper function to test events. Emits a provided event with account index 0.


### PR DESCRIPTION
# Description of change

Use RwLock instead of Mutex for event_emitter

## Links to any relevant issues

Might help to prevent things like https://github.com/iotaledger/iota-sdk/issues/406 in the future

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the event example

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
