### PR TITLE
fix(cli): fix wallet initialization

### DIFF
--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -140,10 +140,7 @@ pub async fn init_command(
             snapshot_path.display()
         )));
     }
-    // Set up password.
     let password = get_password("Stronghold password", true)?;
-
-    // Set up mnemonic.
     let mnemonic = match parameters.mnemonic_file_path {
         Some(path) => import_mnemonic(&path).await?,
         None => enter_or_generate_mnemonic().await?,

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -128,32 +128,41 @@ pub async fn init_command(
     snapshot_path: &Path,
     parameters: InitParameters,
 ) -> Result<Wallet, Error> {
-    let password = get_password("Stronghold password", !snapshot_path.exists())?;
-    let secret_manager = SecretManager::Stronghold(
-        StrongholdSecretManager::builder()
-            .password(&password)
-            .build(snapshot_path)?,
-    );
-    let wallet = Wallet::builder()
-        .with_secret_manager(secret_manager)
-        .with_client_options(ClientOptions::new().with_node(parameters.node_url.as_str())?)
-        .with_storage_path(storage_path.to_str().expect("invalid unicode"))
-        .with_coin_type(parameters.coin_type)
-        .finish()
-        .await?;
+    if storage_path.exists() {
+        return Err(Error::Miscellaneous(format!(
+            "cannot initialize: {} already exists",
+            storage_path.display()
+        )));
+    }
+    if snapshot_path.exists() {
+        return Err(Error::Miscellaneous(format!(
+            "cannot initialize: {} already exists",
+            snapshot_path.display()
+        )));
+    }
+    // Set up password.
+    let password = get_password("Stronghold password", true)?;
 
+    // Set up mnemonic.
     let mnemonic = match parameters.mnemonic_file_path {
         Some(path) => import_mnemonic(&path).await?,
         None => enter_or_generate_mnemonic().await?,
     };
 
-    if let SecretManager::Stronghold(secret_manager) = &mut *wallet.get_secret_manager().write().await {
-        secret_manager.store_mnemonic(mnemonic).await?;
-    } else {
-        panic!("cli-wallet only supports Stronghold-backed secret managers at the moment.");
-    }
+    let secret_manager = StrongholdSecretManager::builder()
+        .password(&password)
+        .build(snapshot_path)?;
+    // TODO: allow providing the mnemonic in the builder?
+    secret_manager.store_mnemonic(mnemonic.clone()).await?;
+    let secret_manager = SecretManager::Stronghold(secret_manager);
 
-    Ok(wallet)
+    Ok(Wallet::builder()
+        .with_secret_manager(secret_manager)
+        .with_client_options(ClientOptions::new().with_node(parameters.node_url.as_str())?)
+        .with_storage_path(storage_path.to_str().expect("invalid unicode"))
+        .with_coin_type(parameters.coin_type)
+        .finish()
+        .await?)
 }
 
 pub async fn migrate_stronghold_snapshot_v2_to_v3_command(path: Option<String>) -> Result<(), Error> {

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -153,7 +153,7 @@ pub async fn init_command(
         .password(&password)
         .build(snapshot_path)?;
     // TODO: allow providing the mnemonic in the builder?
-    secret_manager.store_mnemonic(mnemonic.clone()).await?;
+    secret_manager.store_mnemonic(mnemonic).await?;
     let secret_manager = SecretManager::Stronghold(secret_manager);
 
     Ok(Wallet::builder()

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -152,7 +152,6 @@ pub async fn init_command(
     let secret_manager = StrongholdSecretManager::builder()
         .password(&password)
         .build(snapshot_path)?;
-    // TODO: allow providing the mnemonic in the builder?
     secret_manager.store_mnemonic(mnemonic).await?;
     let secret_manager = SecretManager::Stronghold(secret_manager);
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::Path;
+
 use iota_sdk::wallet::Wallet;
 
 use crate::{
@@ -15,8 +17,8 @@ use crate::{
 };
 
 pub async fn new_wallet(cli: WalletCli) -> Result<(Option<Wallet>, Option<String>), Error> {
-    let storage_path = std::path::Path::new(&cli.wallet_db_path);
-    let snapshot_path = std::path::Path::new(&cli.stronghold_snapshot_path);
+    let storage_path = Path::new(&cli.wallet_db_path);
+    let snapshot_path = Path::new(&cli.stronghold_snapshot_path);
 
     let (wallet, account) = if let Some(command) = cli.command {
         match command {


### PR DESCRIPTION
# Description of change

This fixes a bug with initialization of a new wallet. It ensures that a stronghold snapshot file is only created when a mnemonic has been successfully stored. Prior to that PR you could abort the dialoguer interaction with CTRL-C during mnemonic generation, and this would end up with a Stronghold file that has no mnemonic stored. An alternative would be to check whether the stronghold file contains a mnemnoic on start and re-request the user to provide a mnemonic, but the solution provided with this PR fixes the issue with minimal code changes.

## Links to any relevant issues

Fixes #361 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running the cli-wallet binary.