### PR TITLE
Fix python burn constructor

### DIFF
--- a/bindings/python/iota_sdk/types/burn.py
+++ b/bindings/python/iota_sdk/types/burn.py
@@ -24,10 +24,10 @@ class Burn:
         The native tokens to burn
     """
 
-    aliases: Optional[List[HexStr]]
-    nfts: Optional[List[HexStr]]
-    foundries: Optional[List[HexStr]]
-    nativeTokens: Optional[List[NativeToken]]
+    aliases: Optional[List[HexStr]] = None
+    nfts: Optional[List[HexStr]] = None
+    foundries: Optional[List[HexStr]] = None
+    nativeTokens: Optional[List[NativeToken]] = None
 
     def add_alias(self, alias: HexStr) -> Burn:
         if self.aliases is None:


### PR DESCRIPTION
# Description of change

Fixed the burn constructor to take no arguments

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested with burn example

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
