### PR TITLE
fix: default number of workers for  `Miner` to `num_cpu::get()`

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dto type conversion to represented type now always takes owned data;
 - Rename `WalletOptions::build_manager` to `build`;
 - `PeerDto` renamed to `PeerResponse`, `ReceiptDto` to `ReceiptResponse`, `LedgerInclusionStateDto` to `LedgerInclusionState`, `HeartbeatDto` to `Heartbeat`, `MetricsDto` tp `Metrics`, `GossipDto` to `Gossip`, `RelationDto` to `Relation`;
+- Default number of workers for nonce `Miner` changed from `1` to `num_cpu::get()`;
 
 ### Removed
 

--- a/sdk/src/pow/miner.rs
+++ b/sdk/src/pow/miner.rs
@@ -25,8 +25,6 @@ use crypto::{
 
 use crate::pow::{score::count_trailing_zeros, LN_3};
 
-const DEFAULT_NUM_WORKERS: usize = 1;
-
 /// A type to cancel a [`Miner`] to abort operations.
 #[derive(Default, Clone)]
 pub struct MinerCancel(Arc<AtomicBool>);
@@ -82,7 +80,7 @@ impl MinerBuilder {
     /// Builds the [`Miner`].
     pub fn finish(self) -> Miner {
         Miner {
-            num_workers: self.num_workers.unwrap_or(DEFAULT_NUM_WORKERS),
+            num_workers: self.num_workers.unwrap_or(num_cpus::get()),
             cancel: self.cancel.unwrap_or_else(MinerCancel::new),
         }
     }

--- a/sdk/src/pow/miner.rs
+++ b/sdk/src/pow/miner.rs
@@ -80,7 +80,7 @@ impl MinerBuilder {
     /// Builds the [`Miner`].
     pub fn finish(self) -> Miner {
         Miner {
-            num_workers: self.num_workers.unwrap_or(num_cpus::get()),
+            num_workers: self.num_workers.unwrap_or_else(num_cpus::get),
             cancel: self.cancel.unwrap_or_else(MinerCancel::new),
         }
     }


### PR DESCRIPTION
# Description of change

Default number of workers for nonce `Miner` changed from `1` to `num_cpu::get()`

## Links to any relevant issues

closes #516 


## Type of change


Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
