### PR TITLE
Add get_secret_manager to bindings

### DIFF
--- a/bindings/core/Cargo.toml
+++ b/bindings/core/Cargo.toml
@@ -23,10 +23,8 @@ primitive-types = { version = "0.12.1", default-features = false }
 serde = { version = "1.0.163", default-features = false }
 serde_json = { version = "1.0.96", default-features = false }
 thiserror = { version = "1.0.40", default-features = false }
-zeroize = { version = "1.6.0", default-features = false }
-
-[dev-dependencies]
 tokio = { version = "1.28.2", default-features = false }
+zeroize = { version = "1.6.0", default-features = false }
 
 [features]
 events = [ "iota-sdk/events" ]

--- a/bindings/core/src/method_handler/call_method.rs
+++ b/bindings/core/src/method_handler/call_method.rs
@@ -8,6 +8,7 @@ use iota_sdk::{
     client::{secret::SecretManager, Client},
     wallet::wallet::Wallet,
 };
+use tokio::sync::RwLock;
 
 use crate::{
     method::{ClientMethod, SecretManagerMethod, WalletMethod},
@@ -40,14 +41,6 @@ impl CallMethod for Wallet {
 
     fn call_method<'a>(&'a self, method: Self::Method) -> Pin<Box<dyn Future<Output = Response> + 'a>> {
         Box::pin(call_wallet_method(self, method))
-    }
-}
-
-impl CallMethod for SecretManager {
-    type Method = SecretManagerMethod;
-
-    fn call_method<'a>(&'a self, method: Self::Method) -> Pin<Box<dyn Future<Output = Response> + 'a>> {
-        Box::pin(call_secret_manager_method(self, method))
     }
 }
 
@@ -85,7 +78,10 @@ pub fn call_utils_method(method: UtilsMethod) -> Response {
 }
 
 /// Call a secret manager method.
-pub async fn call_secret_manager_method(secret_manager: &SecretManager, method: SecretManagerMethod) -> Response {
+pub async fn call_secret_manager_method(
+    secret_manager: &RwLock<SecretManager>,
+    method: SecretManagerMethod,
+) -> Response {
     log::debug!("Secret manager method: {method:?}");
     let result =
         convert_async_panics(|| async { call_secret_manager_method_internal(secret_manager, method).await }).await;

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -9,14 +9,16 @@ use iota_sdk::{
     },
     types::block::{payload::dto::PayloadDto, signature::dto::Ed25519SignatureDto, unlock::Unlock},
 };
+use tokio::sync::RwLock;
 
 use crate::{method::SecretManagerMethod, response::Response, Result};
 
 /// Call a secret manager method.
 pub(crate) async fn call_secret_manager_method_internal(
-    secret_manager: &SecretManager,
+    secret_manager: &RwLock<SecretManager>,
     method: SecretManagerMethod,
 ) -> Result<Response> {
+    let secret_manager = secret_manager.read().await;
     let response = match method {
         SecretManagerMethod::GenerateEd25519Addresses { options } => {
             let addresses = secret_manager.generate_ed25519_addresses(options).await?;
@@ -28,7 +30,7 @@ pub(crate) async fn call_secret_manager_method_internal(
         }
         #[cfg(feature = "ledger_nano")]
         SecretManagerMethod::GetLedgerNanoStatus => {
-            if let SecretManager::LedgerNano(secret_manager) = secret_manager {
+            if let SecretManager::LedgerNano(secret_manager) = &*secret_manager {
                 Response::LedgerNanoStatus(secret_manager.get_ledger_nano_status().await)
             } else {
                 return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
@@ -64,7 +66,7 @@ pub(crate) async fn call_secret_manager_method_internal(
         }
         #[cfg(feature = "stronghold")]
         SecretManagerMethod::StoreMnemonic { mnemonic } => {
-            if let SecretManager::Stronghold(secret_manager) = secret_manager {
+            if let SecretManager::Stronghold(secret_manager) = &*secret_manager {
                 secret_manager.store_mnemonic(mnemonic).await?;
                 Response::Ok
             } else {

--- a/bindings/core/tests/secrets_manager.rs
+++ b/bindings/core/tests/secrets_manager.rs
@@ -1,20 +1,23 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use iota_sdk::client::{api::GetAddressesOptions, constants::ETHER_COIN_TYPE, secret::SecretManager};
-use iota_sdk_bindings_core::{CallMethod, Response, Result, SecretManagerMethod};
+use iota_sdk_bindings_core::{call_secret_manager_method, Response, Result, SecretManagerMethod};
+use tokio::sync::RwLock;
 
 #[tokio::test]
 async fn generate_ed25519_addresses() -> Result<()> {
-    let secret_manager = SecretManager::try_from_mnemonic(
+    let secret_manager = Arc::new(RwLock::new(SecretManager::try_from_mnemonic(
         "endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river",
-    )?;
+    )?));
 
     let method = SecretManagerMethod::GenerateEd25519Addresses {
         options: GetAddressesOptions::default().with_range(0..1),
     };
 
-    let response = secret_manager.call_method(method).await;
+    let response = call_secret_manager_method(&secret_manager, method).await;
     match response {
         Response::GeneratedEd25519Addresses(addresses) => assert_eq!(
             addresses[0],
@@ -28,9 +31,9 @@ async fn generate_ed25519_addresses() -> Result<()> {
 
 #[tokio::test]
 async fn generate_evm_addresses() -> Result<()> {
-    let secret_manager = SecretManager::try_from_mnemonic(
+    let secret_manager = Arc::new(RwLock::new(SecretManager::try_from_mnemonic(
         "endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river",
-    )?;
+    )?));
 
     let method = SecretManagerMethod::GenerateEvmAddresses {
         options: GetAddressesOptions::default()
@@ -38,7 +41,7 @@ async fn generate_evm_addresses() -> Result<()> {
             .with_coin_type(ETHER_COIN_TYPE),
     };
 
-    let response = secret_manager.call_method(method).await;
+    let response = call_secret_manager_method(&secret_manager, method).await;
     match response {
         Response::GeneratedEvmAddresses(addresses) => {
             assert_eq!(addresses[0], "0xcaefde2b487ded55688765964320ff390cd87828")

--- a/bindings/nodejs/lib/bindings.ts
+++ b/bindings/nodejs/lib/bindings.ts
@@ -24,6 +24,7 @@ const {
     listenWallet,
     destroyWallet,
     getClientFromWallet,
+    getSecretManagerFromWallet,
 } = addon;
 
 const callClientMethodAsync = (
@@ -109,5 +110,6 @@ export {
     destroyWallet,
     listenWalletAsync,
     getClientFromWallet,
+    getSecretManagerFromWallet,
     listenMqtt,
 };

--- a/bindings/nodejs/lib/secretManager/SecretManager.ts
+++ b/bindings/nodejs/lib/secretManager/SecretManager.ts
@@ -20,7 +20,7 @@ import { SecretManagerType } from '../types/secretManager/';
 export class SecretManager {
     private methodHandler: SecretManagerMethodHandler;
 
-    constructor(options: SecretManagerType) {
+    constructor(options: SecretManagerType | SecretManagerMethodHandler) {
         this.methodHandler = new SecretManagerMethodHandler(options);
     }
 

--- a/bindings/nodejs/lib/secretManager/SecretManagerMethodHandler.ts
+++ b/bindings/nodejs/lib/secretManager/SecretManagerMethodHandler.ts
@@ -11,8 +11,13 @@ import {
 export class SecretManagerMethodHandler {
     methodHandler: SecretManagerMethodHandler;
 
-    constructor(secretManager: SecretManagerType) {
-        this.methodHandler = createSecretManager(JSON.stringify(secretManager));
+    constructor(options: SecretManagerType | SecretManagerMethodHandler) {
+        // The rust secret manager object is not extensible
+        if (Object.isExtensible(options)) {
+            this.methodHandler = createSecretManager(JSON.stringify(options));
+        } else {
+            this.methodHandler = options as SecretManagerMethodHandler;
+        }
     }
 
     async callMethod(method: __SecretManagerMethods__): Promise<string> {

--- a/bindings/nodejs/lib/wallet/Wallet.ts
+++ b/bindings/nodejs/lib/wallet/Wallet.ts
@@ -16,6 +16,7 @@ import type {
 } from '../types/wallet';
 import { IAuth, IClientOptions, LedgerNanoStatus } from '../types/client';
 import { Client } from '../client';
+import { SecretManager } from '../secretManager';
 
 /** The Wallet class. */
 export class Wallet {
@@ -142,6 +143,13 @@ export class Wallet {
      */
     async getClient(): Promise<Client> {
         return this.methodHandler.getClient();
+    }
+
+    /**
+     * Get secret manager.
+     */
+    async getSecretManager(): Promise<SecretManager> {
+        return this.methodHandler.getSecretManager();
     }
 
     /**

--- a/bindings/nodejs/lib/wallet/WalletMethodHandler.ts
+++ b/bindings/nodejs/lib/wallet/WalletMethodHandler.ts
@@ -7,6 +7,7 @@ import {
     listenWalletAsync,
     destroyWallet,
     getClientFromWallet,
+    getSecretManagerFromWallet,
 } from '../bindings';
 import type {
     WalletEventType,
@@ -17,6 +18,7 @@ import type {
     Event,
 } from '../types/wallet';
 import { Client } from '../client';
+import { SecretManager } from '../secretManager';
 
 // The WalletMethodHandler class interacts with methods with the rust bindings.
 export class WalletMethodHandler {
@@ -91,6 +93,20 @@ export class WalletMethodHandler {
                     resolve(new Client(result));
                 }
             });
+        });
+    }
+
+    async getSecretManager(): Promise<SecretManager> {
+        return new Promise((resolve, reject) => {
+            getSecretManagerFromWallet(this.methodHandler).then(
+                (result: any) => {
+                    if (result.message !== undefined) {
+                        reject(JSON.parse(result.message).payload);
+                    } else {
+                        resolve(new SecretManager(result));
+                    }
+                },
+            );
         });
     }
 }

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -61,6 +61,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("createWallet", wallet::create_wallet)?;
     cx.export_function("destroyWallet", wallet::destroy_wallet)?;
     cx.export_function("getClientFromWallet", wallet::get_client)?;
+    cx.export_function("getSecretManagerFromWallet", wallet::get_secret_manager)?;
     cx.export_function("listenWallet", wallet::listen_wallet)?;
 
     Ok(())

--- a/bindings/nodejs/src/secret_manager.rs
+++ b/bindings/nodejs/src/secret_manager.rs
@@ -9,10 +9,11 @@ use iota_sdk_bindings_core::{
     Response, SecretManagerMethod,
 };
 use neon::prelude::*;
+use tokio::sync::RwLock;
 
 pub struct SecretManagerMethodHandler {
     channel: Channel,
-    secret_manager: SecretManager,
+    secret_manager: Arc<RwLock<SecretManager>>,
 }
 
 impl Finalize for SecretManagerMethodHandler {}
@@ -23,6 +24,13 @@ impl SecretManagerMethodHandler {
             serde_json::from_str::<SecretManagerDto>(&options).expect("error initializing secret manager");
         let secret_manager = SecretManager::try_from(&secret_manager_dto).expect("error initializing secret manager");
 
+        Arc::new(Self {
+            channel,
+            secret_manager: Arc::new(RwLock::new(secret_manager)),
+        })
+    }
+
+    pub fn new_with_secret_manager(channel: Channel, secret_manager: Arc<RwLock<SecretManager>>) -> Arc<Self> {
         Arc::new(Self {
             channel,
             secret_manager,

--- a/bindings/python/iota_sdk/secret_manager/secret_manager.py
+++ b/bindings/python/iota_sdk/secret_manager/secret_manager.py
@@ -60,8 +60,11 @@ class SecretManagerError(Exception):
 
 
 class SecretManager():
-    def __init__(self, secret_manager: MnemonicSecretManager | SeedSecretManager | StrongholdSecretManager | LedgerNanoSecretManager):
-        self.handle = create_secret_manager(dumps(secret_manager))
+    def __init__(self, secret_manager: MnemonicSecretManager | SeedSecretManager | StrongholdSecretManager | LedgerNanoSecretManager=None, secret_manager_handle=None):
+        if secret_manager_handle is None:
+            self.handle = create_secret_manager(dumps(secret_manager))
+        else:
+            self.handle = secret_manager_handle
 
     def _call_method(self, name, data=None):
         """Dumps json string and call call_secret_manager_method()

--- a/bindings/python/iota_sdk/wallet/wallet.py
+++ b/bindings/python/iota_sdk/wallet/wallet.py
@@ -1,8 +1,8 @@
 # Copyright 2023 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-from iota_sdk import destroy_wallet, create_wallet, listen_wallet, get_client_from_wallet, Client
-from iota_sdk.secret_manager.secret_manager import LedgerNanoSecretManager, MnemonicSecretManager, StrongholdSecretManager
+from iota_sdk import destroy_wallet, create_wallet, listen_wallet, get_client_from_wallet, get_secret_manager_from_wallet, Client
+from iota_sdk.secret_manager.secret_manager import LedgerNanoSecretManager, MnemonicSecretManager, StrongholdSecretManager, SecretManager
 from iota_sdk.wallet.account import Account, _call_method_routine
 from json import dumps
 from typing import Any, Dict, List, Optional
@@ -49,6 +49,11 @@ class Wallet():
         """Get the client instance
         """
         return Client(client_handle=get_client_from_wallet(self.handle))
+
+    def get_secret_manager(self):
+        """Get the secret manager instance
+        """
+        return SecretManager(secret_manager_handle=get_secret_manager_from_wallet(self.handle))
 
     @_call_method_routine
     def _call_method(self, name: str, data=None):

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -85,7 +85,8 @@ fn iota_sdk(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(call_wallet_method, m)?).unwrap();
     m.add_function(wrap_pyfunction!(destroy_wallet, m)?).unwrap();
     m.add_function(wrap_pyfunction!(get_client_from_wallet, m)?).unwrap();
-    m.add_function(wrap_pyfunction!(get_secret_manager_from_wallet, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(get_secret_manager_from_wallet, m)?)
+        .unwrap();
     m.add_function(wrap_pyfunction!(listen_wallet, m)?).unwrap();
 
     m.add_function(wrap_pyfunction!(migrate_stronghold_snapshot_v2_to_v3, m)?)

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -85,6 +85,7 @@ fn iota_sdk(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(call_wallet_method, m)?).unwrap();
     m.add_function(wrap_pyfunction!(destroy_wallet, m)?).unwrap();
     m.add_function(wrap_pyfunction!(get_client_from_wallet, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(get_secret_manager_from_wallet, m)?).unwrap();
     m.add_function(wrap_pyfunction!(listen_wallet, m)?).unwrap();
 
     m.add_function(wrap_pyfunction!(migrate_stronghold_snapshot_v2_to_v3, m)?)

--- a/bindings/python/src/secret_manager.rs
+++ b/bindings/python/src/secret_manager.rs
@@ -1,18 +1,21 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use iota_sdk_bindings_core::{
     call_secret_manager_method as rust_call_secret_manager_method,
     iota_sdk::client::secret::{SecretManager as RustSecretManager, SecretManagerDto},
     SecretManagerMethod,
 };
 use pyo3::prelude::*;
+use tokio::sync::RwLock;
 
 use crate::error::Result;
 
 #[pyclass]
 pub struct SecretManager {
-    pub secret_manager: RustSecretManager,
+    pub secret_manager: Arc<RwLock<RustSecretManager>>,
 }
 
 /// Create secret_manager for python-side usage.
@@ -20,7 +23,9 @@ pub struct SecretManager {
 pub fn create_secret_manager(options: String) -> Result<SecretManager> {
     let secret_manager_dto = serde_json::from_str::<SecretManagerDto>(&options)?;
     let secret_manager = RustSecretManager::try_from(&secret_manager_dto)?;
-    Ok(SecretManager { secret_manager })
+    Ok(SecretManager {
+        secret_manager: Arc::new(RwLock::new(secret_manager)),
+    })
 }
 
 #[pyfunction]

--- a/bindings/python/src/wallet.rs
+++ b/bindings/python/src/wallet.rs
@@ -14,6 +14,7 @@ use tokio::sync::RwLock;
 use crate::{
     client::Client,
     error::{Error, Result},
+    SecretManager,
 };
 
 #[pyclass]
@@ -106,4 +107,27 @@ pub fn get_client_from_wallet(wallet: &Wallet) -> Result<Client> {
     })?;
 
     Ok(Client { client })
+}
+
+/// Get the secret manager from the wallet.
+#[pyfunction]
+pub fn get_secret_manager_from_wallet(wallet: &Wallet) -> Result<SecretManager> {
+    let secret_manager = crate::block_on(async {
+        wallet
+            .wallet
+            .read()
+            .await
+            .as_ref()
+            .map(|w| w.get_secret_manager().clone())
+            .ok_or_else(|| {
+                Error::from(
+                    serde_json::to_string(&Response::Panic("wallet got destroyed".into()))
+                        .expect("json to string error")
+                        .as_str(),
+                )
+            })
+    })?
+    .clone();
+
+    Ok(SecretManager { secret_manager })
 }

--- a/bindings/python/src/wallet.rs
+++ b/bindings/python/src/wallet.rs
@@ -126,8 +126,7 @@ pub fn get_secret_manager_from_wallet(wallet: &Wallet) -> Result<SecretManager> 
                         .as_str(),
                 )
             })
-    })?
-    .clone();
+    })?;
 
     Ok(SecretManager { secret_manager })
 }

--- a/bindings/wasm/lib/bindings.ts
+++ b/bindings/wasm/lib/bindings.ts
@@ -9,7 +9,7 @@ import { __UtilsMethods__ } from './utils';
 // Import needs to be in a single line, otherwise it breaks
 // prettier-ignore
 // @ts-ignore: path is set to match runtime transpiled js path when bundled.
-const { initLogger, createClient, createSecretManager, createWallet, callClientMethodAsync, callSecretManagerMethodAsync, callUtilsMethodRust, callWalletMethodAsync, destroyWallet, listenWalletAsync, getClientFromWallet, listenMqtt } = require('../wasm/iota_sdk_wasm');
+const { initLogger, createClient, createSecretManager, createWallet, callClientMethodAsync, callSecretManagerMethodAsync, callUtilsMethodRust, callWalletMethodAsync, destroyWallet, listenWalletAsync, getClientFromWallet, getSecretManagerFromWallet, listenMqtt } = require('../wasm/iota_sdk_wasm');
 
 const callUtilsMethod = (method: __UtilsMethods__): any => {
     const response = JSON.parse(callUtilsMethodRust(JSON.stringify(method)));
@@ -32,5 +32,6 @@ export {
     listenWalletAsync,
     destroyWallet,
     getClientFromWallet,
+    getSecretManagerFromWallet,
     listenMqtt,
 };

--- a/bindings/wasm/src/secret_manager.rs
+++ b/bindings/wasm/src/secret_manager.rs
@@ -1,13 +1,14 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use iota_sdk_bindings_core::{
     call_secret_manager_method,
     iota_sdk::client::secret::{SecretManager, SecretManagerDto},
     Response, SecretManagerMethod,
 };
+use tokio::sync::RwLock;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::future_to_promise;
 
@@ -16,7 +17,7 @@ use crate::PromiseString;
 /// The SecretManager method handler.
 #[wasm_bindgen(js_name = SecretManagerMethodHandler)]
 pub struct SecretManagerMethodHandler {
-    pub(crate) secret_manager: Rc<SecretManager>,
+    pub(crate) secret_manager: Arc<RwLock<SecretManager>>,
 }
 
 /// Creates a method handler with the given secret_manager options.
@@ -27,7 +28,7 @@ pub fn create_secret_manager(options: String) -> Result<SecretManagerMethodHandl
     let secret_manager = SecretManager::try_from(&secret_manager_dto).map_err(|err| err.to_string())?;
 
     Ok(SecretManagerMethodHandler {
-        secret_manager: Rc::new(secret_manager),
+        secret_manager: Arc::new(RwLock::new(secret_manager)),
     })
 }
 
@@ -40,8 +41,7 @@ pub fn call_secret_manager_method_async(
     method: String,
     methodHandler: &SecretManagerMethodHandler,
 ) -> Result<PromiseString, JsValue> {
-    let secret_manager: Rc<SecretManager> = Rc::clone(&methodHandler.secret_manager);
-
+    let secret_manager = methodHandler.secret_manager.clone();
     let promise: js_sys::Promise = future_to_promise(async move {
         let method: SecretManagerMethod = serde_json::from_str(&method).map_err(|err| err.to_string())?;
 

--- a/bindings/wasm/src/wallet.rs
+++ b/bindings/wasm/src/wallet.rs
@@ -14,7 +14,7 @@ use iota_sdk_bindings_core::{
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
-use crate::client::ClientMethodHandler;
+use crate::{client::ClientMethodHandler, secret_manager::SecretManagerMethodHandler};
 
 /// The Wallet method handler.
 #[wasm_bindgen(js_name = WalletMethodHandler)]
@@ -56,6 +56,19 @@ pub async fn get_client(method_handler: &WalletMethodHandler) -> Result<ClientMe
         .clone();
 
     Ok(ClientMethodHandler { client })
+}
+
+#[wasm_bindgen(js_name = getSecretManagerFromWallet)]
+pub async fn get_secret_manager(method_handler: &WalletMethodHandler) -> Result<SecretManagerMethodHandler, JsValue> {
+    let wallet = method_handler.wallet.borrow_mut();
+
+    let secret_manager = wallet
+        .as_ref()
+        .ok_or_else(|| "wallet got destroyed".to_string())?
+        .get_secret_manager()
+        .clone();
+
+    Ok(SecretManagerMethodHandler { secret_manager })
 }
 
 /// Handles a method, returns the response as a JSON-encoded string.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stronghold snapshot migration from v2 to v3;
 - `SecretManage::sign_evm`;
 - `Account::addresses_balance` method accepting addresses to get balance for;
+- `Wallet::get_secret_manager` method;
 
 ### Changed
 

--- a/sdk/src/wallet/wallet/mod.rs
+++ b/sdk/src/wallet/wallet/mod.rs
@@ -151,7 +151,7 @@ impl Wallet {
 
 impl WalletInner {
     /// Get the [SecretManager]
-    pub fn get_secret_manager(&self) -> &RwLock<SecretManager> {
+    pub fn get_secret_manager(&self) -> &Arc<RwLock<SecretManager>> {
         &self.secret_manager
     }
 


### PR DESCRIPTION
# Description of change

Add get_secret_manager to bindings
`get_secret_manager` didn't had a changelog entry yet

## Links to any relevant issues

Fixes #515 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Modified Python and NodeJS examples to generate addresses from the returned secret manager

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
