### PR TITLE
Python: more type hints, rename QueryParameter, add OutputIdsResponse

### DIFF
--- a/bindings/python/examples/client/03_get_address_outputs.py
+++ b/bindings/python/examples/client/03_get_address_outputs.py
@@ -9,7 +9,7 @@ node_url = os.environ.get('NODE_URL', 'https://api.testnet.shimmer.network')
 # Create a Client instance
 client = Client(nodes=[node_url])
 
-query_parameters = NodeIndexerAPI.QueryParameter(
+query_parameters = NodeIndexerAPI.QueryParameters(
     address='rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy',
     has_expiration=False,
     has_timelock=False,
@@ -21,5 +21,5 @@ output_ids_response = client.basic_output_ids(query_parameters)
 print(f'{output_ids_response}')
 
 # Get the outputs by their id
-outputs = client.get_outputs(output_ids_response['items'])
+outputs = client.get_outputs(output_ids_response.items)
 print(f'{outputs}')

--- a/bindings/python/examples/client/05_get_address_balance.py
+++ b/bindings/python/examples/client/05_get_address_balance.py
@@ -10,7 +10,7 @@ node_url = os.environ.get('NODE_URL', 'https://api.testnet.shimmer.network')
 client = Client(nodes=[node_url])
 
 address='rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy'
-query_parameters = NodeIndexerAPI.QueryParameter(
+query_parameters = NodeIndexerAPI.QueryParameters(
     address,
     has_expiration=False,
     has_timelock=False,
@@ -22,7 +22,7 @@ output_ids_response = client.basic_output_ids(query_parameters)
 print(f'{output_ids_response}')
 
 # Get the outputs by their id
-outputs = client.get_outputs(output_ids_response['items'])
+outputs = client.get_outputs(output_ids_response.items)
 print(f'{outputs}')
 
 

--- a/bindings/python/iota_sdk/client/_high_level_api.py
+++ b/bindings/python/iota_sdk/client/_high_level_api.py
@@ -1,16 +1,21 @@
 # Copyright 2023 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
+from iota_sdk.types.common import HexStr
+from iota_sdk.types.output_id import OutputId
+from typing import List, Optional
+
+
 class HighLevelAPI():
 
-    def get_outputs(self, output_ids):
+    def get_outputs(self, output_ids: List[OutputId]):
         """Fetch OutputResponse from provided OutputIds (requests are sent in parallel).
         """
         return self._call_method('getOutputs', {
             'outputIds': output_ids
         })
 
-    def get_outputs_ignore_errors(self, output_ids):
+    def get_outputs_ignore_errors(self, output_ids: List[OutputId]):
         """Try to get OutputResponse from provided OutputIds.
            Requests are sent in parallel and errors are ignored, can be useful for spent outputs.
         """
@@ -18,20 +23,20 @@ class HighLevelAPI():
             'outputIds': output_ids
         })
 
-    def find_blocks(self, block_ids):
+    def find_blocks(self, block_ids: List[HexStr]):
         """Find all blocks by provided block IDs.
         """
         return self._call_method('findBlocks', {
             'blockIds': block_ids
         })
 
-    def retry(self, block_id):
+    def retry(self, block_id: HexStr):
         """Retries (promotes or reattaches) a block for provided block id. Block should only be
            retried only if they are valid and haven't been confirmed for a while.
         """
         return self._call_method('retry', {'blockId': block_id})
 
-    def retry_until_included(self, block_id, interval=None, max_attempts=None):
+    def retry_until_included(self, block_id: HexStr, interval: Optional[int] = None, max_attempts: Optional[int] = None):
         """Retries (promotes or reattaches) a block for provided block id until it's included (referenced by a
            milestone). Default interval is 5 seconds and max attempts is 40. Returns the included block at first
            position and additional reattached blocks.
@@ -51,7 +56,7 @@ class HighLevelAPI():
             'generateAddressesOptions': generate_addresses_options,
         })
 
-    def find_inputs(self, addresses, amount):
+    def find_inputs(self, addresses: List[str], amount: int):
         """Function to find inputs from addresses for a provided amount (useful for offline signing)
         """
         return self._call_method('findInputs', {
@@ -59,7 +64,7 @@ class HighLevelAPI():
             'amount': amount
         })
 
-    def find_outputs(self, output_ids, addresses):
+    def find_outputs(self, output_ids: List[OutputId], addresses: List[str]):
         """Find all outputs based on the requests criteria. This method will try to query multiple nodes if
            the request amount exceeds individual node limit.
         """
@@ -68,7 +73,7 @@ class HighLevelAPI():
             'addresses': addresses
         })
 
-    def reattach(self, block_id):
+    def reattach(self, block_id: HexStr):
         """Reattaches blocks for provided block id. Blocks can be reattached only if they are valid and haven't been
            confirmed for a while.
         """
@@ -76,14 +81,14 @@ class HighLevelAPI():
             'blockId': block_id
         })
 
-    def reattach_unchecked(self, block_id):
+    def reattach_unchecked(self, block_id: HexStr):
         """Reattach a block without checking if it should be reattached.
         """
         return self._call_method('reattachUnchecked', {
             'blockId': block_id
         })
 
-    def promote(self, block_id):
+    def promote(self, block_id: HexStr):
         """Promotes a block. The method should validate if a promotion is necessary through get_block. If not, the
            method should error out and should not allow unnecessary promotions.
         """
@@ -91,7 +96,7 @@ class HighLevelAPI():
             'blockId': block_id
         })
 
-    def promote_unchecked(self, block_id):
+    def promote_unchecked(self, block_id: HexStr):
         """Promote a block without checking if it should be promoted.
         """
         return self._call_method('promoteUnchecked', {

--- a/bindings/python/iota_sdk/client/_node_core_api.py
+++ b/bindings/python/iota_sdk/client/_node_core_api.py
@@ -1,16 +1,21 @@
 # Copyright 2023 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
+from iota_sdk.types.common import HexStr
+from iota_sdk.types.output_id import OutputId
+from typing import List
+
+
 class NodeCoreAPI():
 
-    def get_node_health(self, url):
+    def get_node_health(self, url: str):
         """ Get node health.
         """
         return self._call_method('getNodeHealth', {
             'url': url
         })
 
-    def get_node_info(self, url, auth=None):
+    def get_node_info(self, url: str, auth=None):
         """Get node info.
         """
         return self._call_method('getNodeInfo', {
@@ -28,7 +33,7 @@ class NodeCoreAPI():
         """
         return self._call_method('getPeers')
 
-    def get_tips(self):
+    def get_tips(self) -> List[HexStr]:
         """Get tips.
         """
         return self._call_method('getTips')
@@ -40,21 +45,21 @@ class NodeCoreAPI():
             'block': block
         })
 
-    def get_block_data(self, block_id):
+    def get_block_data(self, block_id: HexStr):
         """Post block.
         """
         return self._call_method('getBlock', {
             'blockId': block_id
         })
 
-    def get_block_metadata(self, block_id):
+    def get_block_metadata(self, block_id: HexStr):
         """Get block metadata with block_id.
         """
         return self._call_method('getBlockMetadata', {
             'blockId': block_id
         })
 
-    def get_block_raw(self, block_id):
+    def get_block_raw(self, block_id: HexStr):
         """Get block raw.
         """
         return self._call_method('getBlockRaw', {
@@ -68,56 +73,56 @@ class NodeCoreAPI():
             'blockBytes': block_bytes
         })
 
-    def get_output(self, output_id):
+    def get_output(self, output_id: OutputId):
         """Get output.
         """
         return self._call_method('getOutput', {
             'outputId': output_id
         })
 
-    def get_output_metadata(self, output_id):
+    def get_output_metadata(self, output_id: OutputId):
         """Get output metadata.
         """
         return self._call_method('getOutputMetadata', {
             'outputId': output_id
         })
 
-    def get_milestone_by_id(self, milestone_id):
+    def get_milestone_by_id(self, milestone_id: HexStr):
         """Get the milestone by the given milestone id.
         """
         return self._call_method('getMilestoneById', {
             'milestoneId': milestone_id
         })
 
-    def get_milestone_by_id_raw(self, milestone_id):
+    def get_milestone_by_id_raw(self, milestone_id: HexStr):
         """Get the raw milestone by the given milestone id.
         """
         return self._call_method('getMilestoneByIdRaw', {
             'milestoneId': milestone_id
         })
 
-    def get_milestone_by_index(self, index):
+    def get_milestone_by_index(self, index: int):
         """Get the milestone by the given index.
         """
         return self._call_method('getMilestoneByIndex', {
             'index': index
         })
 
-    def get_milestone_by_index_raw(self, index):
+    def get_milestone_by_index_raw(self, index: int):
         """Get the milestone by the given index.
         """
         return self._call_method('getMilestoneByIndexRaw', {
             'index': index
         })
 
-    def get_utxo_changes_by_id(self, milestone_id):
+    def get_utxo_changes_by_id(self, milestone_id: HexStr):
         """Get the UTXO changes by the given milestone id.
         """
         return self._call_method('getUtxoChangesById', {
             'milestoneId': milestone_id
         })
 
-    def get_utxo_changes_by_index(self, index):
+    def get_utxo_changes_by_index(self, index: int):
         """Get the UTXO changes by the given milestone index.
         """
         return self._call_method('getUtxoChangesByIndex', {
@@ -129,7 +134,7 @@ class NodeCoreAPI():
         """
         return self._call_method('getReceipts')
 
-    def get_receipts_migrated_at(self, milestone_index):
+    def get_receipts_migrated_at(self, milestone_index: int):
         """Get the receipts by the given milestone index.
         """
         return self._call_method('getReceiptsMigratedAt', {
@@ -141,14 +146,14 @@ class NodeCoreAPI():
         """
         return self._call_method('getTreasury')
 
-    def get_included_block(self, transaction_id):
+    def get_included_block(self, transaction_id: HexStr):
         """Returns the included block of the transaction.
         """
         return self._call_method('getIncludedBlock', {
             'transactionId': transaction_id
         })
 
-    def get_included_block_metadata(self, transaction_id):
+    def get_included_block_metadata(self, transaction_id: HexStr):
         """Returns the metadata of the included block of the transaction.
         """
         return self._call_method('getIncludedBlockMetadata', {

--- a/bindings/python/iota_sdk/client/_node_indexer_api.py
+++ b/bindings/python/iota_sdk/client/_node_indexer_api.py
@@ -1,98 +1,112 @@
 # Copyright 2023 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
+from iota_sdk.types.common import HexStr
+from iota_sdk.types.output_id import OutputId
 from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 import humps
+import json
 
 
 class NodeIndexerAPI():
 
-    def basic_output_ids(self, query_parameters):
+    @dataclass
+    class QueryParameters:
+        address: Optional[str] = None
+        alias_address: Optional[str] = None
+        created_after: Optional[int] = None
+        created_before: Optional[int] = None
+        cursor: Optional[str] = None
+        expiration_return_address: Optional[str] = None
+        expires_after: Optional[int] = None
+        expires_before: Optional[int] = None
+        governor: Optional[str] = None
+        has_expiration: Optional[bool] = None
+        has_native_tokens: Optional[bool] = None
+        has_storage_deposit_return: Optional[bool] = None
+        has_timelock: Optional[bool] = None
+        issuer: Optional[str] = None
+        max_native_token_count: Optional[int] = None
+        min_native_token_count: Optional[int] = None
+        page_size: Optional[int] = None
+        sender: Optional[str] = None
+        state_controller: Optional[str] = None
+        storage_deposit_return_address: Optional[str] = None
+        tag: Optional[str] = None
+        timelocked_after: Optional[int] = None
+        timelocked_before: Optional[int] = None
+
+        def as_dict(self):
+            return humps.camelize([{k: v} for k, v in self.__dict__.items() if v != None])
+
+    @dataclass
+    class OutputIdsResponse:
+        ledgerIndex: int
+        cursor: Optional[str]
+        items: List[OutputId]
+
+    def basic_output_ids(self, query_parameters: QueryParameters) -> OutputIdsResponse:
         """Fetch basic output IDs.
         """
 
-        query_parameters = query_parameters.as_dict()
+        query_parameters_camelized = query_parameters.as_dict()
 
-        return self._call_method('basicOutputIds', {
-            'queryParameters': query_parameters,
+        response = self._call_method('basicOutputIds', {
+            'queryParameters': query_parameters_camelized,
         })
+        return self.OutputIdsResponse(response['ledgerIndex'], response['cursor'], response['items'])
 
-    def alias_output_ids(self, query_parameters):
+    def alias_output_ids(self, query_parameters: QueryParameters) -> OutputIdsResponse:
         """Fetch alias output IDs.
         """
 
-        query_parameters = query_parameters.as_dict()
+        query_parameters_camelized = query_parameters.as_dict()
 
-        return self._call_method('aliasOutputIds', {
-            'queryParameters': query_parameters,
+        response = self._call_method('aliasOutputIds', {
+            'queryParameters': query_parameters_camelized,
         })
+        return self.OutputIdsResponse(response['ledgerIndex'], response['cursor'], response['items'])
 
-    def alias_output_id(self, alias_id):
+    def alias_output_id(self, alias_id: HexStr) -> OutputId:
         """Fetch alias output ID.
         """
         return self._call_method('aliasOutputId', {
             'aliasId': alias_id
         })
 
-    def nft_output_ids(self, query_parameters):
+    def nft_output_ids(self, query_parameters: QueryParameters) -> OutputIdsResponse:
         """Fetch NFT output IDs.
         """
 
-        query_parameters = query_parameters.as_dict()
+        query_parameters_camelized = query_parameters.as_dict()
 
-        return self._call_method('nftOutputIds', {
-            'queryParameters': query_parameters,
+        response = self._call_method('nftOutputIds', {
+            'queryParameters': query_parameters_camelized,
         })
+        return self.OutputIdsResponse(response['ledgerIndex'], response['cursor'], response['items'])
 
-    def nft_output_id(self, nft_id):
+    def nft_output_id(self, nft_id: HexStr) -> OutputId:
         """Fetch NFT output ID.
         """
         return self._call_method('nftOutputId', {
             'nftId': nft_id
         })
 
-    def foundry_output_ids(self, query_parameters):
+    def foundry_output_ids(self, query_parameters: QueryParameters) -> OutputIdsResponse:
         """Fetch foundry Output IDs.
         """
 
-        query_parameters = query_parameters.as_dict()
+        query_parameters_camelized = query_parameters.as_dict()
 
-        return self._call_method('foundryOutputIds', {
-            'queryParameters': query_parameters,
+        response = self._call_method('foundryOutputIds', {
+            'queryParameters': query_parameters_camelized,
         })
+        return self.OutputIdsResponse(response['ledgerIndex'], response['cursor'], response['items'])
 
-    def foundry_output_id(self, foundry_id):
+    def foundry_output_id(self, foundry_id: HexStr) -> OutputId:
         """Fetch foundry Output ID.
         """
         return self._call_method('foundryOutputId', {
             'foundryId': foundry_id
         })
-
-    @dataclass
-    class QueryParameter:
-        address: str = None
-        alias_address: str = None
-        created_after: int = None
-        created_before: int = None
-        cursor: str = None
-        expiration_return_address: str = None
-        expires_after: int = None
-        expires_before: int = None
-        governor: str = None
-        has_expiration: bool = None
-        has_native_tokens: bool = None
-        has_storage_deposit_return: bool = None
-        has_timelock: bool = None
-        issuer: str = None
-        max_native_token_count: int = None
-        min_native_token_count: int = None
-        page_size: int = None
-        sender: str = None
-        state_controller: str = None
-        storage_deposit_return_address: str = None
-        tag: str = None
-        timelocked_after: int = None
-        timelocked_before: int = None
-
-        def as_dict(self):
-            return humps.camelize([{k: v} for k, v in self.__dict__.items() if v != None])

--- a/bindings/python/iota_sdk/client/_utils.py
+++ b/bindings/python/iota_sdk/client/_utils.py
@@ -1,9 +1,13 @@
 # Copyright 2023 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
+from iota_sdk.types.common import HexStr
+from typing import Optional
+
+
 class ClientUtils():
 
-    def hex_to_bech32(self, hex, bech32_hrp):
+    def hex_to_bech32(self, hex: HexStr, bech32_hrp: str) -> str:
         """Transforms a hex encoded address to a bech32 encoded address.
         """
         return self._call_method('hexToBech32', {
@@ -11,7 +15,7 @@ class ClientUtils():
             'bech32Hrp': bech32_hrp
         })
 
-    def alias_id_to_bech32(self, alias_id, bech32_hrp):
+    def alias_id_to_bech32(self, alias_id: HexStr, bech32_hrp: str) -> str:
         """Transforms an alias id to a bech32 encoded address.
         """
         return self._call_method('aliasIdToBech32', {
@@ -19,7 +23,7 @@ class ClientUtils():
             'bech32Hrp': bech32_hrp
         })
 
-    def nft_id_to_bech32(self, nft_id, bech32_hrp):
+    def nft_id_to_bech32(self, nft_id: HexStr, bech32_hrp: str) -> str:
         """Transforms an nft id to a bech32 encoded address.
         """
         return self._call_method('nftIdToBech32', {
@@ -27,7 +31,7 @@ class ClientUtils():
             'bech32Hrp': bech32_hrp
         })
 
-    def hex_public_key_to_bech32_address(self, hex, bech32_hrp=None):
+    def hex_public_key_to_bech32_address(self, hex: HexStr, bech32_hrp: Optional[str] = None) -> str:
         """Transforms a hex encoded public key to a bech32 encoded address.
         """
         return self._call_method('hexPublicKeyToBech32Address', {
@@ -35,7 +39,7 @@ class ClientUtils():
             'bech32Hrp': bech32_hrp
         })
 
-    def request_funds_from_faucet(self, url, address):
+    def request_funds_from_faucet(self, url: str, address: str) -> str:
         """Requests funds from the faucet, for example `https://faucet.testnet.shimmer.network/api/enqueue` or `http://localhost:8091/api/enqueue`.
         """
         return self._call_method(


### PR DESCRIPTION
# Description of change

Add more type hints, rename QueryParameter to QueryParameters, add OutputIdsResponse
QueryParameters had to be moved to the top, because it must be defined before used

## Links to any relevant issues

#129 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Running examples and checking with mypy