### PR TITLE
Fix deadlock in sync incoming txs

### DIFF
--- a/.changes/sync-deadlock.md
+++ b/.changes/sync-deadlock.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Fixed deadlock in .sync() with incoming transactions;

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved `internal` field from `IGenerateAddressesOptions` to `IGenerateAddressOptions`;
 - Error handling in `Client`, `SecretManager` and `Wallet` constructors;
+- Deadlock in .sync() with incoming transactions;
 
 ## 1.0.0-rc.1 - 2023-06-19
 

--- a/sdk/src/wallet/account/operations/syncing/outputs.rs
+++ b/sdk/src/wallet/account/operations/syncing/outputs.rs
@@ -135,6 +135,7 @@ where
                     .inaccessible_incoming_transactions
                     .contains(transaction_id))
         });
+        drop(account_details);
 
         // Limit parallel requests to 100, to avoid timeouts
         let results =

--- a/sdk/tests/wallet/message_interface.rs
+++ b/sdk/tests/wallet/message_interface.rs
@@ -203,7 +203,7 @@ async fn message_interface_events() -> Result<()> {
 
     let response = wallet_handle.send_message(transaction).await;
 
-    let Response::SentTransaction(_)= response else {
+    let Response::SentTransaction(_) = response else {
         panic!("unexpected response {response:?}");
     };
 


### PR DESCRIPTION
# Description of change

Fix deadlock in sync incoming txs

Changelog entry for Rust isn't needed since this was introduced in https://github.com/iotaledger/iota-sdk/commit/0b515e7bc2f78b9ae4863b1409a41b809b45a131 which isn't part of the latest release

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running an example which synced incoming transaction

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
