### PR TITLE
fix: change default permissions for mnemonic file

### DIFF
--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -197,8 +197,9 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
 async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error> {
     let mut open_options = OpenOptions::new().create(true).append(true).to_owned();
 
-    #[cfg(unix)]
-    open_options.mode(0o600);
+    if cfg!(unix) {
+        open_options.mode(0o600);
+    }
 
     let mut file = open_options.open(path).await?;
     file.write_all(format!("{mnemonic}\n").as_bytes()).await?;

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -195,7 +195,8 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
 }
 
 async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error> {
-    let mut open_options = OpenOptions::new().create(true).append(true).to_owned();
+    let mut open_options = OpenOptions::new();
+    open_options.create(true).append(true);
 
     #[cfg(unix)]
     open_options.mode(0o600);

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -195,7 +195,12 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
 }
 
 async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error> {
-    let mut file = OpenOptions::new().create(true).append(true).open(path).await?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path)
+        .await?;
     file.write_all(format!("{mnemonic}\n").as_bytes()).await?;
 
     Ok(())

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -195,12 +195,12 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
 }
 
 async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error> {
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .mode(0o600)
-        .open(path)
-        .await?;
+    let mut open_options = OpenOptions::new().create(true).append(true).to_owned();
+
+    #[cfg(unix)]
+    open_options.mode(0o600);
+
+    let mut file = open_options.open(path).await?;
     file.write_all(format!("{mnemonic}\n").as_bytes()).await?;
 
     Ok(())

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -197,9 +197,8 @@ pub async fn import_mnemonic(path: &str) -> Result<String, Error> {
 async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error> {
     let mut open_options = OpenOptions::new().create(true).append(true).to_owned();
 
-    if cfg!(unix) {
-        open_options.mode(0o600);
-    }
+    #[cfg(unix)]
+    open_options.mode(0o600);
 
     let mut file = open_options.open(path).await?;
     file.write_all(format!("{mnemonic}\n").as_bytes()).await?;


### PR DESCRIPTION
# Description of change

The file containing the mnemonic contains sensitive content. According to layered security, default permission should be minimal `(0600)` 

## Links to any relevant issues

Part of #389 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

manually

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
