### PR TITLE
Remove get_node_info from wallet

### DIFF
--- a/bindings/python/iota_sdk/wallet/wallet.py
+++ b/bindings/python/iota_sdk/wallet/wallet.py
@@ -185,16 +185,6 @@ class Wallet():
             }
         )
 
-    def get_node_info(self, url: str, auth):
-        """Get node info.
-        """
-        return self._call_method(
-            'getNodeInfo', {
-                'url': url,
-                'auth': auth
-            }
-        )
-
     def set_stronghold_password(self, password: str):
         """Set stronghold password.
         """

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -105,6 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Bech32Addresses` and `RawAddresses`;
 - `Client::get_addresses`;
 - `Topic` `TryFrom<String>` impl;
+- `Client::generate_ed25519_addresses`
+- `Wallet::get_node_info`
 
 ### Fixed
 

--- a/sdk/src/wallet/wallet/operations/client.rs
+++ b/sdk/src/wallet/wallet/operations/client.rs
@@ -11,7 +11,7 @@ use crate::{
             builder::NodeManagerBuilder,
             node::{Node, NodeAuth, NodeDto},
         },
-        Client, ClientBuilder, NodeInfoWrapper,
+        Client, ClientBuilder,
     },
     wallet::Wallet,
     Url,
@@ -60,13 +60,6 @@ impl Wallet {
                 .await?;
         }
         Ok(())
-    }
-
-    /// Get the node info.
-    pub async fn get_node_info(&self) -> crate::wallet::Result<NodeInfoWrapper> {
-        let node_info_wrapper = self.client().get_info().await?;
-
-        Ok(node_info_wrapper)
     }
 
     /// Update the authentication for a node.

--- a/sdk/tests/wallet/message_interface.rs
+++ b/sdk/tests/wallet/message_interface.rs
@@ -360,7 +360,7 @@ async fn address_conversion_methods() -> Result<()> {
     let response = wallet_handle
         .send_message(Message::HexToBech32 {
             hex: hex_address.into(),
-            bech32_hrp: None,
+            bech32_hrp: Some(Hrp::from_str_unchecked("rms")),
         })
         .await;
 


### PR DESCRIPTION
# Description of change

Remove get_node_info from wallet since it can be called from the client
Kept it in the message interface and old bindings, but when they get removed, we don't need to touch anything else to have it removed everywhere

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-sdk/issues/556

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
