### PR TITLE
Format Python API reference

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -107,10 +107,16 @@ python3 examples/client/00_get_info.py
 
 ## API Reference
 
-You can generate the Python API reference with the following command from this directory:
+To generate the Python API reference you need to first install the needed dependencies with the following command:
 
 ```bash
-pip install pydoc-markdown && pydoc-markdown
+pip install -r requirements.txt
+```
+
+and afterwards you can generate them with:
+
+```bash
+pydoc-markdown
 ```
 
 ## Learn More

--- a/bindings/python/pydoc-markdown.yml
+++ b/bindings/python/pydoc-markdown.yml
@@ -4,6 +4,7 @@ processors:
   - type: filter
     skip_empty_modules: true
   - type: smart
+  - type: pydoc_markdown_iota.IotaProcessor
   - type: crossref
 renderer:
   type: docusaurus

--- a/bindings/python/pydoc_markdown_iota.py
+++ b/bindings/python/pydoc_markdown_iota.py
@@ -1,0 +1,24 @@
+# Inspired by https://github.com/tqdm/tqdm.github.io/blob/main/pydoc_markdown_tqdm.py as reference
+
+from pydoc_markdown.contrib.processors.pydocmd import PydocmdProcessor
+import re
+from functools import partial
+
+sub = partial(re.sub, flags=re.M)
+
+
+class IotaProcessor(PydocmdProcessor):
+    def _process(self, node):
+        if not getattr(node, "docstring", None):
+            return
+        
+        c = node.docstring.content
+        # join long lines ending in escape (\)
+        c = sub(r"\\\n\s*", "", c)
+        # convert parameter lists to markdown list
+        c = sub(r"^(\w+)\s{1,}(:.*?)$", r"* __\1__*\2*  ", c)
+        # Convert "Parameters" and "Returns" to <h4>
+        c = sub(r"^(.+?)\n[-]{4,}$", r"#### \1\n", c)
+        node.docstring.content = c
+
+        return super()._process(node)

--- a/bindings/python/requirements-dev.txt
+++ b/bindings/python/requirements-dev.txt
@@ -3,3 +3,4 @@ setuptools-rust>=1.5.2
 wheel>=0.38.4
 pyhumps>=3.8.0
 python-dotenv>=1.0.0
+pydoc-markdown>=4.8.0

--- a/documentation/sdk/docs/references/python/iota_sdk/client/client.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/client/client.md
@@ -211,45 +211,6 @@ Returns
 -------
 Output as dict
 
-### generate\_ed25519\_addresses
-
-```python
-def generate_ed25519_addresses(
-        secret_manager,
-        account_index: Optional[int] = None,
-        start: Optional[int] = None,
-        end: Optional[int] = None,
-        internal: Optional[bool] = None,
-        coin_type: Optional[int] = None,
-        bech32_hrp: Optional[str] = None,
-        ledger_nano_prompt: Optional[bool] = None) -> List[str]
-```
-
-Generate addresses.
-
-Parameters
-----------
-secret_manager : Any type of SecretManager.
-    The secret manager to use. Can be (MnemonicSecretManager, SeedSecretManager, StrongholdSecretManager or LedgerNanoSecretManager.
-account_index : int
-    Account index.
-start : int
-    Start index of generated addresses
-end : int
-    End index of generated addresses
-internal : bool
-    Internal addresses
-coin_type : int
-    Coin type. The CoinType enum can be used
-bech32_hrp : string
-    Bech32 human readable part.
-ledger_nano_prompt : bool
-    Display the address on ledger devices.
-
-Returns
--------
-Addresses as array of strings.
-
 ### build\_and\_post\_block
 
 ```python

--- a/documentation/sdk/docs/references/python/iota_sdk/client/client.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/client/client.md
@@ -41,40 +41,40 @@ def __init__(nodes: Optional[str | List[str]] = None,
 
 Initialize the IOTA Client.
 
-Parameters
-----------
-nodes : string or array of string
+#### Parameters
+
+* __nodes__*: string or array of string*  
     A single Node URL or an array of URLs.
-primary_node : string
+* __primary_node__*: string*  
     Node which will be tried first for all requests.
-primary_pow_node : string
+* __primary_pow_node__*: string*  
     Node which will be tried first when using remote PoW, even before the primary_node.
-permanode : string
+* __permanode__*: string*  
     Permanode URL.
-ignore_node_health : bool
+* __ignore_node_health__*: bool*  
     If the node health should be ignored.
-api_timeout : datetime.timedelta
+* __api_timeout__*: datetime.timedelta*  
     Timeout for API requests.
-node_sync_interval : datetime.timedelta
+* __node_sync_interval__*: datetime.timedelta*  
     Interval in which nodes will be checked for their sync status and the [NetworkInfo](crate::NetworkInfo) gets updated.
-remote_pow_timeout : datetime.timedelta
+* __remote_pow_timeout__*: datetime.timedelta*  
     Timeout when sending a block that requires remote proof of work.
-tips_interval : int
+* __tips_interval__*: int*  
     Tips request interval during PoW in seconds.
-quorum : bool
+* __quorum__*: bool*  
     If node quorum is enabled. Will compare the responses from multiple nodes 
     and only returns the response if `quorum_threshold`% of the nodes return the same one.
-min_quorum_size : int
+* __min_quorum_size__*: int*  
     Minimum amount of nodes required for request when quorum is enabled.
-quorum_threshold : int
+* __quorum_threshold__*: int*  
     % of nodes that have to return the same response so it gets accepted.
-user_agent : string
+* __user_agent__*: string*  
     The User-Agent header for requests.
-local_pow : bool
+* __local_pow__*: bool*  
     Local proof of work.
-fallback_to_local_pow : bool
+* __fallback_to_local_pow__*: bool*  
     Fallback to local proof of work if the node doesn&#x27;t support remote PoW.
-pow_worker_count : int
+* __pow_worker_count__*: int*  
     The amount of threads to be used for proof of work.
 
 ### build\_alias\_output
@@ -93,29 +93,29 @@ def build_alias_output(alias_id: HexStr,
 
 Build an AliasOutput.
 
-Parameters
-----------
-alias_id : string
+#### Parameters
+
+* __alias_id__*: string*  
     Hex encoded alias id
-unlock_conditions : array of UnlockCondition
+* __unlock_conditions__*: array of UnlockCondition*  
     The unlock conditions for this output
-amount : int
+* __amount__*: int*  
     Amount of base token
-native_tokens : array of NativeToken
+* __native_tokens__*: array of NativeToken*  
     The native token to add to the output
-state_index : int
+* __state_index__*: int*  
     Index of the state
-state_metadata : string
+* __state_metadata__*: string*  
     Hex encoded state metadata
-foundry_counter : int
+* __foundry_counter__*: int*  
     Counter of foundry outputs created
-features : array of Feature
+* __features__*: array of Feature*  
     Features for this outputs
-immutable_features : array of Feature
+* __immutable_features__*: array of Feature*  
     Immutable features
 
-Returns
--------
+#### Returns
+
 Output as dict
 
 ### build\_basic\_output
@@ -129,19 +129,19 @@ def build_basic_output(unlock_conditions: List[UnlockCondition],
 
 Build a BasicOutput.
 
-Parameters
-----------
-unlock_conditions : array of UnlockCondition
+#### Parameters
+
+* __unlock_conditions__*: array of UnlockCondition*  
     The unlock conditions for this output
-amount : int
+* __amount__*: int*  
     Amount of base token
-native_tokens : array of NativeToken
+* __native_tokens__*: array of NativeToken*  
     The native token to add to the output
-features : array of Feature
+* __features__*: array of Feature*  
     Features for this outputs
 
-Returns
--------
+#### Returns
+
 Output as dict
 
 ### build\_foundry\_output
@@ -158,25 +158,25 @@ def build_foundry_output(serial_number: int,
 
 Build a FoundryOutput.
 
-Parameters
-----------
-serial_number : int
+#### Parameters
+
+* __serial_number__*: int*  
     The serial number of the foundry
-token_scheme : TokenScheme
+* __token_scheme__*: TokenScheme*  
     The Token scheme. Currently only a simple scheme is supported
-unlock_conditions : array of UnlockCondition
+* __unlock_conditions__*: array of UnlockCondition*  
     The unlock conditions for this output
-amount : int
+* __amount__*: int*  
     Amount of base token
-native_tokens : array of NativeToken
+* __native_tokens__*: array of NativeToken*  
     The native token to add to the output
-features : array of Feature
+* __features__*: array of Feature*  
     Features for this outputs
-immutable_features : array of Feature
+* __immutable_features__*: array of Feature*  
     Immutable features
 
-Returns
--------
+#### Returns
+
 Output as dict
 
 ### build\_nft\_output
@@ -192,23 +192,23 @@ def build_nft_output(nft_id: HexStr,
 
 Build an NftOutput.
 
-Parameters
-----------
-nft_id : string
+#### Parameters
+
+* __nft_id__*: string*  
     Hex encoded nft id
-unlock_conditions : array of UnlockCondition
+* __unlock_conditions__*: array of UnlockCondition*  
     The unlock conditions for this output
-amount : int
+* __amount__*: int*  
     Amount of base token
-native_tokens : array of NativeToken
+* __native_tokens__*: array of NativeToken*  
     The native tokens to add to the output
-features : array of Feature
+* __features__*: array of Feature*  
     Features for this outputs
-immutable_features : array of Feature
+* __immutable_features__*: array of Feature*  
     Immutable features
 
-Returns
--------
+#### Returns
+
 Output as dict
 
 ### build\_and\_post\_block
@@ -230,33 +230,33 @@ def build_and_post_block(secret_manager=None,
 
 Build and post a block.
 
-Parameters
-----------
-account_index : int
+#### Parameters
+
+* __account_index__*: int*  
     Account Index
-coin_type : int
+* __coin_type__*: int*  
     Coin type. The CoinType enum can be used
-custom_remainder_address : string
+* __custom_remainder_address__*: string*  
     Address to send the remainder funds to
-data : str
+* __data__*: str*  
     Hex encoded data
-initial_address_index : int
+* __initial_address_index__*: int*  
     Initial address index
-input_range_start : int
+* __input_range_start__*: int*  
     Start of the input range
-input_range_end : int
+* __input_range_end__*: int*  
     End of the input range
-inputs : Array of Inputs
+* __inputs__*: Array of Inputs*  
     Inputs to use
-output : SendAmountParams
+* __output__*: SendAmountParams*  
     Address and amount to send to
-outputs : Array of Outputs
+* __outputs__*: Array of Outputs*  
     Outputs to use
-tag : string
+* __tag__*: string*  
     Hex encoded tag
 
-Returns
--------
+#### Returns
+
 Block as dict
 
 ### get\_node

--- a/documentation/sdk/docs/references/python/iota_sdk/secret_manager/secret_manager.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/secret_manager/secret_manager.md
@@ -93,25 +93,25 @@ def generate_ed25519_addresses(account_index: Optional[int] = None,
 
 Generate ed25519 addresses.
 
-Parameters
-----------
-account_index : int
+#### Parameters
+
+* __account_index__*: int*  
     Account index.
-start : int
+* __start__*: int*  
     Start index of generated addresses
-end : int
+* __end__*: int*  
     End index of generated addresses
-internal : bool
+* __internal__*: bool*  
     Internal addresses
-coin_type : int
+* __coin_type__*: int*  
     Coin type. The CoinType enum can be used
-bech32_hrp : string
+* __bech32_hrp__*: string*  
     Bech32 human readable part.
-ledger_nano_prompt : bool
+* __ledger_nano_prompt__*: bool*  
     Display the address on ledger devices.
 
-Returns
--------
+#### Returns
+
 Addresses as array of strings.
 
 ### generate\_evm\_addresses
@@ -127,23 +127,23 @@ def generate_evm_addresses(account_index=None,
 
 Generate EVM addresses.
 
-Parameters
-----------
-account_index : int
+#### Parameters
+
+* __account_index__*: int*  
     Account index.
-start : int
+* __start__*: int*  
     Start index of generated addresses
-end : int
+* __end__*: int*  
     End index of generated addresses
-internal : bool
+* __internal__*: bool*  
     Internal addresses
-coin_type : int
+* __coin_type__*: int*  
     Coin type. The CoinType enum can be used
-ledger_nano_prompt : bool
+* __ledger_nano_prompt__*: bool*  
     Display the address on ledger devices.
 
-Returns
--------
+#### Returns
+
 Addresses as array of strings.
 
 ### get\_ledger\_nano\_status

--- a/documentation/sdk/docs/references/python/iota_sdk/secret_manager/secret_manager.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/secret_manager/secret_manager.md
@@ -170,6 +170,14 @@ def sign_ed25519(message: HexStr, chain: List[int])
 
 Signs a message with an Ed25519 private key.
 
+### sign\_secp256k1\_ecdsa
+
+```python
+def sign_secp256k1_ecdsa(message: HexStr, chain: List[int])
+```
+
+Signs a message with an Secp256k1Ecdsa private key.
+
 ### sign\_transaction
 
 ```python
@@ -185,3 +193,4 @@ def signature_unlock(transaction_essence_hash: HexStr, chain: List[int])
 ```
 
 Sign a transaction essence hash.
+

--- a/documentation/sdk/docs/references/python/iota_sdk/types/address.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/address.md
@@ -17,11 +17,11 @@ def __init__(type: AddressType, address_or_id: HexStr)
 
 Initialize an Address
 
-Parameters
-----------
-type : AddressType
+#### Parameters
+
+* __type__*: AddressType*  
     The type of the Address
-address_or_id : string
+* __address_or_id__*: string*  
     The address to use. Can either be an hex encoded ED25519 address or NFT/Alias id
 
 ## Ed25519Address Objects
@@ -38,9 +38,9 @@ def __init__(address: HexStr)
 
 Initialize an Ed25519Address
 
-Parameters
-----------
-address : string
+#### Parameters
+
+* __address__*: string*  
     The hex encoded address to use.
 
 ## AliasAddress Objects
@@ -57,9 +57,9 @@ def __init__(address_or_id: HexStr)
 
 Initialize an AliasAddress
 
-Parameters
-----------
-address_or_id : string
+#### Parameters
+
+* __address_or_id__*: string*  
     The hex encoded address to use.
 
 ## NFTAddress Objects
@@ -76,8 +76,8 @@ def __init__(address_or_id: HexStr)
 
 Initialize an NFTokenAddress
 
-Parameters
-----------
-address_or_id : string
+#### Parameters
+
+* __address_or_id__*: string*  
     The hex encoded address to use.
 

--- a/documentation/sdk/docs/references/python/iota_sdk/types/common.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/common.md
@@ -17,17 +17,17 @@ def __init__(url=None, jwt=None, username=None, password=None, disabled=None)
 
 Initialize a Node
 
-Parameters
-----------
-url : string
+#### Parameters
+
+* __url__*: string*  
     Node url
-jwt : string
+* __jwt__*: string*  
     JWT token
-username : string
+* __username__*: string*  
     Username for basic authentication
-password : string
+* __password__*: string*  
     Password for basic authentication
-disabled : bool
+* __disabled__*: bool*  
     Disable node
 
 ## SendAmountParams Objects
@@ -44,10 +44,10 @@ def __init__(address, amount)
 
 Initialise SendAmountParams
 
-Parameters
-----------
-address : string
+#### Parameters
+
+* __address__*: string*  
     Address of the output
-amount : int
+* __amount__*: int*  
     Amount of the output
 

--- a/documentation/sdk/docs/references/python/iota_sdk/types/feature.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/feature.md
@@ -17,17 +17,17 @@ def __init__(type, sender=None, issuer=None, data=None, tag=None)
 
 Initialize a feature
 
-Parameters
-----------
-type : FeatureType
+#### Parameters
+
+* __type__*: FeatureType*  
     The type of feature
-sender : Address
+* __sender__*: Address*  
     Sender address
-issuer : Address
+* __issuer__*: Address*  
     Issuer Address
-data : string
+* __data__*: string*  
     Hex encoded metadata
-tag : string
+* __tag__*: string*  
     Hex encoded tag used to index the output
 
 ## SenderFeature Objects
@@ -44,9 +44,9 @@ def __init__(sender)
 
 Initialize a SenderFeature
 
-Parameters
-----------
-sender : Address
+#### Parameters
+
+* __sender__*: Address*  
     Sender address
 
 ## IssuerFeature Objects
@@ -63,9 +63,9 @@ def __init__(issuer)
 
 Initialize an IssuerFeature
 
-Parameters
-----------
-issuer : Address
+#### Parameters
+
+* __issuer__*: Address*  
     Issuer address
 
 ## MetadataFeature Objects
@@ -82,9 +82,9 @@ def __init__(data: HexStr)
 
 Initialize a MetadataFeature
 
-Parameters
-----------
-data : HexStr
+#### Parameters
+
+* __data__*: HexStr*  
     Hex encoded metadata
 
 ## TagFeature Objects
@@ -101,8 +101,8 @@ def __init__(tag: HexStr)
 
 Initialize a TagFeature
 
-Parameters
-----------
-tag : HexStr
+#### Parameters
+
+* __tag__*: HexStr*  
     Hex encoded tag used to index the output
 

--- a/documentation/sdk/docs/references/python/iota_sdk/types/native_token.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/native_token.md
@@ -17,10 +17,10 @@ def __init__(id: HexStr, amount: int)
 
 Initialize NativeToken
 
-Parameters
-----------
-id : string
+#### Parameters
+
+* __id__*: string*  
     Id of the token
-amount : int
+* __amount__*: int*  
     Native token amount
 

--- a/documentation/sdk/docs/references/python/iota_sdk/types/signature.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/signature.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: signature
+title: iota_sdk.types.signature
+---
+
+## Ed25519Signature Objects
+
+```python
+class Ed25519Signature()
+```
+
+### \_\_init\_\_
+
+```python
+def __init__(public_key: HexStr, signature: HexStr)
+```
+
+Initialize an Ed25519Signature
+

--- a/documentation/sdk/docs/references/python/iota_sdk/types/token_scheme.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/token_scheme.md
@@ -17,9 +17,9 @@ def __init__(minted_tokens=None, melted_tokens=None, maximum_supply=None)
 
 Initialize TokenScheme
 
-Parameters
-----------
-minted_tokens : int
-melted_tokens : int
-maximum_supply : int
+#### Parameters
+
+* __minted_tokens__*: int*  
+* __melted_tokens__*: int*  
+* __maximum_supply__*: int*  
 

--- a/documentation/sdk/docs/references/python/iota_sdk/types/unlock_condition.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/types/unlock_condition.md
@@ -21,17 +21,17 @@ def __init__(type=None,
 
 Initialize an UnlockCondition
 
-Parameters
-----------
-type : UnlockConditionType
+#### Parameters
+
+* __type__*: UnlockConditionType*  
     The type of unlock condition
-address : Address
+* __address__*: Address*  
     Address for unlock condition
-amount : int
+* __amount__*: int*  
     Amount for storage deposit unlock condition
-unix_time : int
+* __unix_time__*: int*  
     Unix timestamp for timelock and expiration unlock condition
-return_address : Address
+* __return_address__*: Address*  
     Return address for expiration and storage deposit unlock condition
 
 ## AddressUnlockCondition Objects
@@ -48,9 +48,9 @@ def __init__(address)
 
 Initialize an AddressUnlockCondition
 
-Parameters
-----------
-address : Address
+#### Parameters
+
+* __address__*: Address*  
     Address
 
 ## StorageDepositReturnUnlockCondition Objects
@@ -67,11 +67,11 @@ def __init__(amount, return_address)
 
 Initialize a StorageDepositReturnUnlockCondition
 
-Parameters
-----------
-amount : int
+#### Parameters
+
+* __amount__*: int*  
     Amount
-return_address : Address
+* __return_address__*: Address*  
     Return address
 
 ## TimelockUnlockCondition Objects
@@ -88,9 +88,9 @@ def __init__(unix_time)
 
 Initialize a TimelockUnlockCondition
 
-Parameters
-----------
-unix_time : int
+#### Parameters
+
+* __unix_time__*: int*  
     Unix timestamp at which to unlock output
 
 ## ExpirationUnlockCondition Objects
@@ -107,11 +107,11 @@ def __init__(unix_time, return_address)
 
 Initialize an ExpirationUnlockCondition
 
-Parameters
-----------
-unix_time : int
+#### Parameters
+
+* __unix_time__*: int*  
     Unix timestamp
-return_address : Address
+* __return_address__*: Address*  
     Return address
 
 ## StateControllerAddressUnlockCondition Objects
@@ -128,9 +128,9 @@ def __init__(address)
 
 Initialize a StateControllerAddressUnlockCondition
 
-Parameters
-----------
-address : Address
+#### Parameters
+
+* __address__*: Address*  
     Address for unlock condition
 
 ## GovernorAddressUnlockCondition Objects
@@ -147,9 +147,9 @@ def __init__(address)
 
 Initialize a GovernorAddressUnlockCondition
 
-Parameters
-----------
-address : Address
+#### Parameters
+
+* __address__*: Address*  
     Address for unlock condition
 
 ## ImmutableAliasAddressUnlockCondition Objects
@@ -166,8 +166,8 @@ def __init__(address)
 
 Initialize an ImmutableAliasAddressUnlockCondition
 
-Parameters
-----------
-address : Address
+#### Parameters
+
+* __address__*: Address*  
     Address for unlock condition
 

--- a/documentation/sdk/docs/references/python/iota_sdk/utils.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/utils.md
@@ -140,19 +140,21 @@ Compute the hash of a transaction essence.
 
 ```python
 @staticmethod
-def verify_ed25519_signature(signature: Ed25519Signature, message: HexStr) -> bool
+def verify_ed25519_signature(signature: Ed25519Signature,
+                             message: HexStr) -> bool
 ```
 
-Verifies the Ed25519Signature against a message.
+Verifies an ed25519 signature against a message.
 
 ### verify\_secp256k1\_ecdsa\_signature
 
 ```python
 @staticmethod
-def verify_secp256k1_ecdsa_signature(public_key: HexStr, signature: HexStr, message: HexStr) -> bool
+def verify_secp256k1_ecdsa_signature(public_key: HexStr, signature: HexStr,
+                                     message: HexStr) -> bool
 ```
 
-Verifies the Secp256k1Ecdsa Signature against a message.
+Verifies a Secp256k1Ecdsa signature against a message.
 
 ## UtilsError Objects
 
@@ -161,3 +163,4 @@ class UtilsError(Exception)
 ```
 
 utils error
+

--- a/documentation/sdk/docs/references/python/iota_sdk/wallet/account.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/wallet/account.md
@@ -78,11 +78,10 @@ def generate_ed25519_addresses(amount: int, options=None)
 
 Generate new addresses.
 
-### get\_outputs\_with\_additional\_unlock\_conditions
+### claimable\_outputs
 
 ```python
-def claimable_outputs(
-        outputs_to_claim: List[OutputId])
+def claimable_outputs(outputs_to_claim: List[OutputId])
 ```
 
 Get outputs with additional unlock conditions.

--- a/documentation/sdk/docs/references/python/iota_sdk/wallet/prepared_transaction_data.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/wallet/prepared_transaction_data.md
@@ -17,11 +17,11 @@ def __init__(account, prepared_transaction_data)
 
 Helper struct for offline signing
 
-Parameters
-----------
-account : account object
+#### Parameters
+
+* __account__*: account object*  
     An account object used to continue building this transaction.
-prepared_transaction_data : dict of prepared data
+* __prepared_transaction_data__*: dict of prepared data*  
     The data of a prepared transaction object
 
 ## PreparedMintTokenTransaction Objects

--- a/documentation/sdk/docs/references/python/iota_sdk/wallet/wallet.md
+++ b/documentation/sdk/docs/references/python/iota_sdk/wallet/wallet.md
@@ -47,6 +47,14 @@ def get_client()
 
 Get the client instance
 
+### get\_secret\_manager
+
+```python
+def get_secret_manager()
+```
+
+Get the secret manager instance
+
 ### get\_account\_data
 
 ```python
@@ -160,14 +168,6 @@ def generate_ed25519_address(account_index: int,
 ```
 
 Generate an address without storing it.
-
-### get\_node\_info
-
-```python
-def get_node_info(url: str, auth)
-```
-
-Get node info.
 
 ### set\_stronghold\_password
 

--- a/documentation/sdk/docs/references/python/sidebar.json
+++ b/documentation/sdk/docs/references/python/sidebar.json
@@ -28,6 +28,7 @@
             "references/python/iota_sdk/types/feature",
             "references/python/iota_sdk/types/native_token",
             "references/python/iota_sdk/types/output_id",
+            "references/python/iota_sdk/types/signature",
             "references/python/iota_sdk/types/token_scheme",
             "references/python/iota_sdk/types/unlock_condition"
           ],


### PR DESCRIPTION
# Description of change

I changed the formatting of the API reference in two steps with the help of a `pydoc-markdown` processor.
First I transformed all parameter lists to actual markdown parameter lists.
Second I transformed all "Parameters" and "Returns" to h4. Before they where h2 which doesn't really fit into the hierarchy

## Links to any relevant issues

Fixes #636.

## Type of change

- Documentation Fix

## How the change has been tested

Tested locally by running:
```
python -m vent .venv-python
source .venv-python/bin/activate
cd bindings/python
pip install -r requirements.txt
PYTHONPATH=".:$PYTHONPATH" pydoc-markdown
```

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
