### PR TITLE
Fix yarn format commands

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -6,8 +6,8 @@
     "types": "out/index.d.ts",
     "scripts": {
         "lint": "eslint --ignore-path .eslintignore --ext .js,.ts .",
-        "format": "prettier --ignore-path .eslintignore -w {,*/**/}*.{ts,js,json}",
-        "format-check": "prettier --ignore-path .eslintignore -c {,*/**/}*.{ts,js,json}",
+        "format": "prettier --ignore-path .eslintignore -w \"{,*/**/}*.{ts,js,json}\"",
+        "format-check": "prettier --ignore-path .eslintignore -c \"{,*/**/}*.{ts,js,json}\"",
         "build": "node scripts/neon-build && tsc",
         "build:neon": "cargo-cp-artifact -ac iota-sdk-nodejs ./index.node -- cargo build --release --message-format=json-render-diagnostics",
         "docs-wiki-build": "typedoc --githubPages false --disableSources --excludePrivate --excludeInternal --excludeNotDocumented --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order --exclude ./**/src/index.ts --out ../../documentation/docs/references/nodejs ./lib/index.ts ",

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -26,8 +26,8 @@
         "bundle:web": "wasm-bindgen ../../target/wasm32-unknown-unknown/release/iota_sdk_wasm.wasm --typescript --weak-refs --target web --out-dir web/wasm && node ./build_scripts/web && tsc --project tsconfig.web.json --outDir web/lib",
         "copy-nodejs-defs": "node ./build_scripts/copyNodejsDefs.js",
         "lint": "eslint --ignore-path .eslintignore --ext .js,.ts .",
-        "format": "prettier --ignore-path .eslintignore -w {,*/**/}*.{ts,js,json}",
-        "format-check": "prettier --ignore-path .eslintignore -c {,*/**/}*.{ts,js,json}",
+        "format": "prettier --ignore-path .eslintignore -w \"{,*/**/}*.{ts,js,json}\"",
+        "format-check": "prettier --ignore-path .eslintignore -c \"{,*/**/}*.{ts,js,json}\"",
         "docs-wiki-build": "typedoc --githubPages false --disableSources --excludePrivate --excludeInternal --excludeNotDocumented --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order --exclude ./**/src/index.ts --out ../../documentation/docs/libraries/wasm/references/ ./lib/index.ts",
         "test": "jest --forceExit",
         "test2": "npm run bundle:nodejs && wasm-opt -O node/wasm/iota_sdk_wasm_bg.wasm -o node/wasm/iota_sdk_wasm_bg.wasm"

--- a/sdk/src/wallet/bindings/nodejs/package.json
+++ b/sdk/src/wallet/bindings/nodejs/package.json
@@ -6,8 +6,8 @@
     "types": "out/lib/index.d.ts",
     "scripts": {
         "lint": "eslint --ignore-path .eslintignore --ext .js,.ts .",
-        "format": "prettier --ignore-path .eslintignore -w {,*/**/}*.{ts,js,json}",
-        "format-check": "prettier --ignore-path .eslintignore -c {,*/**/}*.{ts,js,json}",
+        "format": "prettier --ignore-path .eslintignore -w \"{,*/**/}*.{ts,js,json}\"",
+        "format-check": "prettier --ignore-path .eslintignore -c \"{,*/**/}*.{ts,js,json}\"",
         "build": "node scripts/neon-build && tsc",
         "build:neon": "cargo-cp-artifact -ac iota-wallet-nodejs ./index.node -- cargo build --release --message-format=json-render-diagnostics",
         "docs-wiki-build": "typedoc --githubPages false --disableSources --excludePrivate --excludeInternal --excludeNotDocumented --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order --exclude ./**/src/index.ts --out ../../documentation/docs/references/nodejs ./lib/index.ts ",


### PR DESCRIPTION
Avoid things like `[error] No files matching the pattern were found: "*.ts".`