### PR TITLE
Rename signEvm to signSecp256k1Ecdsa

### DIFF
--- a/.changes/sign-evm.md
+++ b/.changes/sign-evm.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Add `Account::signEvm` method. Add `EvmSignature` to types.

--- a/.changes/sign-evm.md
+++ b/.changes/sign-evm.md
@@ -1,5 +1,0 @@
----
-"wallet-nodejs-binding": patch
----
-
-Add `Account::signEvm` method. Add `EvmSignature` to types.

--- a/.changes/sign-secp256k1_ecdsa.md
+++ b/.changes/sign-secp256k1_ecdsa.md
@@ -2,4 +2,4 @@
 "wallet-nodejs-binding": patch
 ---
 
-Add `Account::signSecp256k1Ecdsa` method. Add `Secp256k1EcdsaSignature` to types.
+Rename `Account::signEvm` to `signSecp256k1Ecdsa` and `EvmSignature` to `Secp256k1EcdsaSignature`.

--- a/.changes/sign-secp256k1_ecdsa.md
+++ b/.changes/sign-secp256k1_ecdsa.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Add `Account::signSecp256k1Ecdsa` method. Add `Secp256k1EcdsaSignature` to types.

--- a/bindings/core/src/method/secret_manager.rs
+++ b/bindings/core/src/method/secret_manager.rs
@@ -13,12 +13,12 @@ use crate::OmittedDebug;
 #[derivative(Debug)]
 #[serde(tag = "name", content = "data", rename_all = "camelCase")]
 pub enum SecretManagerMethod {
-    /// Generate addresses.
+    /// Generate Ed25519 addresses.
     GenerateEd25519Addresses {
         /// Addresses generation options
         options: GetAddressesOptions,
     },
-    /// Generate EVM addresses.
+    /// Generate Evm addresses.
     GenerateEvmAddresses { options: GetAddressesOptions },
     /// Get the ledger status
     /// Expected response: [`LedgerNanoStatus`](crate::Response::LedgerNanoStatus)
@@ -40,8 +40,8 @@ pub enum SecretManagerMethod {
         /// Chain to sign the essence hash with
         chain: Vec<u32>,
     },
-    /// Signs a message with an Evm private key.
-    SignEvm {
+    /// Signs a message with an Secp256k1Ecdsa private key.
+    SignSecp256k1Ecdsa {
         /// The message to sign, hex encoded String
         message: String,
         /// Chain to sign the message with

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -64,10 +64,12 @@ pub(crate) async fn call_secret_manager_method_internal(
                 .await?;
             Response::Ed25519Signature(Ed25519SignatureDto::from(&signature))
         }
-        SecretManagerMethod::SignEvm { message, chain } => {
+        SecretManagerMethod::SignSecp256k1Ecdsa { message, chain } => {
             let msg: Vec<u8> = prefix_hex::decode(message)?;
-            let (public_key, signature) = secret_manager.sign_evm(&msg, &Chain::from_u32(chain)).await?;
-            Response::EvmSignature {
+            let (public_key, signature) = secret_manager
+                .sign_secp256k1_ecdsa(&msg, &Chain::from_u32(chain))
+                .await?;
+            Response::Secp256k1EcdsaSignature {
                 public_key: prefix_hex::encode(public_key.to_bytes()),
                 signature: prefix_hex::encode(signature.to_bytes()),
             }

--- a/bindings/core/src/response.rs
+++ b/bindings/core/src/response.rs
@@ -30,7 +30,8 @@ use iota_sdk::{
             },
             payload::{
                 dto::{MilestonePayloadDto, PayloadDto},
-                transaction::TransactionId, milestone::MilestoneId,
+                milestone::MilestoneId,
+                transaction::TransactionId,
             },
             protocol::dto::ProtocolParametersDto,
             signature::dto::Ed25519SignatureDto,
@@ -101,9 +102,9 @@ pub enum Response {
     /// - [`SignEd25519`](crate::method::SecretManagerMethod::SignEd25519)
     Ed25519Signature(Ed25519SignatureDto),
     /// Response for:
-    /// - [`SignEvm`](crate::method::SecretManagerMethod::SignEvm)
+    /// - [`SignSecp256k1Ecdsa`](crate::method::SecretManagerMethod::SignSecp256k1Ecdsa)
     #[serde(rename_all = "camelCase")]
-    EvmSignature { public_key: String, signature: String },
+    Secp256k1EcdsaSignature { public_key: String, signature: String },
     /// Response for:
     /// - [`UnhealthyNodes`](crate::method::ClientMethod::UnhealthyNodes)
     #[cfg(not(target_family = "wasm"))]

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Account::getOutputsWithAdditionalUnlockConditions` renamed to `claimableOutputs`;
+- Rename `Account::signEvm` to `signSecp256k1Ecdsa` and `EvmSignature` to `Secp256k1EcdsaSignature`;
 
 ## 1.0.0-rc.0 - 2023-06-15
 

--- a/bindings/nodejs/examples/how_tos/sign_secp256k1_ecdsa/sign-secp256k1_ecdsa.ts
+++ b/bindings/nodejs/examples/how_tos/sign_secp256k1_ecdsa/sign-secp256k1_ecdsa.ts
@@ -11,9 +11,9 @@ import {
 } from '@iota/sdk';
 require('dotenv').config({ path: '.env' });
 
-// In this example we will sign with secp256k1.
+// In this example we will sign with secp256k1_ecdsa.
 // Run with command:
-// yarn run-example ./how_tos/sign_evm/sign-evm.ts
+// yarn run-example ./how_tos/sign_secp256k1_ecdsa/sign-secp256k1_ecdsa.ts
 
 const FOUNDRY_METADATA = {
     standard: 'IRC30',
@@ -42,7 +42,7 @@ async function run() {
         const secretManager = new SecretManager({
             stronghold: {
                 password: process.env.STRONGHOLD_PASSWORD,
-                snapshotPath: 'sign_evm.stronghold',
+                snapshotPath: 'sign_secp256k1_ecdsa.stronghold',
             },
         });
 
@@ -61,10 +61,13 @@ async function run() {
             ADDRESS_INDEX,
         ];
         const message = utf8ToHex(JSON.stringify(FOUNDRY_METADATA));
-        const evmSignature = await secretManager.signEvm(message, bip32Chain);
+        const secp256k1EcdsaSignature = await secretManager.signSecp256k1Ecdsa(
+            message,
+            bip32Chain,
+        );
 
-        console.log(`Public key: ${evmSignature.publicKey}`);
-        console.log(`Signature: ${evmSignature.signature}`);
+        console.log(`Public key: ${secp256k1EcdsaSignature.publicKey}`);
+        console.log(`Signature: ${secp256k1EcdsaSignature.signature}`);
     } catch (error) {
         console.error('Error: ', error);
     }

--- a/bindings/nodejs/lib/secret_manager/secret-manager.ts
+++ b/bindings/nodejs/lib/secret_manager/secret-manager.ts
@@ -8,7 +8,10 @@ import type {
     LedgerNanoStatus,
     IBip32Chain,
 } from '../types/client';
-import { EvmSignature, SecretManagerType } from '../types/secret_manager';
+import {
+    Secp256k1EcdsaSignature,
+    SecretManagerType,
+} from '../types/secret_manager';
 import { Ed25519Signature, HexEncodedString, Payload, Unlock } from '../types';
 
 /** The SecretManager to interact with nodes. */
@@ -113,14 +116,14 @@ export class SecretManager {
     }
 
     /**
-     * Signs a message with an Evm private key.
+     * Signs a message with an Secp256k1Ecdsa private key.
      */
-    async signEvm(
+    async signSecp256k1Ecdsa(
         message: HexEncodedString,
         chain: IBip32Chain,
-    ): Promise<EvmSignature> {
+    ): Promise<Secp256k1EcdsaSignature> {
         const response = await this.methodHandler.callMethod({
-            name: 'signEvm',
+            name: 'signSecp256k1Ecdsa',
             data: {
                 message,
                 chain,

--- a/bindings/nodejs/lib/types/secret_manager/bridge/index.ts
+++ b/bindings/nodejs/lib/types/secret_manager/bridge/index.ts
@@ -6,7 +6,7 @@ import type {
     __StoreMnemonicMethod__,
     __SignatureUnlockMethod__,
     __SignEd25519Method__,
-    __SignEvmMethod__,
+    __SignSecp256k1EcdsaMethod__,
 } from './secret-manager';
 
 export type __SecretManagerMethods__ =
@@ -17,4 +17,4 @@ export type __SecretManagerMethods__ =
     | __SignatureUnlockMethod__
     | __StoreMnemonicMethod__
     | __SignEd25519Method__
-    | __SignEvmMethod__;
+    | __SignSecp256k1EcdsaMethod__;

--- a/bindings/nodejs/lib/types/secret_manager/bridge/secret-manager.ts
+++ b/bindings/nodejs/lib/types/secret_manager/bridge/secret-manager.ts
@@ -52,8 +52,8 @@ export interface __SignEd25519Method__ {
     };
 }
 
-export interface __SignEvmMethod__ {
-    name: 'signEvm';
+export interface __SignSecp256k1EcdsaMethod__ {
+    name: 'signSecp256k1Ecdsa';
     data: {
         message: HexEncodedString;
         chain: IBip32Chain;

--- a/bindings/nodejs/lib/types/secret_manager/secret-manager.ts
+++ b/bindings/nodejs/lib/types/secret_manager/secret-manager.ts
@@ -37,7 +37,7 @@ export type SecretManagerType =
     | StrongholdSecretManager
     | PlaceholderSecretManager;
 
-export interface EvmSignature {
+export interface Secp256k1EcdsaSignature {
     /**
      * The public key.
      */

--- a/bindings/python/examples/how_tos/sign_evm/sign_evm.py
+++ b/bindings/python/examples/how_tos/sign_evm/sign_evm.py
@@ -18,7 +18,7 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")
 
 secret_manager = SecretManager(StrongholdSecretManager(
-    "sign_evm.stronghold", os.environ['STRONGHOLD_PASSWORD']))
+    "sign_secp256k1_ecdsa.stronghold", os.environ['STRONGHOLD_PASSWORD']))
 
 # Store the mnemonic in the Stronghold snapshot, this needs to be done only the first time.
 # The mnemonic can't be retrieved from the Stronghold file, so make a backup in a secure place!
@@ -34,6 +34,6 @@ bip32_chain = [
 ]
 
 message = utf8_to_hex(FOUNDRY_METADATA)
-evm_signature = secret_manager.sign_evm(message, bip32_chain)
-print(f'Public key: {evm_signature["publicKey"]}')
-print(f'Signature: {evm_signature["signature"]}')
+secp256k1_ecdsa_signature = secret_manager.sign_secp256k1_ecdsa(message, bip32_chain)
+print(f'Public key: {secp256k1_ecdsa_signature["publicKey"]}')
+print(f'Signature: {secp256k1_ecdsa_signature["signature"]}')

--- a/bindings/python/iota_sdk/secret_manager/secret_manager.py
+++ b/bindings/python/iota_sdk/secret_manager/secret_manager.py
@@ -224,10 +224,10 @@ class SecretManager():
             'chain': chain,
         })
 
-    def sign_evm(self, message: HexStr, chain: List[int]):
-        """Signs a message with an Evm private key.
+    def sign_secp256k1_ecdsa(self, message: HexStr, chain: List[int]):
+        """Signs a message with an Secp256k1Ecdsa private key.
         """
-        return self._call_method('signEvm', {
+        return self._call_method('signSecp256k1Ecdsa', {
             'message': message,
             'chain': chain,
         })

--- a/documentation/sdk/docs/references/python/iota_sdk/secret_manager/secret_manager.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/secret_manager/secret_manager.md
@@ -185,4 +185,3 @@ def signature_unlock(transaction_essence_hash: HexStr, chain: List[int])
 ```
 
 Sign a transaction essence hash.
-

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.5.0 - 2023-MM-DD
+
+### Changed
+
+- `SecretManage::sign_evm` renamed to `sign_secp256k1_ecdsa`;
+
 ## 0.4.0 - 2023-06-14
 
 ### Added
@@ -35,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple prepare methods returning `PreparedTransactionData`: `prepare_consolidate_outputs`, `prepare_vote`, `prepare_stop_participating`, `prepare_increase_voting_power`, `prepare_decrease_voting_power`, `prepare_decrease_native_token_supply` and `prepare_burn`;
 - Multiple prepare methods returning `PreparedMintTokenTransaction`: `prepare_mint_native_token` and `prepare_increase_native_token_supply`;
 - Stronghold snapshot migration from v2 to v3;
-- `SecretManage::sign_secp256k1_ecdsa`;
+- `SecretManage::sign_evm`;
 - `Account::addresses_balance` method accepting addresses to get balance for;
 - `Wallet::get_secret_manager` method;
 - `Password` type which is `Zeroize` and `ZeroizeOnDrop`;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.5.0 - YYYY-MM-DD
+
+### Changed
+
+- Rename `Account::signEvm` to `signSecp256k1Ecdsa` and `EvmSignature` to `Secp256k1EcdsaSignature`;
+
 ## 0.4.0 - 2023-06-14
 
 ### Added
@@ -35,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple prepare methods returning `PreparedTransactionData`: `prepare_consolidate_outputs`, `prepare_vote`, `prepare_stop_participating`, `prepare_increase_voting_power`, `prepare_decrease_voting_power`, `prepare_decrease_native_token_supply` and `prepare_burn`;
 - Multiple prepare methods returning `PreparedMintTokenTransaction`: `prepare_mint_native_token` and `prepare_increase_native_token_supply`;
 - Stronghold snapshot migration from v2 to v3;
-- `SecretManage::sign_secp256k1_ecdsa`;
+- `SecretManage::sign_evm`;
 - `Account::addresses_balance` method accepting addresses to get balance for;
 - `Wallet::get_secret_manager` method;
 - `Password` type which is `Zeroize` and `ZeroizeOnDrop`;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,12 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.5.0 - 2023-MM-DD
-
-### Changed
-
-- `SecretManage::sign_evm` renamed to `sign_secp256k1_ecdsa`;
-
 ## 0.4.0 - 2023-06-14
 
 ### Added
@@ -41,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple prepare methods returning `PreparedTransactionData`: `prepare_consolidate_outputs`, `prepare_vote`, `prepare_stop_participating`, `prepare_increase_voting_power`, `prepare_decrease_voting_power`, `prepare_decrease_native_token_supply` and `prepare_burn`;
 - Multiple prepare methods returning `PreparedMintTokenTransaction`: `prepare_mint_native_token` and `prepare_increase_native_token_supply`;
 - Stronghold snapshot migration from v2 to v3;
-- `SecretManage::sign_evm`;
+- `SecretManage::sign_secp256k1_ecdsa`;
 - `Account::addresses_balance` method accepting addresses to get balance for;
 - `Wallet::get_secret_manager` method;
 - `Password` type which is `Zeroize` and `ZeroizeOnDrop`;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,12 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.5.0 - YYYY-MM-DD
-
-### Changed
-
-- Rename `Account::signEvm` to `signSecp256k1Ecdsa` and `EvmSignature` to `Secp256k1EcdsaSignature`;
-
 ## 0.4.0 - 2023-06-14
 
 ### Added

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple prepare methods returning `PreparedTransactionData`: `prepare_consolidate_outputs`, `prepare_vote`, `prepare_stop_participating`, `prepare_increase_voting_power`, `prepare_decrease_voting_power`, `prepare_decrease_native_token_supply` and `prepare_burn`;
 - Multiple prepare methods returning `PreparedMintTokenTransaction`: `prepare_mint_native_token` and `prepare_increase_native_token_supply`;
 - Stronghold snapshot migration from v2 to v3;
-- `SecretManage::sign_evm`;
+- `SecretManage::sign_secp256k1_ecdsa`;
 - `Account::addresses_balance` method accepting addresses to get balance for;
 - `Wallet::get_secret_manager` method;
 - `Password` type which is `Zeroize` and `ZeroizeOnDrop`;

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -183,7 +183,7 @@ impl SecretManage for LedgerSecretManager {
         Err(Error::UnsupportedOperation.into())
     }
 
-    async fn sign_evm(
+    async fn sign_secp256k1_ecdsa(
         &self,
         _msg: &[u8],
         _chain: &Chain,

--- a/sdk/src/client/secret/mnemonic.rs
+++ b/sdk/src/client/secret/mnemonic.rs
@@ -107,12 +107,12 @@ impl SecretManage for MnemonicSecretManager {
         Ok(Ed25519Signature::new(public_key, signature))
     }
 
-    async fn sign_evm(
+    async fn sign_secp256k1_ecdsa(
         &self,
         msg: &[u8],
         chain: &Chain,
     ) -> Result<(secp256k1_ecdsa::PublicKey, secp256k1_ecdsa::Signature), Self::Error> {
-        // Get the private and public key for this Evm address
+        // Get the private and public key for this secp256k1_ecdsa key
         let private_key = self.0.derive::<secp256k1_ecdsa::SecretKey>(chain)?.secret_key();
         let public_key = private_key.public_key();
         let signature = private_key.sign(msg);

--- a/sdk/src/client/secret/mod.rs
+++ b/sdk/src/client/secret/mod.rs
@@ -85,7 +85,7 @@ pub trait SecretManage: Send + Sync {
     async fn sign_ed25519(&self, msg: &[u8], chain: &Chain) -> Result<Ed25519Signature, Self::Error>;
 
     /// Signs msg using the given [`Chain`] using Secp256k1.
-    async fn sign_evm(
+    async fn sign_secp256k1_ecdsa(
         &self,
         msg: &[u8],
         chain: &Chain,
@@ -316,17 +316,17 @@ impl SecretManage for SecretManager {
         }
     }
 
-    async fn sign_evm(
+    async fn sign_secp256k1_ecdsa(
         &self,
         msg: &[u8],
         chain: &Chain,
     ) -> Result<(secp256k1_ecdsa::PublicKey, secp256k1_ecdsa::Signature), Self::Error> {
         match self {
             #[cfg(feature = "stronghold")]
-            Self::Stronghold(secret_manager) => Ok(secret_manager.sign_evm(msg, chain).await?),
+            Self::Stronghold(secret_manager) => Ok(secret_manager.sign_secp256k1_ecdsa(msg, chain).await?),
             #[cfg(feature = "ledger_nano")]
-            Self::LedgerNano(secret_manager) => Ok(secret_manager.sign_evm(msg, chain).await?),
-            Self::Mnemonic(secret_manager) => secret_manager.sign_evm(msg, chain).await,
+            Self::LedgerNano(secret_manager) => Ok(secret_manager.sign_secp256k1_ecdsa(msg, chain).await?),
+            Self::Mnemonic(secret_manager) => secret_manager.sign_secp256k1_ecdsa(msg, chain).await,
             Self::Placeholder(_) => Err(Error::PlaceholderSecretManager),
         }
     }

--- a/sdk/src/client/stronghold/secret.rs
+++ b/sdk/src/client/stronghold/secret.rs
@@ -204,7 +204,7 @@ impl SecretManage for StrongholdAdapter {
         Ok(Ed25519Signature::new(public_key, signature))
     }
 
-    async fn sign_evm(
+    async fn sign_secp256k1_ecdsa(
         &self,
         msg: &[u8],
         chain: &Chain,

--- a/sdk/src/wallet/bindings/nodejs/lib/Account.ts
+++ b/sdk/src/wallet/bindings/nodejs/lib/Account.ts
@@ -33,7 +33,7 @@ import type {
     ParticipationEventRegistrationOptions,
     ParticipationEventMap,
     GenerateAddressesOptions,
-    EvmSignature,
+    Secp256k1EcdsaSignature,
 } from '../types';
 import type { SignedTransactionEssence } from '../types/signedTransactionEssence';
 import type {
@@ -397,14 +397,14 @@ export class Account {
     /**
      * Signs a message with an Evm private key.
      */
-    async signEvm(
+    async signSecp256k1Ecdsa(
         message: HexEncodedString,
         chain: number[],
-    ): Promise<EvmSignature> {
+    ): Promise<Secp256k1EcdsaSignature> {
         const response = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'signEvm',
+                name: 'signSecp256k1Ecdsa',
                 data: {
                     message,
                     chain,

--- a/sdk/src/wallet/bindings/nodejs/lib/Account.ts
+++ b/sdk/src/wallet/bindings/nodejs/lib/Account.ts
@@ -395,7 +395,7 @@ export class Account {
     }
 
     /**
-     * Signs a message with an Evm private key.
+     * Signs a message with a Secp256k1Ecdsa private key.
      */
     async signSecp256k1Ecdsa(
         message: HexEncodedString,

--- a/sdk/src/wallet/bindings/nodejs/types/bridge/account.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/bridge/account.ts
@@ -141,8 +141,8 @@ export type __GenerateEvmAddressesMethod__ = {
     };
 };
 
-export type __SignEvmMethod__ = {
-    name: 'signEvm';
+export type __SignSecp256k1EcdsaMethod__ = {
+    name: 'signSecp256k1Ecdsa';
     data: {
         message: HexEncodedString;
         chain: number[];

--- a/sdk/src/wallet/bindings/nodejs/types/bridge/index.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/bridge/index.ts
@@ -15,7 +15,7 @@ import type {
     __DeregisterParticipationEventMethod__,
     __GenerateEd25519AddressesMethod__,
     __GenerateEvmAddressesMethod__,
-    __SignEvmMethod__,
+    __SignSecp256k1EcdsaMethod__,
     __GetBalanceMethod__,
     __GetOutputMethod__,
     __GetFoundryOutputMethod__,
@@ -103,7 +103,7 @@ export type __AccountMethod__ =
     | __DestroyFoundryMethod__
     | __GenerateEd25519AddressesMethod__
     | __GenerateEvmAddressesMethod__
-    | __SignEvmMethod__
+    | __SignSecp256k1EcdsaMethod__
     | __GetBalanceMethod__
     | __GetOutputMethod__
     | __GetIncomingTransactionMethod__

--- a/sdk/src/wallet/bindings/nodejs/types/secretManager.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/secretManager.ts
@@ -57,7 +57,7 @@ export type SecretManager =
     | StrongholdSecretManager
     | PlaceholderSecretManager;
 
-export interface EvmSignature {
+export interface Secp256k1EcdsaSignature {
     /**
      * The public key.
      */

--- a/sdk/src/wallet/message_interface/account_method.rs
+++ b/sdk/src/wallet/message_interface/account_method.rs
@@ -167,8 +167,8 @@ pub enum AccountMethod {
     /// Expected response:
     /// [`GeneratedEvmAddresses`](crate::wallet::message_interface::Response::GeneratedEvmAddresses)
     GenerateEvmAddresses { options: GetAddressesOptions },
-    /// Signs a message with an Evm private key.
-    SignEvm {
+    /// Signs a message with an Secp256k1Ecdsa private key.
+    SignSecp256k1Ecdsa {
         /// The message to sign, hex encoded String
         message: String,
         /// Chain to sign the message with

--- a/sdk/src/wallet/message_interface/message_handler.rs
+++ b/sdk/src/wallet/message_interface/message_handler.rs
@@ -572,16 +572,16 @@ impl WalletMessageHandler {
                     .await?;
                 Ok(Response::GeneratedEvmAddresses(addresses))
             }
-            AccountMethod::SignEvm { message, chain } => {
+            AccountMethod::SignSecp256k1Ecdsa { message, chain } => {
                 let msg: Vec<u8> = prefix_hex::decode(message).map_err(crate::client::Error::from)?;
                 let (public_key, signature) = account
                     .wallet
                     .secret_manager
                     .read()
                     .await
-                    .sign_evm(&msg, &Chain::from_u32(chain))
+                    .sign_secp256k1_ecdsa(&msg, &Chain::from_u32(chain))
                     .await?;
-                Ok(Response::EvmSignature {
+                Ok(Response::Secp256k1EcdsaSignature {
                     public_key: prefix_hex::encode(public_key.to_bytes()),
                     signature: prefix_hex::encode(signature.to_bytes()),
                 })

--- a/sdk/src/wallet/message_interface/response.rs
+++ b/sdk/src/wallet/message_interface/response.rs
@@ -100,9 +100,9 @@ pub enum Response {
     /// [`GenerateEvmAddresses`](crate::wallet::message_interface::AccountMethod::GenerateEvmAddresses)
     GeneratedEvmAddresses(Vec<String>),
     /// Response for:
-    /// - [`SignEvm`](crate::method::SecretManagerMethod::SignEvm)
+    /// - [`SignSecp256k1Ecdsa`](crate::method::SecretManagerMethod::SignSecp256k1Ecdsa)
     #[serde(rename_all = "camelCase")]
-    EvmSignature { public_key: String, signature: String },
+    Secp256k1EcdsaSignature { public_key: String, signature: String },
     /// Response for
     /// [`GetBalance`](crate::wallet::message_interface::AccountMethod::GetBalance),
     /// [`SyncAccount`](crate::wallet::message_interface::AccountMethod::SyncAccount)
@@ -219,10 +219,10 @@ impl Debug for Response {
             }
             Self::GeneratedEd25519Addresses(addresses) => write!(f, "GeneratedEd25519Addresses({addresses:?})"),
             Self::GeneratedEvmAddresses(addresses) => write!(f, "GeneratedEvmAddresses({addresses:?})"),
-            Self::EvmSignature { public_key, signature } => {
+            Self::Secp256k1EcdsaSignature { public_key, signature } => {
                 write!(
                     f,
-                    "EvmSignature{{ public_key: {public_key:?}, signature: {signature:?} }}"
+                    "Secp256k1EcdsaSignature{{ public_key: {public_key:?}, signature: {signature:?} }}"
                 )
             }
             Self::Balance(balance) => write!(f, "Balance({balance:?})"),


### PR DESCRIPTION
# Description of change

Renames `signEvm` to `signSecp256k1Ecdsa` to better reflect its functionality.

## Links to any relevant issues

- Closes #536

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
