### PR TITLE
Allow issuer queryparameter for NFTs

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -134,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation for transitions in the input selection;
 - Automatically increase foundry counter of alias outputs;
 - Validate that foundry outputs can't have serial number `0`;
+- Allow QueryParameter::Issuer for NFTs;
 
 ## 0.3.0 - 2023-05-02
 

--- a/sdk/src/client/node_api/indexer/query_parameters.rs
+++ b/sdk/src/client/node_api/indexer/query_parameters.rs
@@ -12,7 +12,7 @@ use crate::{
     types::block::address::Bech32Address,
 };
 
-// https://github.com/gohornet/hornet/blob/bb1271be9f3a638f6acdeb6de74eab64515f27f1/plugins/indexer/v1/routes.go#L54
+// https://github.com/iotaledger/inx-indexer/tree/develop/pkg/indexer
 
 /// Query parameters for output_id requests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -283,6 +283,7 @@ pub(crate) fn verify_query_parameters_nft_outputs(query_parameters: Vec<QueryPar
         QueryParameter::ExpiresBefore,
         QueryParameter::ExpiresAfter,
         QueryParameter::ExpirationReturnAddress,
+        QueryParameter::Issuer,
         QueryParameter::Sender,
         QueryParameter::Tag,
         QueryParameter::CreatedBefore,


### PR DESCRIPTION
# Description of change

Allow issuer queryparameter for NFTs

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running 
```py
from iota_sdk import Client, NodeIndexerAPI

client = Client(nodes=['https://api.shimmer.network'])

nft_issuer_address='smr1zqzpuas8xqn2l2c4mwhgdm4jclwksakyv09rnlsr7ch7euwhk6exstatc2m'
query_parameters = NodeIndexerAPI.QueryParameters(
    issuer=nft_issuer_address,
)

output_ids_response = client.nft_output_ids(query_parameters)
print(f'{output_ids_response}')

```

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
