### PR TITLE
docs:  update `wallet init` command line options

### DIFF
--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -86,7 +86,7 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 | Name                           | Description                                      | Default                             | Environment Variable | Example                   |
 | ------------------------------ | ------------------------------------------------ |------------------------------------ |--------------------- | ------------------------- |
-| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics   	| ✘                                   | ✘                    | my_mnemonic.txt           |
+| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics     | ✘                                   | ✘                    | my_mnemonic.txt           |
 | `--node-url` (`-n`)            | Sets the node to connect to                      | https://api.testnet.shimmer.network | `NODE_URL`           | http://localhost:14265    |
 | `--coin-type` (`-c`)           | Sets the coin type associated with the wallet    | 4219 (=Shimmer)                     | ✘                    | 4218(=IOTA)               |
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -20,6 +20,7 @@ You can run `./wallet --help` to print all available CLI commands, arguments, an
 ### `./wallet`
 
 Starts the wallet without a specified account:
+
 - If the wallet has only one account, it will be used;
 - If the wallet has more than one account, a selector will be shown to decide which account to use.
 
@@ -56,6 +57,7 @@ Creates a stronghold backup file.
 #### Example
 
 Create a stronghold backup file.
+
 ```sh
 ./wallet backup backup.stronghold
 ```
@@ -67,6 +69,7 @@ Changes the stronghold password.
 #### Example
 
 Change the stronghold password.
+
 ```sh
 ./wallet change-password
 ```
@@ -81,32 +84,36 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 #### Options
 
-| Name                 | Description                                    | Default                             | Environment Variable | Example                 |
-| -------------------- | ---------------------------------------------- |------------------------------------ |----------------------| ----------------------- |
-| `--mnemonic` (`-m`)  | Initialises a wallet from an existing mnemonic | ✘                                   | ✘                    |"aunt middle impose ..." |
-| `--node-url` (`-n`)  | Sets the node to connect to                    | https://api.testnet.shimmer.network | `NODE_URL`           | http://localhost:14265  |
-| `--coin-type` (`-c`) | Sets the coin type associated with the wallet  | 4219 (=Shimmer)                     | ✘                    | 4218(=IOTA)             |
+| Name                       | Description                                            | Default                              | Environment Variable | Example                   |
+| ------------------------------ | ------------------------------------------------------ |-------------------------------------- |----------------------| ------------------------- |
+| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics      | ✘                                    | ✘                    | my_mnemonic.txt   |
+| `--node-url` (`-n`)        | Sets the node to connect to                        | <https://api.testnet.shimmer.network> | `NODE_URL`           | <http://localhost:14265>  |
+| `--coin-type` (`-c`)       | Sets the coin type associated with the wallet      | 4219 (=Shimmer)                      | ✘                    | 4218(=IOTA)               |
 
 #### Examples
 
 Initialize the wallet with a randomly generated mnemonic and the default node.
+
 ```sh
 ./wallet init
 ```
 
 Initialize the wallet with a given mnemonic and the default node.
 DO NOT USE THIS MNEMONIC.
+
 ```sh
 ./wallet init --mnemonic "aunt middle impose faith ramp kid olive good practice motor grab ready group episode oven matrix silver rhythm avocado assume humble tiger shiver hurt"
 ```
 
 Initialize the wallet with a randomly generated mnemonic and a given node.
+
 ```sh
 ./wallet init --node http://localhost:14265
 ```
 
 Initialize the wallet with a given coin type.
 See [SLIP-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) for all registered coin types.
+
 ```sh
 ./wallet init --coin-type 4219
 ```
@@ -124,11 +131,13 @@ Migrates a stronghold snapshot from v2 to v3.
 #### Example
 
 Migrate a stronghold snapshot from v2 to v3 with the default path: "./stardust-cli-wallet.stronghold".
+
 ```sh
 ./wallet migrate-stronghold-snapshot-v2-to-v3
 ```
 
 Migrate a stronghold snapshot from v2 to v3 with a custom path.
+
 ```sh
 ./wallet migrate-stronghold-snapshot-v2-to-v3 some-other-path.stronghold
 ```
@@ -140,6 +149,7 @@ Generates a new random mnemonic.
 #### Example
 
 Generate a new random mnemonic.
+
 ```sh
 ./wallet mnemonic
 ```
@@ -159,11 +169,13 @@ The wallet needs to be initialised (`init` command).
 #### Examples
 
 Create a new account with the account index as alias.
+
 ```sh
 ./wallet new
 ```
 
 Create a new account with a provided alias.
+
 ```sh
 ./wallet new main
 ```
@@ -181,6 +193,7 @@ Restores accounts from a stronghold backup file.
 #### Example
 
 Restore accounts from a stronghold backup file.
+
 ```sh
 ./wallet restore backup.stronghold
 ```
@@ -195,7 +208,7 @@ The new node URL is persisted to the storage and all future requests will use it
 
 | Name  | Optional  | Example                |
 | ----- | --------- | ---------------------- |
-| `url` | ✘         | http://localhost:14265 |
+| `url` | ✘         | <http://localhost:14265> |
 
 #### Example
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -84,11 +84,11 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 #### Options
 
-| Name                       | Description                                            | Default                              | Environment Variable | Example                   |
-| ------------------------------ | ------------------------------------------------------ |-------------------------------------- |----------------------| ------------------------- |
-| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics      | ✘                                    | ✘                    | my_mnemonic.txt   |
-| `--node-url` (`-n`)        | Sets the node to connect to                        | <https://api.testnet.shimmer.network> | `NODE_URL`           | <http://localhost:14265>  |
-| `--coin-type` (`-c`)       | Sets the coin type associated with the wallet      | 4219 (=Shimmer)                      | ✘                    | 4218(=IOTA)               |
+| Name                           | Description                                      | Default                               | Environment Variable | Example                   |
+| ------------------------------ | ------------------------------------------------ |-------------------------------------- |--------------------- | ------------------------- |
+| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics     | ✘                                     | ✘                    | my_mnemonic.txt           |
+| `--node-url` (`-n`)            | Sets the node to connect to                      | <https://api.testnet.shimmer.network> | `NODE_URL`           | <http://localhost:14265>  |
+| `--coin-type` (`-c`)           | Sets the coin type associated with the wallet    | 4219 (=Shimmer)                       | ✘                    | 4218(=IOTA)               |
 
 #### Examples
 
@@ -98,11 +98,10 @@ Initialize the wallet with a randomly generated mnemonic and the default node.
 ./wallet init
 ```
 
-Initialize the wallet with a given mnemonic and the default node.
-DO NOT USE THIS MNEMONIC.
+Initialize the wallet with the default node and a file containing mnemonic.
 
 ```sh
-./wallet init --mnemonic "aunt middle impose faith ramp kid olive good practice motor grab ready group episode oven matrix silver rhythm avocado assume humble tiger shiver hurt"
+./wallet init --mnemonic my_mnemonic.txt
 ```
 
 Initialize the wallet with a randomly generated mnemonic and a given node.

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -84,11 +84,11 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 #### Options
 
-| Name                           | Description                                      | Default                               | Environment Variable | Example                   |
-| ------------------------------ | ------------------------------------------------ |-------------------------------------- |--------------------- | ------------------------- |
-| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics     | ✘                                     | ✘                    | my_mnemonic.txt           |
-| `--node-url` (`-n`)            | Sets the node to connect to                      | <https://api.testnet.shimmer.network> | `NODE_URL`           | <http://localhost:14265>  |
-| `--coin-type` (`-c`)           | Sets the coin type associated with the wallet    | 4219 (=Shimmer)                       | ✘                    | 4218(=IOTA)               |
+| Name                           | Description                                      | Default                             | Environment Variable | Example                   |
+| ------------------------------ | ------------------------------------------------ |------------------------------------ |--------------------- | ------------------------- |
+| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics     | ✘                                   | ✘                    | my_mnemonic.txt           |
+| `--node-url` (`-n`)            | Sets the node to connect to                      | https://api.testnet.shimmer.network | `NODE_URL`           | http://localhost:14265    |
+| `--coin-type` (`-c`)           | Sets the coin type associated with the wallet    | 4219 (=Shimmer)                     | ✘                    | 4218(=IOTA)               |
 
 #### Examples
 
@@ -207,7 +207,7 @@ The new node URL is persisted to the storage and all future requests will use it
 
 | Name  | Optional  | Example                |
 | ----- | --------- | ---------------------- |
-| `url` | ✘         | <http://localhost:14265> |
+| `url` | ✘         | http://localhost:14265 |
 
 #### Example
 

--- a/documentation/cli/docs/02_wallet.md
+++ b/documentation/cli/docs/02_wallet.md
@@ -86,7 +86,7 @@ When just initialised, the wallet has no account yet, use the `new` command to c
 
 | Name                           | Description                                      | Default                             | Environment Variable | Example                   |
 | ------------------------------ | ------------------------------------------------ |------------------------------------ |--------------------- | ------------------------- |
-| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics     | ✘                                   | ✘                    | my_mnemonic.txt           |
+| `--mnemonic-file-path` (`-m`)  | Sets the path to a file containing mnemonics   	| ✘                                   | ✘                    | my_mnemonic.txt           |
 | `--node-url` (`-n`)            | Sets the node to connect to                      | https://api.testnet.shimmer.network | `NODE_URL`           | http://localhost:14265    |
 | `--coin-type` (`-c`)           | Sets the coin type associated with the wallet    | 4219 (=Shimmer)                     | ✘                    | 4218(=IOTA)               |
 
@@ -98,7 +98,7 @@ Initialize the wallet with a randomly generated mnemonic and the default node.
 ./wallet init
 ```
 
-Initialize the wallet with the default node and a file containing mnemonic.
+Initialize the wallet with the default node and a file containing a mnemonic.
 
 ```sh
 ./wallet init --mnemonic my_mnemonic.txt


### PR DESCRIPTION
# Description of change

Updates options for `wallet init`
Current usage:

```
Usage: wallet init [OPTIONS]

Options:
  -m, --mnemonic-file-path <PATH>  Set the path to a file containing mnemonics. If empty, a mnemonic has to be entered or will be randomly generated
  -n, --node-url <URL>             Set the node to connect to with this wallet [env: NODE_URL=] [default: https://api.testnet.shimmer.network]
  -c, --coin-type <COIN_TYPE>      Coin type, SHIMMER_COIN_TYPE (4219) if not provided [default: 4219]
  -h, --help                       Print help
  -V, --version                    Print version
```


## Links to any relevant issues

#389 

## Type of change

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
