### PR TITLE
refactor(account)!: rename send methods

### DIFF
--- a/.changes/account-send-rename.md
+++ b/.changes/account-send-rename.md
@@ -1,0 +1,6 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Rename `SendAmountParams` to `SendParams`;
+Rename `Account::sendAmount` to `send`, `Account::prepareSendAmount` to `prepareSend`;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,13 +161,13 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -287,7 +293,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -514,7 +520,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -529,7 +535,7 @@ version = "1.0.0-rc.2"
 dependencies = [
  "chrono",
  "clap",
- "colored 2.0.0",
+ "colored 2.0.1",
  "dialoguer",
  "dotenvy",
  "fern-logger",
@@ -562,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "17bfac9400fe632590700de801b5dfbdca8b6944073832d1284bdbeef7f00e45"
 dependencies = [
  "atty",
  "lazy_static",
@@ -697,6 +703,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -889,8 +911,19 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+dependencies = [
+ "serde",
+ "signature",
 ]
 
 [[package]]
@@ -899,11 +932,27 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af5e1fb700a3c779c7a7ed25c8c0b7f193db101de3773ac46e704bcb882d772"
+dependencies = [
+ "curve25519-dalek 4.0.0-rc.2",
+ "ed25519",
+ "hashbrown 0.14.0",
+ "hex",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.7",
  "zeroize",
 ]
 
@@ -920,9 +969,11 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1021,6 +1072,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fixed-hash"
@@ -1125,7 +1182,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1310,6 +1367,10 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1328,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1434,10 +1495,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls 0.21.2",
@@ -1545,6 +1607,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb2df6763689b6e2b95787941eb9a58b29d16d17c2055392f550b3daf40bdce"
 dependencies = [
  "aead",
+ "autocfg",
+ "blake2",
+ "chacha20poly1305",
+ "cipher",
+ "digest 0.10.7",
+ "ed25519-zebra 3.1.0",
+ "generic-array",
+ "getrandom",
+ "hmac",
+ "k256",
+ "num-traits",
+ "pbkdf2",
+ "rand",
+ "serde",
+ "sha2 0.10.7",
+ "tiny-keccak",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
+name = "iota-crypto"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22b9d6f6b7601c3fcff97cdf6298cbfdd6fb44812b4e6f82a016152be1c891"
+dependencies = [
+ "aead",
  "aes",
  "aes-gcm",
  "autocfg",
@@ -1552,15 +1641,15 @@ dependencies = [
  "blake2",
  "chacha20poly1305",
  "cipher",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "digest 0.10.7",
- "ed25519-zebra",
+ "ed25519-zebra 4.0.0",
  "generic-array",
  "getrandom",
  "hkdf",
  "hmac",
+ "iterator-sorted",
  "k256",
- "num-traits",
  "pbkdf2",
  "rand",
  "scrypt",
@@ -1615,7 +1704,7 @@ dependencies = [
  "heck",
  "hex",
  "instant",
- "iota-crypto",
+ "iota-crypto 0.20.1",
  "iota-ledger-nano",
  "iota-sdk",
  "iota_stronghold",
@@ -1652,7 +1741,7 @@ dependencies = [
  "derivative",
  "fern-logger",
  "futures",
- "iota-crypto",
+ "iota-crypto 0.20.1",
  "iota-sdk",
  "log",
  "packable",
@@ -1721,12 +1810,12 @@ dependencies = [
 
 [[package]]
 name = "iota_stronghold"
-version = "1.1.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#9df6d19de325481771d69b47534d151e03eae623"
+version = "2.0.0-rc.0"
+source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
 dependencies = [
  "bincode",
  "hkdf",
- "iota-crypto",
+ "iota-crypto 0.21.2",
  "rust-argon2",
  "serde",
  "stronghold-derive",
@@ -1748,7 +1837,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1761,9 +1850,9 @@ checksum = "d101775d2bc8f99f4ac18bf29b9ed70c0dd138b9a1e88d7b80179470cbbe8bd2"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "jobserver"
@@ -1793,6 +1882,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.7",
 ]
 
@@ -1870,6 +1960,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "librocksdb-sys"
@@ -2093,7 +2189,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -2159,10 +2255,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-scale-codec"
-version = "3.6.1"
+name = "packed_simd_2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756d439303e94fae44f288ba881ad29670c65b0c4b0e05674ca81061bb65f2c5"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2174,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6937b5e67bfba3351b87b040d48352a2fcb6ad72f81855412ce97b45c8f110"
+checksum = "9d884d78fcf214d70b1e239fcd1c6e5e95aa3be1881918da2e488cc946c7a476"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2209,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "pbkdf2"
@@ -2228,6 +2334,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2247,29 +2362,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e138fdd8263907a2b0e1b4e80b7e58c721126479b6e6eedfb1b402acea7b9bd"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -2292,6 +2407,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "poly1305"
@@ -2340,7 +2461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2688,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -2756,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "salsa20"
@@ -2780,11 +2901,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2824,6 +2945,7 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2874,9 +2996,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
@@ -2892,13 +3014,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2914,13 +3036,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+checksum = "6f0a21fba416426ac927b1691996e82079f8b6156e920c85345f135b2e9ba2de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2932,6 +3054,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -3075,7 +3207,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stronghold-derive"
 version = "1.0.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#9df6d19de325481771d69b47534d151e03eae623"
+source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3084,11 +3216,11 @@ dependencies = [
 
 [[package]]
 name = "stronghold-runtime"
-version = "1.1.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#9df6d19de325481771d69b47534d151e03eae623"
+version = "2.0.0-rc.0"
+source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
 dependencies = [
  "dirs",
- "iota-crypto",
+ "iota-crypto 0.21.2",
  "libc",
  "libsodium-sys",
  "log",
@@ -3103,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "stronghold-utils"
 version = "1.0.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#9df6d19de325481771d69b47534d151e03eae623"
+source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
 dependencies = [
  "rand",
  "stronghold-derive",
@@ -3111,13 +3243,13 @@ dependencies = [
 
 [[package]]
 name = "stronghold_engine"
-version = "1.1.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#9df6d19de325481771d69b47534d151e03eae623"
+version = "2.0.0-rc.0"
+source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
 dependencies = [
  "anyhow",
  "dirs-next",
  "hex",
- "iota-crypto",
+ "iota-crypto 0.21.2",
  "once_cell",
  "paste",
  "serde",
@@ -3151,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3200,7 +3332,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3291,7 +3423,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3436,9 +3568,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -3561,7 +3693,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -3595,7 +3727,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3688,21 +3820,6 @@ dependencies = [
  "windows_i686_msvc 0.36.1",
  "windows_x86_64_gnu 0.36.1",
  "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3920,7 +4037,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
  "zeroize",
 ]
@@ -3943,5 +4060,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,12 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,21 +697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.0.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
- "fiat-crypto",
- "packed_simd_2",
- "platforms",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,7 +738,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -911,19 +889,8 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
-dependencies = [
- "serde",
- "signature",
 ]
 
 [[package]]
@@ -932,27 +899,11 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek",
  "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af5e1fb700a3c779c7a7ed25c8c0b7f193db101de3773ac46e704bcb882d772"
-dependencies = [
- "curve25519-dalek 4.0.0-rc.2",
- "ed25519",
- "hashbrown 0.14.0",
- "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.7",
  "zeroize",
 ]
 
@@ -969,11 +920,9 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1072,12 +1021,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fixed-hash"
@@ -1367,10 +1310,6 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-dependencies = [
- "ahash 0.8.3",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -1607,33 +1546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb2df6763689b6e2b95787941eb9a58b29d16d17c2055392f550b3daf40bdce"
 dependencies = [
  "aead",
- "autocfg",
- "blake2",
- "chacha20poly1305",
- "cipher",
- "digest 0.10.7",
- "ed25519-zebra 3.1.0",
- "generic-array",
- "getrandom",
- "hmac",
- "k256",
- "num-traits",
- "pbkdf2",
- "rand",
- "serde",
- "sha2 0.10.7",
- "tiny-keccak",
- "unicode-normalization",
- "zeroize",
-]
-
-[[package]]
-name = "iota-crypto"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d22b9d6f6b7601c3fcff97cdf6298cbfdd6fb44812b4e6f82a016152be1c891"
-dependencies = [
- "aead",
  "aes",
  "aes-gcm",
  "autocfg",
@@ -1641,15 +1553,15 @@ dependencies = [
  "blake2",
  "chacha20poly1305",
  "cipher",
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek",
  "digest 0.10.7",
- "ed25519-zebra 4.0.0",
+ "ed25519-zebra",
  "generic-array",
  "getrandom",
  "hkdf",
  "hmac",
- "iterator-sorted",
  "k256",
+ "num-traits",
  "pbkdf2",
  "rand",
  "scrypt",
@@ -1704,7 +1616,7 @@ dependencies = [
  "heck",
  "hex",
  "instant",
- "iota-crypto 0.20.1",
+ "iota-crypto",
  "iota-ledger-nano",
  "iota-sdk",
  "iota_stronghold",
@@ -1741,7 +1653,7 @@ dependencies = [
  "derivative",
  "fern-logger",
  "futures",
- "iota-crypto 0.20.1",
+ "iota-crypto",
  "iota-sdk",
  "log",
  "packable",
@@ -1810,12 +1722,12 @@ dependencies = [
 
 [[package]]
 name = "iota_stronghold"
-version = "2.0.0-rc.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
+version = "1.1.0"
+source = "git+https://github.com/iotaledger/stronghold.rs?rev=9df6d19de325481771d69b47534d151e03eae623#9df6d19de325481771d69b47534d151e03eae623"
 dependencies = [
  "bincode",
  "hkdf",
- "iota-crypto 0.21.2",
+ "iota-crypto",
  "rust-argon2",
  "serde",
  "stronghold-derive",
@@ -1882,7 +1794,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "serdect",
  "sha2 0.10.7",
 ]
 
@@ -1960,12 +1871,6 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
-
-[[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "librocksdb-sys"
@@ -2255,16 +2160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,15 +2231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,12 +2293,6 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "platforms"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "poly1305"
@@ -2945,7 +2825,6 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -3054,16 +2933,6 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serdect"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
-dependencies = [
- "base16ct",
  "serde",
 ]
 
@@ -3207,7 +3076,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stronghold-derive"
 version = "1.0.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
+source = "git+https://github.com/iotaledger/stronghold.rs?rev=9df6d19de325481771d69b47534d151e03eae623#9df6d19de325481771d69b47534d151e03eae623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3216,11 +3085,11 @@ dependencies = [
 
 [[package]]
 name = "stronghold-runtime"
-version = "2.0.0-rc.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
+version = "1.1.0"
+source = "git+https://github.com/iotaledger/stronghold.rs?rev=9df6d19de325481771d69b47534d151e03eae623#9df6d19de325481771d69b47534d151e03eae623"
 dependencies = [
  "dirs",
- "iota-crypto 0.21.2",
+ "iota-crypto",
  "libc",
  "libsodium-sys",
  "log",
@@ -3235,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "stronghold-utils"
 version = "1.0.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
+source = "git+https://github.com/iotaledger/stronghold.rs?rev=9df6d19de325481771d69b47534d151e03eae623#9df6d19de325481771d69b47534d151e03eae623"
 dependencies = [
  "rand",
  "stronghold-derive",
@@ -3243,13 +3112,13 @@ dependencies = [
 
 [[package]]
 name = "stronghold_engine"
-version = "2.0.0-rc.0"
-source = "git+https://github.com/iotaledger/stronghold.rs?branch=2.0#87d0ae07a26fc6711843174d1d706b066c85f350"
+version = "1.1.0"
+source = "git+https://github.com/iotaledger/stronghold.rs?rev=9df6d19de325481771d69b47534d151e03eae623#9df6d19de325481771d69b47534d151e03eae623"
 dependencies = [
  "anyhow",
  "dirs-next",
  "hex",
- "iota-crypto 0.21.2",
+ "iota-crypto",
  "once_cell",
  "paste",
  "serde",
@@ -4037,7 +3906,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
 ]

--- a/bindings/core/src/method/account.rs
+++ b/bindings/core/src/method/account.rs
@@ -21,7 +21,7 @@ use iota_sdk::{
             CreateAliasParams, CreateNativeTokenParams, FilterOptions, MintNftParams, OutputParams, OutputsToClaim,
             SyncOptions, TransactionOptionsDto,
         },
-        SendAmountParams, SendNativeTokensParams, SendNftParams,
+        SendNativeTokensParams, SendNftParams, SendParams,
     },
     U256,
 };
@@ -209,10 +209,10 @@ pub enum AccountMethod {
         params: Box<OutputParams>,
         transaction_options: Option<TransactionOptionsDto>,
     },
-    /// Prepare send amount.
+    /// Prepare to send base coins.
     /// Expected response: [`PreparedTransaction`](crate::Response::PreparedTransaction)
-    PrepareSendAmount {
-        params: Vec<SendAmountParams>,
+    PrepareSend {
+        params: Vec<SendParams>,
         options: Option<TransactionOptionsDto>,
     },
     /// Prepare to send native tokens.
@@ -269,10 +269,10 @@ pub enum AccountMethod {
         /// Maximum attempts
         max_attempts: Option<u64>,
     },
-    /// Send amount.
+    /// Send base coins.
     /// Expected response: [`SentTransaction`](crate::Response::SentTransaction)
-    SendAmount {
-        params: Vec<SendAmountParams>,
+    Send {
+        params: Vec<SendParams>,
         options: Option<TransactionOptionsDto>,
     },
     /// Send outputs in a transaction.

--- a/bindings/core/src/method_handler/account.rs
+++ b/bindings/core/src/method_handler/account.rs
@@ -213,7 +213,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
                 .await?;
             Response::Output(OutputDto::from(&output))
         }
-        AccountMethod::PrepareSendAmount { params, options } => {
+        AccountMethod::PrepareSend { params, options } => {
             let data = account
                 .prepare_send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                 .await?;
@@ -275,7 +275,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
                 .await?;
             Response::BlockId(block_id)
         }
-        AccountMethod::SendAmount { params, options } => {
+        AccountMethod::Send { params, options } => {
             let transaction = account
                 .send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                 .await?;

--- a/bindings/core/src/method_handler/account.rs
+++ b/bindings/core/src/method_handler/account.rs
@@ -215,7 +215,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
         }
         AccountMethod::PrepareSendAmount { params, options } => {
             let data = account
-                .prepare_send_amount(params, options.map(TransactionOptions::try_from_dto).transpose()?)
+                .prepare_send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                 .await?;
             Response::PreparedTransaction(PreparedTransactionDataDto::from(&data))
         }
@@ -277,7 +277,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
         }
         AccountMethod::SendAmount { params, options } => {
             let transaction = account
-                .send_amount(params, options.map(TransactionOptions::try_from_dto).transpose()?)
+                .send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                 .await?;
             Response::SentTransaction(TransactionDto::from(&transaction))
         }

--- a/bindings/core/src/method_handler/account.rs
+++ b/bindings/core/src/method_handler/account.rs
@@ -284,7 +284,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
         AccountMethod::SendOutputs { outputs, options } => {
             let token_supply = account.client().get_token_supply().await?;
             let transaction = account
-                .send(
+                .send_outputs(
                     outputs
                         .into_iter()
                         .map(|o| Ok(Output::try_from_dto(o, token_supply)?))

--- a/bindings/core/src/response.rs
+++ b/bindings/core/src/response.rs
@@ -328,7 +328,7 @@ pub enum Response {
     /// - [`PrepareMeltNativeToken`](crate::method::AccountMethod::PrepareMeltNativeToken)
     /// - [`PrepareMintNativeToken`](crate::method::AccountMethod::PrepareMintNativeToken),
     /// - [`PrepareMintNfts`](crate::method::AccountMethod::PrepareMintNfts),
-    /// - [`PrepareSendAmount`](crate::method::AccountMethod::PrepareSendAmount),
+    /// - [`PrepareSend`](crate::method::AccountMethod::PrepareSend),
     /// - [`PrepareSendNativeTokens`](crate::method::AccountMethod::PrepareSendNativeTokens),
     /// - [`PrepareSendNft`](crate::method::AccountMethod::PrepareSendNft),
     /// - [`PrepareStopParticipating`](crate::method::AccountMethod::PrepareStopParticipating)
@@ -360,7 +360,7 @@ pub enum Response {
     Balance(Balance),
     /// Response for:
     /// - [`ClaimOutputs`](crate::method::AccountMethod::ClaimOutputs)
-    /// - [`SendAmount`](crate::method::AccountMethod::SendAmount)
+    /// - [`Send`](crate::method::AccountMethod::Send)
     /// - [`SendOutputs`](crate::method::AccountMethod::SendOutputs)
     /// - [`SignAndSubmitTransaction`](crate::method::AccountMethod::SignAndSubmitTransaction)
     /// - [`SubmitAndStoreTransaction`](crate::method::AccountMethod::SubmitAndStoreTransaction)

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `Account::prepareMintNativeToken` to `prepareCreateNativeToken`, `Account::prepareIncreaseNativeTokenSupply` to `prepareMintNativeToken`, `Account::prepareDecreaseNativeTokenSupply` to `prepareMeltNativeToken`;
 - Rename `MintNativeTokenParams` to `CreateNativeTokenParams`;
 - Rename `MintTokenTransaction` to `CreateNativeTokenTransaction` and `PreparedMintTokenTransaction` to `PreparedCreateNativeTokenTransaction` (including their corresponding `Data` types);
+- Rename `SendAmountParams` to `SendParams`;
+- Rename `Account::sendAmount` to `send`, `Account::prepareSendAmount` to `prepareSend`;
 
 ### Fixed
 

--- a/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts
+++ b/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts
@@ -33,7 +33,7 @@ async function run() {
             'rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu';
         const amount = '1';
 
-        const transaction = await account.sendAmount(
+        const transaction = await account.send(
             [
                 {
                     address,

--- a/bindings/nodejs/examples/how_tos/alias_wallet/transaction.ts
+++ b/bindings/nodejs/examples/how_tos/alias_wallet/transaction.ts
@@ -70,7 +70,7 @@ async function run() {
             mandatoryInputs: [input],
             allowMicroAmount: false,
         };
-        const transaction = await account.sendAmount(params, options);
+        const transaction = await account.send(params, options);
         await account.retryTransactionUntilIncluded(transaction.transactionId);
         console.log(
             `Transaction with custom input: https://explorer.iota.org/testnet/transaction/${transaction.transactionId}`,

--- a/bindings/nodejs/examples/how_tos/simple_transaction/simple-transaction.ts
+++ b/bindings/nodejs/examples/how_tos/simple_transaction/simple-transaction.ts
@@ -35,7 +35,7 @@ async function run() {
             'rms1qrrv7flg6lz5cssvzv2lsdt8c673khad060l4quev6q09tkm9mgtupgf0h0';
         const amount = '1000000';
 
-        const response = await account.sendAmount([
+        const response = await account.send([
             {
                 address,
                 amount,

--- a/bindings/nodejs/examples/wallet/06-send-micro-transaction.ts
+++ b/bindings/nodejs/examples/wallet/06-send-micro-transaction.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { SendAmountParams } from '@iota/sdk';
+import { SendParams } from '@iota/sdk';
 
 import { getUnlockedWallet } from './common';
 
@@ -32,11 +32,11 @@ async function run() {
         console.log(
             `Sending '${SEND_MICRO_AMOUNT}' coin(s) to '${RECV_ADDRESS}'...`,
         );
-        const outputs: SendAmountParams[] = [
+        const params: SendParams[] = [
             { address: RECV_ADDRESS, amount: SEND_MICRO_AMOUNT },
         ];
 
-        const transaction = await account.sendAmount(outputs, {
+        const transaction = await account.send(params, {
             allowMicroAmount: true,
         });
         console.log(`Transaction sent: ${transaction.transactionId}`);

--- a/bindings/nodejs/lib/types/wallet/address.ts
+++ b/bindings/nodejs/lib/types/wallet/address.ts
@@ -12,7 +12,7 @@ export interface AccountAddress {
 }
 
 /** Address with a base token amount */
-export interface SendAmountParams {
+export interface SendParams {
     address: string;
     amount: string;
     returnAddress?: string;

--- a/bindings/nodejs/lib/types/wallet/bridge/account.ts
+++ b/bindings/nodejs/lib/types/wallet/bridge/account.ts
@@ -3,7 +3,7 @@
 
 import type { SyncOptions, FilterOptions } from '../account';
 import type {
-    SendAmountParams,
+    SendParams,
     SendNativeTokensParams,
     SendNftParams,
     GenerateAddressOptions,
@@ -219,10 +219,10 @@ export type __PrepareOutputMethod__ = {
     };
 };
 
-export type __PrepareSendAmountMethod__ = {
-    name: 'prepareSendAmount';
+export type __PrepareSendMethod__ = {
+    name: 'prepareSend';
     data: {
-        params: SendAmountParams[];
+        params: SendParams[];
         options?: TransactionOptions;
     };
 };
@@ -251,10 +251,10 @@ export type __RetryTransactionUntilIncludedMethod__ = {
     };
 };
 
-export type __SendAmountMethod__ = {
-    name: 'sendAmount';
+export type __SendMethod__ = {
+    name: 'send';
     data: {
-        params: SendAmountParams[];
+        params: SendParams[];
         options?: TransactionOptions;
     };
 };

--- a/bindings/nodejs/lib/types/wallet/bridge/index.ts
+++ b/bindings/nodejs/lib/types/wallet/bridge/index.ts
@@ -28,11 +28,11 @@ import type {
     __PrepareMintNativeTokenMethod__,
     __PrepareMintNftsMethod__,
     __PrepareOutputMethod__,
-    __PrepareSendAmountMethod__,
+    __PrepareSendMethod__,
     __PrepareTransactionMethod__,
     __RegisterParticipationEventsMethod__,
     __RetryTransactionUntilIncludedMethod__,
-    __SendAmountMethod__,
+    __SendMethod__,
     __PrepareSendNativeTokensMethod__,
     __PrepareSendNftMethod__,
     __SendOutputsMethod__,
@@ -113,11 +113,11 @@ export type __AccountMethod__ =
     | __PrepareMintNativeTokenMethod__
     | __PrepareMintNftsMethod__
     | __PrepareOutputMethod__
-    | __PrepareSendAmountMethod__
+    | __PrepareSendMethod__
     | __PrepareTransactionMethod__
     | __RegisterParticipationEventsMethod__
     | __RetryTransactionUntilIncludedMethod__
-    | __SendAmountMethod__
+    | __SendMethod__
     | __PrepareSendNativeTokensMethod__
     | __PrepareSendNftMethod__
     | __SendOutputsMethod__

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -879,7 +879,7 @@ export class Account {
     }
 
     /**
-     * Prepare a send transaction, useful for offline signing.
+     * Prepare to send base coins, useful for offline signing.
      * @param params Address with amounts to send.
      * @param options The options to define a `RemainderValueStrategy`
      * or custom inputs.
@@ -977,7 +977,7 @@ export class Account {
     }
 
     /**
-     * Send a transaction with amounts from input addresses.
+     * Send base coins with amounts from input addresses.
      * @param params Addresses with amounts.
      * @param transactionOptions The options to define a `RemainderValueStrategy`
      * or custom inputs.

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -8,7 +8,7 @@ import {
     SyncOptions,
     AccountMeta,
     AccountAddress,
-    SendAmountParams,
+    SendParams,
     SendNativeTokensParams,
     SendNftParams,
     AddressWithUnspentOutputs,
@@ -885,14 +885,14 @@ export class Account {
      * or custom inputs.
      * @returns The prepared transaction data.
      */
-    async prepareSendAmount(
-        params: SendAmountParams[],
+    async prepareSend(
+        params: SendParams[],
         options?: TransactionOptions,
     ): Promise<PreparedTransaction> {
         const response = await this.methodHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'prepareSendAmount',
+                name: 'prepareSend',
                 data: {
                     params,
                     options,
@@ -983,14 +983,14 @@ export class Account {
      * or custom inputs.
      * @returns The sent transaction.
      */
-    async sendAmount(
-        params: SendAmountParams[],
+    async send(
+        params: SendParams[],
         transactionOptions?: TransactionOptions,
     ): Promise<Transaction> {
         const response = await this.methodHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'sendAmount',
+                name: 'send',
                 data: {
                     params,
                     options: transactionOptions,

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -879,7 +879,7 @@ export class Account {
     }
 
     /**
-     * Prepare a send amount transaction, useful for offline signing.
+     * Prepare a send transaction, useful for offline signing.
      * @param params Address with amounts to send.
      * @param options The options to define a `RemainderValueStrategy`
      * or custom inputs.

--- a/bindings/python/examples/client/09_transaction.py
+++ b/bindings/python/examples/client/09_transaction.py
@@ -1,4 +1,4 @@
-from iota_sdk import Client, MnemonicSecretManager, SendAmountParams
+from iota_sdk import Client, MnemonicSecretManager, SendParams
 from dotenv import load_dotenv
 import os
 
@@ -15,11 +15,11 @@ if 'NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1' not in os.environ:
 secret_manager = MnemonicSecretManager(
     os.environ['NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1'])
 
-output = SendAmountParams(
+params = SendParams(
     address='rms1qzpf0tzpf8yqej5zyhjl9k3km7y6j0xjnxxh7m2g3jtj2z5grej67sl6l46',
     amount=1000000,
 )
 
 # Create and post a block with a transaction
-block = client.build_and_post_block(secret_manager, output=output)
+block = client.build_and_post_block(secret_manager, output=params)
 print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{block[0]}')

--- a/bindings/python/examples/client/09_transaction.py
+++ b/bindings/python/examples/client/09_transaction.py
@@ -21,5 +21,5 @@ params = SendParams(
 )
 
 # Create and post a block with a transaction
-block = client.build_and_post_block(secret_manager, output=params)
+block = client.build_and_post_block(secret_manager, params=params)
 print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{block[0]}')

--- a/bindings/python/examples/client/09_transaction.py
+++ b/bindings/python/examples/client/09_transaction.py
@@ -21,5 +21,5 @@ params = SendParams(
 )
 
 # Create and post a block with a transaction
-block = client.build_and_post_block(secret_manager, params=params)
+block = client.build_and_post_block(secret_manager, output=params)
 print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{block[0]}')

--- a/bindings/python/examples/how_tos/advanced_transactions/send_micro_transaction.py
+++ b/bindings/python/examples/how_tos/advanced_transactions/send_micro_transaction.py
@@ -18,12 +18,12 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
 
 wallet.set_stronghold_password(os.environ["STRONGHOLD_PASSWORD"])
 
-outputs = [{
+params = [{
     "address": "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
     "amount": "1",
 }]
 
-transaction = account.send_amount(outputs, {"allowMicroAmount": True})
+transaction = account.send(params, {"allowMicroAmount": True})
 print(f'Transaction sent: {transaction["transactionId"]}')
 
 block_id = account.retry_transaction_until_included(transaction["transactionId"])

--- a/bindings/python/examples/how_tos/alias_wallet/transaction.py
+++ b/bindings/python/examples/how_tos/alias_wallet/transaction.py
@@ -40,7 +40,7 @@ params = [{
 options = {
     'mandatoryInputs': [input],
 }
-transaction = account.send_amount(params, options)
+transaction = account.send(params, options)
 account.retry_transaction_until_included(
     transaction['transactionId'], None, None)
 print(

--- a/bindings/python/examples/how_tos/simple_transaction/simple_transaction.py
+++ b/bindings/python/examples/how_tos/simple_transaction/simple_transaction.py
@@ -18,10 +18,10 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
 
 wallet.set_stronghold_password(os.environ["STRONGHOLD_PASSWORD"])
 
-outputs = [{
+params = [{
     "address": "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
     "amount": "1000000",
 }]
 
-transaction = account.send_amount(outputs)
+transaction = account.send(params)
 print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{transaction["blockId"]}')

--- a/bindings/python/examples/wallet/transaction_options.py
+++ b/bindings/python/examples/wallet/transaction_options.py
@@ -18,12 +18,12 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
 
 wallet.set_stronghold_password(os.environ["STRONGHOLD_PASSWORD"])
 
-outputs = [{
+params = [{
     "address": "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
     "amount": "1000000",
 }]
 
-transaction = account.send_amount(outputs, TransactionOptions(remainder_value_strategy=RemainderValueStrategy.ReuseAddress,
+transaction = account.send(params, TransactionOptions(remainder_value_strategy=RemainderValueStrategy.ReuseAddress,
                                   note="my first tx", tagged_data_payload=TaggedDataPayload(utf8_to_hex("tag"), utf8_to_hex("data"))))
 print(transaction)
 print(

--- a/bindings/python/iota_sdk/client/client.py
+++ b/bindings/python/iota_sdk/client/client.py
@@ -406,7 +406,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
             End of the input range
         inputs : Array of Inputs
             Inputs to use
-        output : SendAmountParams
+        output : SendParams
             Address and amount to send to
         outputs : Array of Outputs
             Outputs to use

--- a/bindings/python/iota_sdk/client/client.py
+++ b/bindings/python/iota_sdk/client/client.py
@@ -383,7 +383,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                              input_range_start: Optional[int] = None,
                              input_range_end: Optional[int] = None,
                              inputs: Optional[List[Dict[str, Any]]] = None,
-                             params: Optional[Dict[str, Any]] = None,
+                             output: Optional[Dict[str, Any]] = None,
                              outputs: Optional[List[Any]] = None,
                              tag: Optional[HexStr] = None) -> List[HexStr|Block]:
         """Build and post a block.
@@ -406,7 +406,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
             End of the input range
         inputs : Array of Inputs
             Inputs to use
-        params : SendParams
+        output : Any # TODO: https://github.com/iotaledger/iota-sdk/issues/129
             Address and amount to send to
         outputs : Array of Outputs
             Outputs to use
@@ -425,8 +425,8 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
 
         options = {k: v for k, v in options.items() if v != None}
 
-        if 'params' in options:
-            options['output'] = options.pop('params').as_dict()
+        if 'output' in options:
+            options['output'] = options.pop('output').as_dict()
 
         if 'coin_type' in options:
             options['coin_type'] = int(options.pop('coin_type'))

--- a/bindings/python/iota_sdk/client/client.py
+++ b/bindings/python/iota_sdk/client/client.py
@@ -383,7 +383,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                              input_range_start: Optional[int] = None,
                              input_range_end: Optional[int] = None,
                              inputs: Optional[List[Dict[str, Any]]] = None,
-                             output: Optional[Dict[str, Any]] = None,
+                             params: Optional[Dict[str, Any]] = None,
                              outputs: Optional[List[Any]] = None,
                              tag: Optional[HexStr] = None) -> List[HexStr|Block]:
         """Build and post a block.
@@ -406,7 +406,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
             End of the input range
         inputs : Array of Inputs
             Inputs to use
-        output : SendParams
+        params : SendParams
             Address and amount to send to
         outputs : Array of Outputs
             Outputs to use
@@ -425,8 +425,8 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
 
         options = {k: v for k, v in options.items() if v != None}
 
-        if 'output' in options:
-            options['output'] = options.pop('output').as_dict()
+        if 'params' in options:
+            options['output'] = options.pop('params').as_dict()
 
         if 'coin_type' in options:
             options['coin_type'] = int(options.pop('coin_type'))

--- a/bindings/python/iota_sdk/types/common.py
+++ b/bindings/python/iota_sdk/types/common.py
@@ -58,9 +58,9 @@ class Node():
         return config
 
 
-class SendAmountParams():
+class SendParams():
     def __init__(self, address, amount):
-        """Initialise SendAmountParams
+        """Initialize SendParams
 
         Parameters
         ----------

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -308,11 +308,11 @@ class Account:
             }
         )
 
-    def prepare_send_amount(self, params, options: Optional[TransactionOptions] = None):
-        """Prepare send amount.
+    def prepare_send(self, params, options: Optional[TransactionOptions] = None):
+        """Prepare to send base coins.
         """
         prepared = self._call_account_method(
-            'prepareSendAmount', {
+            'prepareSend', {
                 'params': params,
                 'options': options
             }
@@ -354,10 +354,10 @@ class Account:
         )
 
     def send(self, params, options: Optional[TransactionOptions] = None):
-        """Send amount.
+        """Send base coins.
         """
         return self._call_account_method(
-            'sendAmount', {
+            'send', {
                 'params': params,
                 'options': options
             }

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -353,7 +353,7 @@ class Account:
             }
         )
 
-    def send_amount(self, params, options: Optional[TransactionOptions] = None):
+    def send(self, params, options: Optional[TransactionOptions] = None):
         """Send amount.
         """
         return self._call_account_method(

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -645,7 +645,7 @@ pub async fn send_command(
         .with_return_address(return_address.map(ConvertTo::convert).transpose()?)
         .with_expiration(expiration)];
     let transaction = account
-        .send_amount(
+        .send(
             params,
             TransactionOptions {
                 allow_micro_amount,

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -641,12 +641,12 @@ pub async fn send_command(
     expiration: Option<u32>,
     allow_micro_amount: bool,
 ) -> Result<(), Error> {
-    let outputs = [SendAmountParams::new(address, amount)?
+    let params = [SendAmountParams::new(address, amount)?
         .with_return_address(return_address.map(ConvertTo::convert).transpose()?)
         .with_expiration(expiration)];
     let transaction = account
         .send_amount(
-            outputs,
+            params,
             TransactionOptions {
                 allow_micro_amount,
                 ..Default::default()
@@ -687,7 +687,7 @@ pub async fn send_native_token_command(
             )?])
             .finish_output(token_supply)?];
 
-        account.send(outputs, None).await?
+        account.send_outputs(outputs, None).await?
     } else {
         // Send native tokens with storage deposit return and expiration
         let outputs = [SendNativeTokensParams::new(

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -20,7 +20,7 @@ use iota_sdk::{
     },
     wallet::{
         account::{types::AccountAddress, Account, OutputsToClaim, TransactionOptions},
-        CreateNativeTokenParams, MintNftParams, SendAmountParams, SendNativeTokensParams, SendNftParams,
+        CreateNativeTokenParams, MintNftParams, SendNativeTokensParams, SendNftParams, SendParams,
     },
     U256,
 };
@@ -641,7 +641,7 @@ pub async fn send_command(
     expiration: Option<u32>,
     allow_micro_amount: bool,
 ) -> Result<(), Error> {
-    let params = [SendAmountParams::new(address, amount)?
+    let params = [SendParams::new(address, amount)?
         .with_return_address(return_address.map(ConvertTo::convert).transpose()?)
         .with_expiration(expiration)];
     let transaction = account

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `Account::prepare_mint_native_token` to `prepare_create_native_token`, `Account::prepare_increase_native_token_supply` to `prepare_mint_native_token`, `Account::prepare_decrease_native_token_supply` to `prepare_melt_native_token`;
 - Rename `MintNativeTokenParams` to `CreateNativeTokenParams`;
 - Rename `MintNativeTokenTransaction` to `CreateNativeTokenTransaction` and `PreparedMintNativeTokenTransaction` to `PreparedCreateNativeTokenTransaction` (including their corresponding DTOs);
+- Rename `SendAmountParams` to `SendParams`;
 - Rename `Account::send` to `send_outputs`, `Account::send_amount` to `send`, `Account::prepare_send_amount` to `prepare_send`;
 
 ### Removed

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `Account::prepare_mint_native_token` to `prepare_create_native_token`, `Account::prepare_increase_native_token_supply` to `prepare_mint_native_token`, `Account::prepare_decrease_native_token_supply` to `prepare_melt_native_token`;
 - Rename `MintNativeTokenParams` to `CreateNativeTokenParams`;
 - Rename `MintNativeTokenTransaction` to `CreateNativeTokenTransaction` and `PreparedMintNativeTokenTransaction` to `PreparedCreateNativeTokenTransaction` (including their corresponding DTOs);
+- Rename `Account::send` to `send_outputs`, `Account::send_amount` to `send`, `Account::prepare_send_amount` to `prepare_send`;
 
 ### Removed
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,7 +44,7 @@ heck = { version = "0.4.1", default-features = false, optional = true }
 instant = { version = "0.1.12", default-features = false, optional = true }
 iota-ledger-nano = { version = "1.0.0-alpha.4", default-features = false, optional = true }
 # iota_stronghold = { version = "1.0.5", default-features = false, optional = true }
-iota_stronghold = { git = "https://github.com/iotaledger/stronghold.rs", branch = "2.0", default-features = false, optional = true }
+iota_stronghold = { git = "https://github.com/iotaledger/stronghold.rs", rev = "9df6d19de325481771d69b47534d151e03eae623", default-features = false, optional = true }
 log = { version = "0.4.18", default-features = false, optional = true }
 num_cpus = { version = "1.15.0", default-features = false, optional = true }
 once_cell = { version = "1.17.2", default-features = false, optional = true }

--- a/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
             .add_unlock_condition(TimelockUnlockCondition::new(in_an_hour)?)
             .finish_output(account.client().get_token_supply().await?)?;
 
-        let transaction = account.send(vec![basic_output], None).await?;
+        let transaction = account.send_outputs(vec![basic_output], None).await?;
         println!("Transaction sent: {}", transaction.transaction_id);
 
         // Wait for transaction to get included

--- a/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
@@ -43,11 +43,11 @@ async fn main() -> Result<()> {
     println!("Sending '{}' coin(s) to '{}'...", SEND_MICRO_AMOUNT, RECV_ADDRESS);
 
     // Send a micro transaction
-    let outputs = [SendAmountParams::new(RECV_ADDRESS, SEND_MICRO_AMOUNT)?];
+    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_MICRO_AMOUNT)?];
 
     let transaction = account
-        .send_amount(
-            outputs,
+        .send(
+            params,
             TransactionOptions {
                 allow_micro_amount: true,
                 ..Default::default()

--- a/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
@@ -12,7 +12,7 @@
 //! ```
 
 use iota_sdk::{
-    wallet::{account::TransactionOptions, Result, SendAmountParams},
+    wallet::{account::TransactionOptions, Result, SendParams},
     Wallet,
 };
 
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     println!("Sending '{}' coin(s) to '{}'...", SEND_MICRO_AMOUNT, RECV_ADDRESS);
 
     // Send a micro transaction
-    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_MICRO_AMOUNT)?];
+    let params = [SendParams::new(RECV_ADDRESS, SEND_MICRO_AMOUNT)?];
 
     let transaction = account
         .send(

--- a/sdk/examples/how_tos/alias_wallet/transaction.rs
+++ b/sdk/examples/how_tos/alias_wallet/transaction.rs
@@ -11,7 +11,7 @@ use iota_sdk::{
     types::block::address::{AliasAddress, ToBech32Ext},
     wallet::{
         account::{AliasSyncOptions, SyncOptions, TransactionOptions},
-        Result, SendAmountParams,
+        Result, SendParams,
     },
     Wallet,
 };
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
 
     let transaction = account
         .send(
-            SendAmountParams::new(
+            SendParams::new(
                 "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
                 1_000_000,
             ),

--- a/sdk/examples/how_tos/alias_wallet/transaction.rs
+++ b/sdk/examples/how_tos/alias_wallet/transaction.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
         .unwrap();
 
     let transaction = account
-        .send_amount(
+        .send(
             SendAmountParams::new(
                 "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
                 1_000_000,

--- a/sdk/examples/how_tos/nfts/mint_nft.rs
+++ b/sdk/examples/how_tos/nfts/mint_nft.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
             .finish_output(token_supply)?,
     ];
 
-    let transaction = account.send(outputs, None).await?;
+    let transaction = account.send_outputs(outputs, None).await?;
     println!("Transaction sent: {}", transaction.transaction_id);
 
     // Wait for transaction to get included

--- a/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
+++ b/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
@@ -41,8 +41,8 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Trying to send '{}' coins to '{}'...", SEND_AMOUNT, RECV_ADDRESS);
-    let outputs = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
-    let transaction = account.send_amount(outputs, None).await?;
+    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let transaction = account.send(params, None).await?;
 
     // Wait for transaction to get included
     let block_id = account

--- a/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
+++ b/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
@@ -12,7 +12,7 @@
 //! ```
 
 use iota_sdk::{
-    wallet::{Result, SendAmountParams},
+    wallet::{Result, SendParams},
     Wallet,
 };
 
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Trying to send '{}' coins to '{}'...", SEND_AMOUNT, RECV_ADDRESS);
-    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let params = [SendParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
     let transaction = account.send(params, None).await?;
 
     // Wait for transaction to get included

--- a/sdk/examples/wallet/events.rs
+++ b/sdk/examples/wallet/events.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
         .add_unlock_condition(AddressUnlockCondition::new(Address::try_from_bech32(RECV_ADDRESS)?))
         .finish_output(account.client().get_token_supply().await?)?];
 
-    let transaction = account.send(outputs, None).await?;
+    let transaction = account.send_outputs(outputs, None).await?;
     println!("Transaction sent: {}", transaction.transaction_id);
 
     let block_id = account

--- a/sdk/examples/wallet/ledger_nano.rs
+++ b/sdk/examples/wallet/ledger_nano.rs
@@ -72,8 +72,8 @@ async fn main() -> Result<()> {
     println!("Balance BEFORE:\n{:?}", balance.base_coin());
 
     println!("Sending the coin-transfer transaction...");
-    let outputs = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
-    let transaction = account.send_amount(outputs, None).await?;
+    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let transaction = account.send(params, None).await?;
     println!("Transaction sent: {}", transaction.transaction_id);
 
     let block_id = account

--- a/sdk/examples/wallet/ledger_nano.rs
+++ b/sdk/examples/wallet/ledger_nano.rs
@@ -19,7 +19,7 @@ use iota_sdk::{
         constants::SHIMMER_COIN_TYPE,
         secret::{ledger_nano::LedgerSecretManager, SecretManager},
     },
-    wallet::{ClientOptions, Result, SendAmountParams, Wallet},
+    wallet::{ClientOptions, Result, SendParams, Wallet},
 };
 
 // The account alias used in this example
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
     println!("Balance BEFORE:\n{:?}", balance.base_coin());
 
     println!("Sending the coin-transfer transaction...");
-    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let params = [SendParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
     let transaction = account.send(params, None).await?;
     println!("Transaction sent: {}", transaction.transaction_id);
 

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
-    let outputs = [SendParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let params = [SendParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
 
     // Recovers addresses from example `0_address_generation`.
     let addresses = read_addresses_from_file().await?;
@@ -57,9 +57,9 @@ async fn main() -> Result<()> {
     // Sync the account to get the outputs for the addresses
     account.sync(None).await?;
 
-    let prepared_transaction = account.prepare_send(outputs.clone(), None).await?;
+    let prepared_transaction = account.prepare_send(params.clone(), None).await?;
 
-    println!("Prepared transaction sending {outputs:?}");
+    println!("Prepared transaction sending {params:?}");
 
     write_transaction_to_file(prepared_transaction).await?;
 

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
     // Sync the account to get the outputs for the addresses
     account.sync(None).await?;
 
-    let prepared_transaction = account.prepare_send_amount(outputs.clone(), None).await?;
+    let prepared_transaction = account.prepare_send(outputs.clone(), None).await?;
 
     println!("Prepared transaction sending {outputs:?}");
 

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
         constants::SHIMMER_COIN_TYPE,
         secret::SecretManager,
     },
-    wallet::{account::types::AccountAddress, ClientOptions, Result, SendAmountParams, Wallet},
+    wallet::{account::types::AccountAddress, ClientOptions, Result, SendParams, Wallet},
 };
 
 const ONLINE_WALLET_DB_PATH: &str = "./examples/wallet/offline_signing/example-online-walletdb";
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
-    let outputs = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let outputs = [SendParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
 
     // Recovers addresses from example `0_address_generation`.
     let addresses = read_addresses_from_file().await?;

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -15,7 +15,7 @@ use iota_sdk::{
         secret::{mnemonic::MnemonicSecretManager, SecretManager},
     },
     types::block::{address::Bech32Address, output::BasicOutput, payload::transaction::TransactionId},
-    wallet::{account::FilterOptions, Account, ClientOptions, Result, SendAmountParams, Wallet},
+    wallet::{account::FilterOptions, Account, ClientOptions, Result, SendParams, Wallet},
 };
 
 // The account alias used in this example.
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
         println!("Creating unspent outputs...");
 
         let transaction = account
-            .send(vec![SendAmountParams::new(recv_address, SEND_AMOUNT)?; 127], None)
+            .send(vec![SendParams::new(recv_address, SEND_AMOUNT)?; 127], None)
             .await?;
         wait_for_inclusion(&transaction.transaction_id, &account).await?;
 
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
                 println!("Thread {n}: sending {SEND_AMOUNT} coins to own address");
 
                 let thread_timer = tokio::time::Instant::now();
-                let params = vec![SendAmountParams::new(recv_address, SEND_AMOUNT).map_err(|err| (n, err))?];
+                let params = vec![SendParams::new(recv_address, SEND_AMOUNT).map_err(|err| (n, err))?];
                 let transaction = account_clone.send(params, None).await.map_err(|err| (n, err))?;
                 let elapsed = thread_timer.elapsed();
 

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
         println!("Creating unspent outputs...");
 
         let transaction = account
-            .send_amount(vec![SendAmountParams::new(recv_address, SEND_AMOUNT)?; 127], None)
+            .send(vec![SendAmountParams::new(recv_address, SEND_AMOUNT)?; 127], None)
             .await?;
         wait_for_inclusion(&transaction.transaction_id, &account).await?;
 
@@ -93,8 +93,8 @@ async fn main() -> Result<()> {
                 println!("Thread {n}: sending {SEND_AMOUNT} coins to own address");
 
                 let thread_timer = tokio::time::Instant::now();
-                let outputs = vec![SendAmountParams::new(recv_address, SEND_AMOUNT).map_err(|err| (n, err))?];
-                let transaction = account_clone.send_amount(outputs, None).await.map_err(|err| (n, err))?;
+                let params = vec![SendAmountParams::new(recv_address, SEND_AMOUNT).map_err(|err| (n, err))?];
+                let transaction = account_clone.send(params, None).await.map_err(|err| (n, err))?;
                 let elapsed = thread_timer.elapsed();
 
                 println!(

--- a/sdk/examples/wallet/split_funds.rs
+++ b/sdk/examples/wallet/split_funds.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
             SEND_AMOUNT,
             outputs_per_transaction.len()
         );
-        let transaction = account.send(outputs_per_transaction, None).await?;
+        let transaction = account.send_outputs(outputs_per_transaction, None).await?;
         println!(
             "Transaction sent: {}/transaction/{}",
             std::env::var("EXPLORER_URL").unwrap(),

--- a/sdk/examples/wallet/update_alias_output.rs
+++ b/sdk/examples/wallet/update_alias_output.rs
@@ -83,7 +83,7 @@ async fn sync_and_print_balance(account: &Account) -> Result<()> {
 }
 
 async fn send_and_wait_for_inclusion(account: &Account, outputs: Vec<Output>) -> Result<()> {
-    let transaction = account.send(outputs, None).await?;
+    let transaction = account.send_outputs(outputs, None).await?;
     println!(
         "Transaction sent: {}/transaction/{}",
         std::env::var("EXPLORER_URL").unwrap(),

--- a/sdk/examples/wallet/wallet.rs
+++ b/sdk/examples/wallet/wallet.rs
@@ -22,7 +22,7 @@ use iota_sdk::{
         secret::{mnemonic::MnemonicSecretManager, SecretManager},
     },
     types::block::payload::transaction::TransactionId,
-    wallet::{Account, ClientOptions, Result, SendAmountParams, Wallet},
+    wallet::{Account, ClientOptions, Result, SendParams, Wallet},
 };
 
 // The number of addresses to generate in this account
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
     print_addresses_with_funds(&account).await?;
 
     println!("Sending '{}' coins to '{}'...", SEND_AMOUNT, RECV_ADDRESS);
-    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let params = [SendParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
     let transaction = account.send(params, None).await?;
     wait_for_inclusion(&transaction.transaction_id, &account).await?;
 

--- a/sdk/examples/wallet/wallet.rs
+++ b/sdk/examples/wallet/wallet.rs
@@ -51,8 +51,8 @@ async fn main() -> Result<()> {
     print_addresses_with_funds(&account).await?;
 
     println!("Sending '{}' coins to '{}'...", SEND_AMOUNT, RECV_ADDRESS);
-    let outputs = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
-    let transaction = account.send_amount(outputs, None).await?;
+    let params = [SendAmountParams::new(RECV_ADDRESS, SEND_AMOUNT)?];
+    let transaction = account.send(params, None).await?;
     wait_for_inclusion(&transaction.transaction_id, &account).await?;
 
     sync_print_balance(&account, false).await?;

--- a/sdk/src/wallet/account/operations/output_consolidation.rs
+++ b/sdk/src/wallet/account/operations/output_consolidation.rs
@@ -89,8 +89,8 @@ where
         Ok(consolidation_tx)
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.consolidate_outputs()](crate::account::Account.consolidate_outputs)
+    /// Account method to prepare the transaction for
+    /// [Account::consolidate_outputs()](crate::account::Account::consolidate_outputs).
     pub async fn prepare_consolidate_outputs(
         &self,
         force: bool,

--- a/sdk/src/wallet/account/operations/output_consolidation.rs
+++ b/sdk/src/wallet/account/operations/output_consolidation.rs
@@ -67,7 +67,7 @@ where
         })
     }
 
-    /// Consolidate basic outputs with only an [AddressUnlockCondition] from an account by sending them to an own
+    /// Consolidates basic outputs with only an [AddressUnlockCondition] from an account by sending them to an own
     /// address again if the output amount is >= the output_consolidation_threshold. When `force` is set to `true`, the
     /// threshold is ignored. Only consolidates the amount of outputs that fit into a single transaction.
     pub async fn consolidate_outputs(
@@ -89,7 +89,7 @@ where
         Ok(consolidation_tx)
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::consolidate_outputs()](crate::account::Account::consolidate_outputs).
     pub async fn prepare_consolidate_outputs(
         &self,

--- a/sdk/src/wallet/account/operations/participation/voting.rs
+++ b/sdk/src/wallet/account/operations/participation/voting.rs
@@ -46,7 +46,7 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::vote()](crate::account::Account::vote).
     pub async fn prepare_vote(
         &self,
@@ -141,7 +141,7 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::stop_participating()](crate::account::Account::stop_participating).
     pub async fn prepare_stop_participating(&self, event_id: ParticipationEventId) -> Result<PreparedTransactionData> {
         let voting_output = self

--- a/sdk/src/wallet/account/operations/participation/voting.rs
+++ b/sdk/src/wallet/account/operations/participation/voting.rs
@@ -46,8 +46,8 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.vote()](crate::account::Account.vote)
+    /// Account method to prepare the transaction for
+    /// [Account::vote()](crate::account::Account::vote).
     pub async fn prepare_vote(
         &self,
         event_id: impl Into<Option<ParticipationEventId>> + Send,
@@ -141,8 +141,8 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.stop_participating()](crate::account::Account.stop_participating)
+    /// Account method to prepare the transaction for
+    /// [Account::stop_participating()](crate::account::Account::stop_participating).
     pub async fn prepare_stop_participating(&self, event_id: ParticipationEventId) -> Result<PreparedTransactionData> {
         let voting_output = self
             .get_voting_output()

--- a/sdk/src/wallet/account/operations/participation/voting_power.rs
+++ b/sdk/src/wallet/account/operations/participation/voting_power.rs
@@ -49,8 +49,8 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.increase_voting_power()](crate::account::Account.increase_voting_power)
+    /// Account method to prepare the transaction for
+    /// [Account::increase_voting_power()](crate::account::Account::increase_voting_power).
     pub async fn prepare_increase_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
         let token_supply = self.client().get_token_supply().await?;
 
@@ -108,8 +108,8 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.decrease_voting_power()](crate::account::Account.decrease_voting_power)
+    /// Account method to prepare the transaction for
+    /// [Account::decrease_voting_power()](crate::account::Account::decrease_voting_power)
     pub async fn prepare_decrease_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
         let token_supply = self.client().get_token_supply().await?;
         let current_output_data = self

--- a/sdk/src/wallet/account/operations/participation/voting_power.rs
+++ b/sdk/src/wallet/account/operations/participation/voting_power.rs
@@ -49,7 +49,7 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::increase_voting_power()](crate::account::Account::increase_voting_power).
     pub async fn prepare_increase_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
         let token_supply = self.client().get_token_supply().await?;
@@ -108,8 +108,8 @@ where
         self.sign_and_submit_transaction(prepared, None).await
     }
 
-    /// Account method to prepare the transaction for
-    /// [Account::decrease_voting_power()](crate::account::Account::decrease_voting_power)
+    /// Prepares the transaction for
+    /// [Account::decrease_voting_power()](crate::account::Account::decrease_voting_power).
     pub async fn prepare_decrease_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
         let token_supply = self.client().get_token_supply().await?;
         let current_output_data = self

--- a/sdk/src/wallet/account/operations/transaction/build_transaction.rs
+++ b/sdk/src/wallet/account/operations/transaction/build_transaction.rs
@@ -23,7 +23,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to build the transaction essence from the selected in and outputs
+    /// Account method to build the transaction essence from the selected in and outputs.
     pub(crate) async fn build_transaction_essence(
         &self,
         selected_transaction_data: Selected,

--- a/sdk/src/wallet/account/operations/transaction/build_transaction.rs
+++ b/sdk/src/wallet/account/operations/transaction/build_transaction.rs
@@ -23,7 +23,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to build the transaction essence from the selected in and outputs.
+    /// Builds the transaction essence from the selected in and outputs.
     pub(crate) async fn build_transaction_essence(
         &self,
         selected_transaction_data: Selected,

--- a/sdk/src/wallet/account/operations/transaction/high_level/burning_melting/melt_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/burning_melting/melt_native_token.rs
@@ -18,7 +18,9 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to melt native tokens. This happens with the foundry output which minted them, by increasing it's
+    /// Melts native tokens.
+    ///
+    /// This happens with the foundry output which minted them, by increasing it's
     /// `melted_tokens` field. This should be preferred over burning, because after burning, the foundry can never be
     /// destroyed anymore.
     pub async fn melt_native_token(
@@ -35,7 +37,7 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::melt_native_token()](crate::account::Account::melt_native_token).
     pub async fn prepare_melt_native_token(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/burning_melting/melt_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/burning_melting/melt_native_token.rs
@@ -18,7 +18,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to melt native tokens. This happens with the foundry output which minted them, by increasing it's
+    /// Account method to melt native tokens. This happens with the foundry output which minted them, by increasing it's
     /// `melted_tokens` field. This should be preferred over burning, because after burning, the foundry can never be
     /// destroyed anymore.
     pub async fn melt_native_token(
@@ -35,8 +35,8 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.melt_native_token()](crate::account::Account.melt_native_token)
+    /// Account method to prepare the transaction for
+    /// [Account::melt_native_token()](crate::account::Account::melt_native_token).
     pub async fn prepare_melt_native_token(
         &self,
         token_id: TokenId,

--- a/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
@@ -38,7 +38,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to create an alias output.
+    /// Account method to create an alias output.
     /// ```ignore
     /// let params = CreateAliasParams {
     ///     address: None,
@@ -65,8 +65,8 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.create_alias_output()](crate::account::Account.create_alias_output)
+    /// Account method to prepare the transaction for
+    /// [Account::create_alias_output()](crate::account::Account::create_alias_output).
     pub async fn prepare_create_alias_output(
         &self,
         params: Option<CreateAliasParams>,

--- a/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
@@ -38,7 +38,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to create an alias output.
+    /// Creates an alias output.
     /// ```ignore
     /// let params = CreateAliasParams {
     ///     address: None,
@@ -65,7 +65,7 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::create_alias_output()](crate::account::Account::create_alias_output).
     pub async fn prepare_create_alias_output(
         &self,
@@ -121,7 +121,7 @@ where
         self.prepare_transaction(outputs, options).await
     }
 
-    /// Get an existing alias output
+    /// Gets an existing alias output.
     pub(crate) async fn get_alias_output(&self, alias_id: Option<AliasId>) -> Option<(AliasId, OutputData)> {
         log::debug!("[get_alias_output]");
         self.details()

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
@@ -91,10 +91,9 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to create a new foundry output with minted native tokens.
-    /// Calls [Account.send()](crate::account::Account.send) internally, the options can define the
-    /// RemainderValueStrategy or custom inputs.
-    /// Address needs to be Bech32 encoded
+    /// Account method to create a new foundry output with minted native tokens.
+    /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally, the options may define the
+    /// remainder value strategy or custom inputs. Note that addresses need to be bech32-encoded.
     /// ```ignore
     /// let params = CreateNativeTokenParams {
     ///     alias_id: None,
@@ -125,7 +124,7 @@ where
             })
     }
 
-    /// Function to prepare the transaction for
+    /// Account method prepare the transaction for
     /// [Account.create_native_token()](crate::account::Account.create_native_token)
     pub async fn prepare_create_native_token(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
@@ -91,7 +91,8 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to create a new foundry output with minted native tokens.
+    /// Creates a new foundry output with minted native tokens.
+    ///
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally, the options may define the
     /// remainder value strategy or custom inputs. Note that addresses need to be bech32-encoded.
     /// ```ignore
@@ -124,7 +125,7 @@ where
             })
     }
 
-    /// Account method prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::create_native_token()](crate::account::Account::create_native_token).
     pub async fn prepare_create_native_token(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
@@ -125,7 +125,7 @@ where
     }
 
     /// Account method prepare the transaction for
-    /// [Account.create_native_token()](crate::account::Account.create_native_token)
+    /// [Account::create_native_token()](crate::account::Account::create_native_token).
     pub async fn prepare_create_native_token(
         &self,
         params: CreateNativeTokenParams,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_native_token.rs
@@ -16,7 +16,9 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to mint additional native tokens when the max supply isn't reached yet. The foundry needs to be
+    /// Mints additional native tokens.
+    ///
+    /// The max supply must not be reached yet. The foundry needs to be
     /// controlled by this account. Address needs to be Bech32 encoded. This will not change the max supply.
     /// ```ignore
     /// let tx = account.mint_native_token(
@@ -44,7 +46,7 @@ where
         Ok(transaction)
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::mint_native_token()](crate::account::Account::mint_native_token).
     pub async fn prepare_mint_native_token(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_native_token.rs
@@ -16,7 +16,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to mint additional native tokens when the max supply isn't reached yet. The foundry needs to be
+    /// Account method to mint additional native tokens when the max supply isn't reached yet. The foundry needs to be
     /// controlled by this account. Address needs to be Bech32 encoded. This will not change the max supply.
     /// ```ignore
     /// let tx = account.mint_native_token(
@@ -44,8 +44,8 @@ where
         Ok(transaction)
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.mint_native_token()](crate::account::Account.mint_native_token)
+    /// Account method to prepare the transaction for
+    /// [Account::mint_native_token()](crate::account::Account::mint_native_token).
     pub async fn prepare_mint_native_token(
         &self,
         token_id: TokenId,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -113,7 +113,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to mint nfts.
+    /// Mints NFTs.
     ///
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally. The options may define the
     /// remainder value strategy or custom inputs. Note that addresses need to be bech32-encoded.
@@ -149,7 +149,7 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::mint_nfts()](crate::account::Account::mint_nfts).
     pub async fn prepare_mint_nfts<I: IntoIterator<Item = MintNftParams> + Send>(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -114,6 +114,7 @@ where
     crate::wallet::Error: From<S::Error>,
 {
     /// Account method to mint nfts.
+    ///
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally. The options may define the
     /// remainder value strategy or custom inputs. Note that addresses need to be bech32-encoded.
     /// ```ignore
@@ -148,8 +149,8 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.mint_nfts()](crate::account::Account.mint_nfts)
+    /// Account method to prepare the transaction for
+    /// [Account::mint_nfts()](crate::account::Account::mint_nfts).
     pub async fn prepare_mint_nfts<I: IntoIterator<Item = MintNftParams> + Send>(
         &self,
         params: I,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -113,10 +113,9 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to mint nfts.
-    /// Calls [Account.send()](crate::account::Account.send) internally, the options can define the
-    /// RemainderValueStrategy or custom inputs.
-    /// Address needs to be Bech32 encoded
+    /// Account method to mint nfts.
+    /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally. The options may define the
+    /// remainder value strategy or custom inputs. Note that addresses need to be bech32-encoded.
     /// ```ignore
     /// let nft_id: [u8; 38] =
     ///     prefix_hex::decode("08e68f7616cd4948efebc6a77c4f93aed770ac53860100000000000000000000000000000000")?

--- a/sdk/src/wallet/account/operations/transaction/high_level/mod.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/mod.rs
@@ -5,6 +5,6 @@ pub(crate) mod burning_melting;
 pub(crate) mod create_alias;
 pub(crate) mod minimum_storage_deposit;
 pub(crate) mod minting;
-pub(crate) mod send_amount;
+pub(crate) mod send;
 pub(crate) mod send_native_tokens;
 pub(crate) mod send_nft;

--- a/sdk/src/wallet/account/operations/transaction/high_level/send.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send.rs
@@ -28,9 +28,9 @@ use crate::{
     },
 };
 
-/// Parameters for `send_amount()`
+/// Parameters for `send()`
 #[derive(Debug, Clone, Serialize, Deserialize, Getters)]
-pub struct SendAmountParams {
+pub struct SendParams {
     /// Bech32 encoded address
     #[getset(get = "pub")]
     address: Bech32Address,
@@ -50,7 +50,7 @@ pub struct SendAmountParams {
     expiration: Option<u32>,
 }
 
-impl SendAmountParams {
+impl SendParams {
     pub fn new(address: impl ConvertTo<Bech32Address>, amount: u64) -> Result<Self, crate::wallet::Error> {
         Ok(Self {
             address: address.convert()?,
@@ -87,20 +87,20 @@ where
     ///
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally.
     /// The options may define the remainder value strategy or custom inputs.
-    /// Addresses provided with [`SendAmountParams`] need to be bech32-encoded.
+    /// Addresses provided with [`SendParams`] need to be bech32-encoded.
     /// ```ignore
-    /// let params = [SendAmountParams::new(
+    /// let params = [SendParams::new(
     ///     "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
     ///     1_000_000)?
     /// ];
     ///
-    /// let tx = account.send_amount(params, None ).await?;
+    /// let tx = account.send(params, None ).await?;
     /// println!("Transaction created: {}", tx.transaction_id);
     /// if let Some(block_id) = tx.block_id {
     ///     println!("Block sent: {}", block_id);
     /// }
     /// ```
-    pub async fn send<I: IntoIterator<Item = SendAmountParams> + Send>(
+    pub async fn send<I: IntoIterator<Item = SendParams> + Send>(
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
@@ -116,7 +116,7 @@ where
 
     /// Account method to prepare the transaction for
     /// [Account::send()](crate::account::Account::send)
-    pub async fn prepare_send<I: IntoIterator<Item = SendAmountParams> + Send>(
+    pub async fn prepare_send<I: IntoIterator<Item = SendParams> + Send>(
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
@@ -135,7 +135,7 @@ where
         let local_time = self.client().get_time_checked().await?;
 
         let mut outputs = Vec::new();
-        for SendAmountParams {
+        for SendParams {
             address,
             amount,
             return_address,

--- a/sdk/src/wallet/account/operations/transaction/high_level/send.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send.rs
@@ -83,7 +83,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to send base coins.
+    /// Sends base coins.
     ///
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally.
     /// The options may define the remainder value strategy or custom inputs.
@@ -114,8 +114,8 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Account method to prepare the transaction for
-    /// [Account::send()](crate::account::Account::send)
+    /// Prepares the transaction for
+    /// [Account::send()](crate::account::Account::send).
     pub async fn prepare_send<I: IntoIterator<Item = SendParams> + Send>(
         &self,
         params: I,

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_amount.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_amount.rs
@@ -83,17 +83,18 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to create basic outputs with which we then will call
-    /// [Account.send()](crate::account::Account.send), the options can define the
-    /// RemainderValueStrategy or custom inputs.
-    /// Address needs to be Bech32 encoded
+    /// Account method to send a certain amount of base coins.
+    ///
+    /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally.
+    /// The options may define the remainder value strategy or custom inputs.
+    /// Addresses provided with [`SendAmountParams`] need to be bech32-encoded.
     /// ```ignore
-    /// let outputs = [SendAmountParams::new(
+    /// let params = [SendAmountParams::new(
     ///     "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
     ///     1_000_000)?
     /// ];
     ///
-    /// let tx = account.send_amount(outputs, None ).await?;
+    /// let tx = account.send_amount(params, None ).await?;
     /// println!("Transaction created: {}", tx.transaction_id);
     /// if let Some(block_id) = tx.block_id {
     ///     println!("Block sent: {}", block_id);

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_amount.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_amount.rs
@@ -83,7 +83,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to send a certain amount of base coins.
+    /// Account method to send base coins.
     ///
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally.
     /// The options may define the remainder value strategy or custom inputs.
@@ -100,7 +100,7 @@ where
     ///     println!("Block sent: {}", block_id);
     /// }
     /// ```
-    pub async fn send_amount<I: IntoIterator<Item = SendAmountParams> + Send>(
+    pub async fn send<I: IntoIterator<Item = SendAmountParams> + Send>(
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
@@ -109,14 +109,14 @@ where
         I::IntoIter: Send,
     {
         let options = options.into();
-        let prepared_transaction = self.prepare_send_amount(params, options.clone()).await?;
+        let prepared_transaction = self.prepare_send(params, options.clone()).await?;
 
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.send_amount()](crate::account::Account.send_amount)
-    pub async fn prepare_send_amount<I: IntoIterator<Item = SendAmountParams> + Send>(
+    /// Account method to prepare the transaction for
+    /// [Account::send()](crate::account::Account::send)
+    pub async fn prepare_send<I: IntoIterator<Item = SendAmountParams> + Send>(
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
@@ -124,7 +124,7 @@ where
     where
         I::IntoIter: Send,
     {
-        log::debug!("[TRANSACTION] prepare_send_amount");
+        log::debug!("[TRANSACTION] prepare_send");
         let options = options.into();
         let rent_structure = self.client().get_rent_structure().await?;
         let token_supply = self.client().get_token_supply().await?;

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
@@ -86,7 +86,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to send native tokens in basic outputs with a [`StorageDepositReturnUnlockCondition`] and an
+    /// Sends native tokens in basic outputs with a [`StorageDepositReturnUnlockCondition`] and an
     /// [`ExpirationUnlockCondition`], so that the storage deposit is returned to the sender and the sender gets access
     /// to the output again after a predefined time (default 1 day).
     /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally. The options may define the
@@ -121,7 +121,7 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::send_native_tokens()](crate::account::Account::send_native_tokens).
     pub async fn prepare_send_native_tokens<I: IntoIterator<Item = SendNativeTokensParams> + Send>(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
@@ -86,14 +86,13 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to send native tokens in basic outputs with a [StorageDepositReturnUnlockCondition] and
-    /// [ExpirationUnlockCondition], so the storage deposit gets back to the sender and also that the sender gets access
-    /// to the output again after a defined time (default 1 day),
-    /// Calls [Account.send()](crate::account::Account.send) internally, the options can define the
-    /// RemainderValueStrategy or custom inputs.
-    /// Address needs to be Bech32 encoded
+    /// Account method to send native tokens in basic outputs with a [`StorageDepositReturnUnlockCondition`] and an
+    /// [`ExpirationUnlockCondition`], so that the storage deposit is returned to the sender and the sender gets access
+    /// to the output again after a predefined time (default 1 day).
+    /// Calls [Account::send_outputs()](crate::account::Account::send_outputs) internally. The options may define the
+    /// remainder value strategy or custom inputs. Note that the address needs to be bech32-encoded.
     /// ```ignore
-    /// let outputs = [SendNativeTokensParams {
+    /// let params = [SendNativeTokensParams {
     ///     address: "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu".to_string(),
     ///     native_tokens: vec![(
     ///         TokenId::from_str("08e68f7616cd4948efebc6a77c4f93aed770ac53860100000000000000000000000000000000")?,
@@ -102,7 +101,7 @@ where
     ///     ..Default::default()
     /// }];
     ///
-    /// let tx = account.send_native_tokens(outputs, None).await?;
+    /// let tx = account.send_native_tokens(params, None).await?;
     /// println!("Transaction created: {}", tx.transaction_id);
     /// if let Some(block_id) = tx.block_id {
     ///     println!("Block sent: {}", block_id);

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
@@ -121,8 +121,8 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.send_native_tokens()](crate::account::Account.send_native_tokens)
+    /// Account method to prepare the transaction for
+    /// [Account::send_native_tokens()](crate::account::Account::send_native_tokens).
     pub async fn prepare_send_native_tokens<I: IntoIterator<Item = SendNativeTokensParams> + Send>(
         &self,
         params: I,

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
@@ -43,7 +43,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to send native tokens in basic outputs with a
+    /// Sends native tokens in basic outputs with a
     /// [`StorageDepositReturnUnlockCondition`](crate::types::block::output::unlock_condition::StorageDepositReturnUnlockCondition) and an
     /// [`ExpirationUnlockCondition`](crate::types::block::output::unlock_condition::ExpirationUnlockCondition), so that
     /// the storage deposit is returned to the sender and the sender gets access to the output again after a
@@ -79,7 +79,7 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Account method to prepare the transaction for
+    /// Prepares the transaction for
     /// [Account::send_nft()](crate::account::Account::send_nft).
     pub async fn prepare_send_nft<I: IntoIterator<Item = SendNftParams> + Send>(
         &self,

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
@@ -79,8 +79,8 @@ where
         self.sign_and_submit_transaction(prepared_transaction, options).await
     }
 
-    /// Function to prepare the transaction for
-    /// [Account.send_nft()](crate::account::Account.send_nft)
+    /// Account method to prepare the transaction for
+    /// [Account::send_nft()](crate::account::Account::send_nft).
     pub async fn prepare_send_nft<I: IntoIterator<Item = SendNftParams> + Send>(
         &self,
         params: I,

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
@@ -43,20 +43,21 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to send native tokens in basic outputs with a
-    /// [`StorageDepositReturnUnlockCondition`](crate::types::block::output::unlock_condition::StorageDepositReturnUnlockCondition) and
-    /// [`ExpirationUnlockCondition`](crate::types::block::output::unlock_condition::ExpirationUnlockCondition), so the
-    /// storage deposit gets back to the sender and also that the sender gets access to the output again after a
-    /// defined time (default 1 day), Calls [Account.send()](crate::wallet::account::Account.send)
-    /// internally, the options can define the RemainderValueStrategy. Custom inputs will be replaced with the
-    /// required nft inputs. Address needs to be Bech32 encoded
+    /// Account method to send native tokens in basic outputs with a
+    /// [`StorageDepositReturnUnlockCondition`](crate::types::block::output::unlock_condition::StorageDepositReturnUnlockCondition) and an
+    /// [`ExpirationUnlockCondition`](crate::types::block::output::unlock_condition::ExpirationUnlockCondition), so that
+    /// the storage deposit is returned to the sender and the sender gets access to the output again after a
+    /// predefined time (default 1 day).
+    /// Calls [Account::send_outputs()](crate::wallet::account::Account::send_outputs) internally. The options may
+    /// define the remainder value strategy. Note that custom inputs will be replaced with the required nft inputs
+    /// and addresses need to be bech32-encoded.
     /// ```ignore
-    /// let outputs = [SendNftParams::new(
+    /// let params = [SendNftParams::new(
     ///     "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
     ///     "0xe645042a8a082957cb4bec4927936699ee8e56048834b090379da64213ce231b",
     /// )?];
     ///
-    /// let transaction = account.send_nft(outputs, None).await?;
+    /// let transaction = account.send_nft(params, None).await?;
     ///
     /// println!(
     ///     "Transaction sent: {}/transaction/{}",

--- a/sdk/src/wallet/account/operations/transaction/mod.rs
+++ b/sdk/src/wallet/account/operations/transaction/mod.rs
@@ -38,7 +38,9 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Send a transaction, if sending a block fails, the function will return None for the block_id, but the wallet
+    /// Account method to send a transaction by specifying its outputs.
+    ///
+    /// Note that, if sending a block fails, the method will return `None` for the block id, but the wallet
     /// will retry sending the transaction during syncing.
     /// ```ignore
     /// let outputs = [
@@ -49,7 +51,7 @@ where
     ///    .finish_output(account.client.get_token_supply().await?;)?,
     /// ];
     /// let tx = account
-    ///     .send(
+    ///     .send_outputs(
     ///         outputs,
     ///         Some(TransactionOptions {
     ///             remainder_value_strategy: RemainderValueStrategy::ReuseAddress,
@@ -62,7 +64,7 @@ where
     ///     println!("Block sent: {}", block_id);
     /// }
     /// ```
-    pub async fn send(
+    pub async fn send_outputs(
         &self,
         outputs: impl Into<Vec<Output>> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,

--- a/sdk/src/wallet/account/operations/transaction/mod.rs
+++ b/sdk/src/wallet/account/operations/transaction/mod.rs
@@ -38,7 +38,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to send a transaction by specifying its outputs.
+    /// Sends a transaction by specifying its outputs.
     ///
     /// Note that, if sending a block fails, the method will return `None` for the block id, but the wallet
     /// will retry sending the transaction during syncing.
@@ -101,7 +101,7 @@ where
             .await
     }
 
-    /// Sign a transaction, submit it to a node and store it in the account
+    /// Signs a transaction, submit it to a node and store it in the account
     pub async fn sign_and_submit_transaction(
         &self,
         prepared_transaction_data: PreparedTransactionData,
@@ -122,7 +122,7 @@ where
             .await
     }
 
-    /// Validate the transaction, submit it to a node and store it in the account
+    /// Validates the transaction, submit it to a node and store it in the account
     pub async fn submit_and_store_transaction(
         &self,
         signed_transaction_data: SignedTransactionData,

--- a/sdk/src/wallet/account/operations/transaction/sign_transaction.rs
+++ b/sdk/src/wallet/account/operations/transaction/sign_transaction.rs
@@ -24,7 +24,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Account method to sign a transaction essence.
+    /// Signs a transaction essence.
     pub async fn sign_transaction_essence(
         &self,
         prepared_transaction_data: &PreparedTransactionData,

--- a/sdk/src/wallet/account/operations/transaction/sign_transaction.rs
+++ b/sdk/src/wallet/account/operations/transaction/sign_transaction.rs
@@ -24,7 +24,7 @@ impl<S: 'static + SecretManage> Account<S>
 where
     crate::wallet::Error: From<S::Error>,
 {
-    /// Function to sign a transaction essence
+    /// Account method to sign a transaction essence.
     pub async fn sign_transaction_essence(
         &self,
         prepared_transaction_data: &PreparedTransactionData,

--- a/sdk/src/wallet/bindings/nodejs/lib/Account.ts
+++ b/sdk/src/wallet/bindings/nodejs/lib/Account.ts
@@ -867,7 +867,7 @@ export class Account {
     }
 
     /**
-     * Prepare a send amount transaction, useful for offline signing.
+     * Prepare a send transaction, useful for offline signing.
      * @param params Address with amounts to send.
      * @param options The options to define a `RemainderValueStrategy`
      * or custom inputs.

--- a/sdk/src/wallet/bindings/nodejs/lib/Account.ts
+++ b/sdk/src/wallet/bindings/nodejs/lib/Account.ts
@@ -8,7 +8,7 @@ import type {
     SyncOptions,
     AccountMeta,
     Address,
-    SendAmountParams,
+    SendParams,
     SendNativeTokensParams,
     SendNftParams,
     AddressWithUnspentOutputs,
@@ -873,14 +873,14 @@ export class Account {
      * or custom inputs.
      * @returns The prepared transaction data.
      */
-    async prepareSendAmount(
-        params: SendAmountParams[],
+    async prepareSend(
+        params: SendParams[],
         options?: TransactionOptions,
     ): Promise<PreparedTransactionData> {
         const response = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'prepareSendAmount',
+                name: 'prepareSend',
                 data: {
                     params,
                     options,
@@ -976,14 +976,14 @@ export class Account {
      * or custom inputs.
      * @returns The sent transaction.
      */
-    async sendAmount(
-        params: SendAmountParams[],
+    async send(
+        params: SendParams[],
         transactionOptions?: TransactionOptions,
     ): Promise<Transaction> {
         const response = await this.messageHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'sendAmount',
+                name: 'send',
                 data: {
                     params,
                     options: transactionOptions,

--- a/sdk/src/wallet/bindings/nodejs/types/address.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/address.ts
@@ -16,8 +16,8 @@ export interface Address {
     used: boolean;
 }
 
-/** Address with a base token amount */
-export interface SendAmountParams {
+/** Address with a base coin amount */
+export interface SendParams {
     address: string;
     amount: string;
     returnAddress?: string;

--- a/sdk/src/wallet/bindings/nodejs/types/bridge/account.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/bridge/account.ts
@@ -5,7 +5,7 @@ import type {
 } from '@iota/types';
 import type { SyncOptions, FilterOptions } from '../account';
 import type {
-    SendAmountParams,
+    SendParams,
     SendNativeTokensParams,
     SendNftParams,
     GenerateAddressOptions,
@@ -280,10 +280,10 @@ export type __PrepareOutputMethod__ = {
     };
 };
 
-export type __PrepareSendAmountMethod__ = {
-    name: 'prepareSendAmount';
+export type __PrepareSendMethod__ = {
+    name: 'prepareSend';
     data: {
-        params: SendAmountParams[];
+        params: SendParams[];
         options?: TransactionOptions;
     };
 };
@@ -320,10 +320,10 @@ export type __RetryTransactionUntilIncludedMethod__ = {
     };
 };
 
-export type __SendAmountMethod__ = {
-    name: 'sendAmount';
+export type __SendMethod__ = {
+    name: 'send';
     data: {
-        params: SendAmountParams[];
+        params: SendParams[];
         options?: TransactionOptions;
     };
 };

--- a/sdk/src/wallet/bindings/nodejs/types/bridge/index.ts
+++ b/sdk/src/wallet/bindings/nodejs/types/bridge/index.ts
@@ -35,12 +35,12 @@ import type {
     __MintNativeTokenMethod__,
     __MintNftsMethod__,
     __PrepareOutputMethod__,
-    __PrepareSendAmountMethod__,
+    __PrepareSendMethod__,
     __PrepareTransactionMethod__,
     __RegisterParticipationEventsMethod__,
     __RequestFundsFromFaucetMethod__,
     __RetryTransactionUntilIncludedMethod__,
-    __SendAmountMethod__,
+    __SendMethod__,
     __SendNativeTokensMethod__,
     __SendNftMethod__,
     __SendOutputsMethod__,
@@ -131,12 +131,12 @@ export type __AccountMethod__ =
     | __MintNativeTokenMethod__
     | __MintNftsMethod__
     | __PrepareOutputMethod__
-    | __PrepareSendAmountMethod__
+    | __PrepareSendMethod__
     | __PrepareTransactionMethod__
     | __RegisterParticipationEventsMethod__
     | __RequestFundsFromFaucetMethod__
     | __RetryTransactionUntilIncludedMethod__
-    | __SendAmountMethod__
+    | __SendMethod__
     | __SendNativeTokensMethod__
     | __SendNftMethod__
     | __SendOutputsMethod__

--- a/sdk/src/wallet/message_interface/account_method.rs
+++ b/sdk/src/wallet/message_interface/account_method.rs
@@ -153,7 +153,7 @@ pub enum AccountMethod {
         alias_id: AliasId,
         options: Option<TransactionOptionsDto>,
     },
-    /// Function to destroy a foundry output with a circulating supply of 0.
+    /// Destroy a foundry output with a circulating supply of 0.
     /// Native tokens in the foundry (minted by other foundries) will be transacted to the controlling alias
     /// Expected response: [`SentTransaction`](crate::wallet::message_interface::Response::SentTransaction)
     #[serde(rename_all = "camelCase")]

--- a/sdk/src/wallet/message_interface/account_method.rs
+++ b/sdk/src/wallet/message_interface/account_method.rs
@@ -42,7 +42,7 @@ use crate::{
             },
             FilterOptions,
         },
-        SendAmountParams, SendNativeTokensParams, SendNftParams,
+        SendNativeTokensParams, SendNftParams, SendParams,
     },
     U256,
 };
@@ -294,11 +294,11 @@ pub enum AccountMethod {
         outputs: Vec<OutputDto>,
         options: Option<TransactionOptionsDto>,
     },
-    /// Prepare send amount.
+    /// Prepare to send base coins.
     /// Expected response: [`PreparedTransaction`](crate::wallet::message_interface::Response::PreparedTransaction)
     #[serde(rename_all = "camelCase")]
-    PrepareSendAmount {
-        params: Vec<SendAmountParams>,
+    PrepareSend {
+        params: Vec<SendParams>,
         options: Option<TransactionOptionsDto>,
     },
     /// Retries (promotes or reattaches) a transaction sent from the account for a provided transaction id until it's
@@ -320,11 +320,11 @@ pub enum AccountMethod {
         /// Sync options
         options: Option<SyncOptions>,
     },
-    /// Send amount.
+    /// Send base coins.
     /// Expected response: [`SentTransaction`](crate::wallet::message_interface::Response::SentTransaction)
     #[serde(rename_all = "camelCase")]
-    SendAmount {
-        params: Vec<SendAmountParams>,
+    Send {
+        params: Vec<SendParams>,
         options: Option<TransactionOptionsDto>,
     },
     /// Send native tokens.

--- a/sdk/src/wallet/message_interface/message_handler.rs
+++ b/sdk/src/wallet/message_interface/message_handler.rs
@@ -754,7 +754,7 @@ impl WalletMessageHandler {
                 })
                 .await
             }
-            AccountMethod::PrepareSendAmount { params, options } => {
+            AccountMethod::PrepareSend { params, options } => {
                 convert_async_panics(|| async {
                     let data = account
                         .prepare_send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
@@ -793,7 +793,7 @@ impl WalletMessageHandler {
                 .await
             }
             AccountMethod::SyncAccount { options } => Ok(Response::Balance(account.sync(options).await?)),
-            AccountMethod::SendAmount { params, options } => {
+            AccountMethod::Send { params, options } => {
                 convert_async_panics(|| async {
                     let transaction = account
                         .send(params, options.map(TransactionOptions::try_from_dto).transpose()?)

--- a/sdk/src/wallet/message_interface/message_handler.rs
+++ b/sdk/src/wallet/message_interface/message_handler.rs
@@ -844,7 +844,7 @@ impl WalletMessageHandler {
                 convert_async_panics(|| async {
                     let token_supply = account.client().get_token_supply().await?;
                     let transaction = account
-                        .send(
+                        .send_outputs(
                             outputs
                                 .into_iter()
                                 .map(|o| Ok(Output::try_from_dto(o, token_supply)?))

--- a/sdk/src/wallet/message_interface/message_handler.rs
+++ b/sdk/src/wallet/message_interface/message_handler.rs
@@ -757,7 +757,7 @@ impl WalletMessageHandler {
             AccountMethod::PrepareSendAmount { params, options } => {
                 convert_async_panics(|| async {
                     let data = account
-                        .prepare_send_amount(params, options.map(TransactionOptions::try_from_dto).transpose()?)
+                        .prepare_send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                         .await?;
                     Ok(Response::PreparedTransaction(PreparedTransactionDataDto::from(&data)))
                 })
@@ -796,7 +796,7 @@ impl WalletMessageHandler {
             AccountMethod::SendAmount { params, options } => {
                 convert_async_panics(|| async {
                     let transaction = account
-                        .send_amount(params, options.map(TransactionOptions::try_from_dto).transpose()?)
+                        .send(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                         .await?;
                     Ok(Response::SentTransaction(TransactionDto::from(&transaction)))
                 })

--- a/sdk/src/wallet/message_interface/response.rs
+++ b/sdk/src/wallet/message_interface/response.rs
@@ -75,7 +75,7 @@ pub enum Response {
     /// [`UnspentOutputs`](crate::wallet::message_interface::AccountMethod::UnspentOutputs)
     OutputsData(Vec<OutputDataDto>),
     /// Response for
-    /// [`PrepareSendAmount`](crate::wallet::message_interface::AccountMethod::PrepareSendAmount),
+    /// [`PrepareSend`](crate::wallet::message_interface::AccountMethod::PrepareSend),
     /// [`PrepareTransaction`](crate::wallet::message_interface::AccountMethod::PrepareTransaction)
     PreparedTransaction(PreparedTransactionDataDto),
     /// Response for
@@ -116,9 +116,8 @@ pub enum Response {
     /// [`ConsolidateOutputs`](crate::wallet::message_interface::AccountMethod::ConsolidateOutputs)
     /// [`ClaimOutputs`](crate::wallet::message_interface::AccountMethod::ClaimOutputs)
     /// [`CreateAliasOutput`](crate::wallet::message_interface::AccountMethod::CreateAliasOutput)
-    /// [`SendAmount`](crate::wallet::message_interface::AccountMethod::SendAmount),
     /// [`MintNfts`](crate::wallet::message_interface::AccountMethod::MintNfts),
-    /// [`SendAmount`](crate::wallet::message_interface::AccountMethod::SendAmount),
+    /// [`Send`](crate::wallet::message_interface::AccountMethod::Send),
     /// [`SendNativeTokens`](crate::wallet::message_interface::AccountMethod::SendNativeTokens),
     /// [`SendNft`](crate::wallet::message_interface::AccountMethod::SendNft),
     /// [`SendOutputs`](crate::wallet::message_interface::AccountMethod::SendOutputs)

--- a/sdk/src/wallet/mod.rs
+++ b/sdk/src/wallet/mod.rs
@@ -37,7 +37,7 @@ pub use self::{
     account::{
         operations::transaction::high_level::{
             minting::{create_native_token::CreateNativeTokenParams, mint_nfts::MintNftParams},
-            send_amount::SendAmountParams,
+            send::SendParams,
             send_native_tokens::SendNativeTokensParams,
             send_nft::SendNftParams,
         },

--- a/sdk/tests/wallet/balance.rs
+++ b/sdk/tests/wallet/balance.rs
@@ -113,7 +113,7 @@ async fn balance_expiration() -> Result<()> {
         .finish_output(token_supply)?];
 
     let balance_before_tx = account_0.balance().await?;
-    let tx = account_0.send(outputs, None).await?;
+    let tx = account_0.send_outputs(outputs, None).await?;
     let balance_after_tx = account_0.balance().await?;
     // Total doesn't change before syncing after tx got confirmed
     assert_eq!(
@@ -160,7 +160,7 @@ async fn balance_expiration() -> Result<()> {
             *account_1.addresses().await?[0].address().as_ref(),
         )])
         .finish_output(token_supply)?];
-    let _tx = account_2.send(outputs, None).await?;
+    let _tx = account_2.send_outputs(outputs, None).await?;
 
     tear_down(storage_path)
 }

--- a/sdk/tests/wallet/bech32_hrp_validation.rs
+++ b/sdk/tests/wallet/bech32_hrp_validation.rs
@@ -4,7 +4,7 @@
 use iota_sdk::{
     client::Error as ClientError,
     types::block::address::{Bech32Address, ToBech32Ext},
-    wallet::{account::OutputParams, Error, Result, SendAmountParams},
+    wallet::{account::OutputParams, Error, Result, SendParams},
 };
 
 use crate::wallet::common::{make_wallet, setup, tear_down};
@@ -21,7 +21,7 @@ async fn bech32_hrp_send_amount() -> Result<()> {
 
     let error = account
         .send(
-            [SendAmountParams::new(
+            [SendParams::new(
                 Bech32Address::try_new("wronghrp", account.addresses().await?[0].address())?,
                 1_000_000,
             )?],

--- a/sdk/tests/wallet/bech32_hrp_validation.rs
+++ b/sdk/tests/wallet/bech32_hrp_validation.rs
@@ -20,7 +20,7 @@ async fn bech32_hrp_send_amount() -> Result<()> {
     let account = wallet.create_account().finish().await?;
 
     let error = account
-        .send_amount(
+        .send(
             [SendAmountParams::new(
                 Bech32Address::try_new("wronghrp", account.addresses().await?[0].address())?,
                 1_000_000,

--- a/sdk/tests/wallet/burn_outputs.rs
+++ b/sdk/tests/wallet/burn_outputs.rs
@@ -79,7 +79,7 @@ async fn mint_and_burn_expired_nft() -> Result<()> {
         ])
         .finish_output(token_supply)?];
 
-    let transaction = account_0.send(outputs, None).await?;
+    let transaction = account_0.send_outputs(outputs, None).await?;
     account_0
         .retry_transaction_until_included(&transaction.transaction_id, None, None)
         .await?;

--- a/sdk/tests/wallet/claim_outputs.rs
+++ b/sdk/tests/wallet/claim_outputs.rs
@@ -27,7 +27,7 @@ async fn claim_2_basic_micro_outputs() -> Result<()> {
 
     let micro_amount = 1;
     let tx = accounts[1]
-        .send_amount(
+        .send(
             [
                 SendAmountParams::new(*accounts[0].addresses().await?[0].address(), micro_amount)?,
                 SendAmountParams::new(*accounts[0].addresses().await?[0].address(), micro_amount)?,
@@ -77,7 +77,7 @@ async fn claim_1_of_2_basic_outputs() -> Result<()> {
 
     let amount = 10;
     let tx = accounts[1]
-        .send_amount(
+        .send(
             [
                 SendAmountParams::new(*accounts[0].addresses().await?[0].address(), amount)?,
                 SendAmountParams::new(*accounts[0].addresses().await?[0].address(), 0)?,
@@ -519,7 +519,7 @@ async fn claim_basic_micro_output_error() -> Result<()> {
 
     let micro_amount = 1;
     let tx = account_0
-        .send_amount(
+        .send(
             [SendAmountParams::new(
                 *account_1.addresses().await?[0].address(),
                 micro_amount,

--- a/sdk/tests/wallet/claim_outputs.rs
+++ b/sdk/tests/wallet/claim_outputs.rs
@@ -143,7 +143,7 @@ async fn claim_2_basic_outputs_no_outputs_in_claim_account() -> Result<()> {
 
     let outputs = vec![output; 2];
 
-    let tx = account_0.send(outputs, None).await?;
+    let tx = account_0.send_outputs(outputs, None).await?;
 
     account_0
         .retry_transaction_until_included(&tx.transaction_id, None, None)
@@ -325,7 +325,7 @@ async fn claim_2_native_tokens_no_outputs_in_claim_account() -> Result<()> {
     let token_supply = account_0.client().get_token_supply().await?;
 
     let tx = account_0
-        .send(
+        .send_outputs(
             [
                 BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
                     .add_unlock_condition(AddressUnlockCondition::new(
@@ -422,7 +422,7 @@ async fn claim_2_nft_outputs() -> Result<()> {
             .finish_output(token_supply)?,
     ];
 
-    let tx = accounts[1].send(outputs, None).await?;
+    let tx = accounts[1].send_outputs(outputs, None).await?;
     accounts[1]
         .retry_transaction_until_included(&tx.transaction_id, None, None)
         .await?;
@@ -483,7 +483,7 @@ async fn claim_2_nft_outputs_no_outputs_in_claim_account() -> Result<()> {
             .finish_output(token_supply)?,
     ];
 
-    let tx = account_0.send(outputs, None).await?;
+    let tx = account_0.send_outputs(outputs, None).await?;
     account_0
         .retry_transaction_until_included(&tx.transaction_id, None, None)
         .await?;

--- a/sdk/tests/wallet/claim_outputs.rs
+++ b/sdk/tests/wallet/claim_outputs.rs
@@ -8,7 +8,7 @@ use iota_sdk::{
     },
     wallet::{
         account::{OutputsToClaim, TransactionOptions},
-        CreateNativeTokenParams, Result, SendAmountParams, SendNativeTokensParams,
+        CreateNativeTokenParams, Result, SendNativeTokensParams, SendParams,
     },
     U256,
 };
@@ -29,8 +29,8 @@ async fn claim_2_basic_micro_outputs() -> Result<()> {
     let tx = accounts[1]
         .send(
             [
-                SendAmountParams::new(*accounts[0].addresses().await?[0].address(), micro_amount)?,
-                SendAmountParams::new(*accounts[0].addresses().await?[0].address(), micro_amount)?,
+                SendParams::new(*accounts[0].addresses().await?[0].address(), micro_amount)?,
+                SendParams::new(*accounts[0].addresses().await?[0].address(), micro_amount)?,
             ],
             TransactionOptions {
                 allow_micro_amount: true,
@@ -79,8 +79,8 @@ async fn claim_1_of_2_basic_outputs() -> Result<()> {
     let tx = accounts[1]
         .send(
             [
-                SendAmountParams::new(*accounts[0].addresses().await?[0].address(), amount)?,
-                SendAmountParams::new(*accounts[0].addresses().await?[0].address(), 0)?,
+                SendParams::new(*accounts[0].addresses().await?[0].address(), amount)?,
+                SendParams::new(*accounts[0].addresses().await?[0].address(), 0)?,
             ],
             TransactionOptions {
                 allow_micro_amount: true,
@@ -520,7 +520,7 @@ async fn claim_basic_micro_output_error() -> Result<()> {
     let micro_amount = 1;
     let tx = account_0
         .send(
-            [SendAmountParams::new(
+            [SendParams::new(
                 *account_1.addresses().await?[0].address(),
                 micro_amount,
             )?],

--- a/sdk/tests/wallet/consolidation.rs
+++ b/sdk/tests/wallet/consolidation.rs
@@ -19,7 +19,7 @@ async fn consolidation() -> Result<()> {
     // Send 10 outputs to account_1
     let amount = 1_000_000;
     let tx = account_0
-        .send_amount(
+        .send(
             vec![SendAmountParams::new(*account_1.addresses().await?[0].address(), amount)?; 10],
             None,
         )

--- a/sdk/tests/wallet/consolidation.rs
+++ b/sdk/tests/wallet/consolidation.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk::wallet::{Result, SendAmountParams};
+use iota_sdk::wallet::{Result, SendParams};
 
 use crate::wallet::common::{create_accounts_with_funds, make_wallet, setup, tear_down};
 
@@ -20,7 +20,7 @@ async fn consolidation() -> Result<()> {
     let amount = 1_000_000;
     let tx = account_0
         .send(
-            vec![SendAmountParams::new(*account_1.addresses().await?[0].address(), amount)?; 10],
+            vec![SendParams::new(*account_1.addresses().await?[0].address(), amount)?; 10],
             None,
         )
         .await?;

--- a/sdk/tests/wallet/syncing.rs
+++ b/sdk/tests/wallet/syncing.rs
@@ -114,7 +114,7 @@ async fn sync_only_most_basic_outputs() -> Result<()> {
             .finish_output(token_supply)?,
     ];
 
-    let tx = account_0.send(outputs, None).await?;
+    let tx = account_0.send_outputs(outputs, None).await?;
     account_0
         .retry_transaction_until_included(&tx.transaction_id, None, None)
         .await?;

--- a/sdk/tests/wallet/transactions.rs
+++ b/sdk/tests/wallet/transactions.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk::wallet::{account::TransactionOptions, MintNftParams, Result, SendAmountParams, SendNftParams};
+use iota_sdk::wallet::{account::TransactionOptions, MintNftParams, Result, SendNftParams, SendParams};
 
 use crate::wallet::common::{create_accounts_with_funds, make_wallet, setup, tear_down};
 
@@ -19,10 +19,7 @@ async fn send_amount() -> Result<()> {
     let amount = 1_000_000;
     let tx = account_0
         .send(
-            [SendAmountParams::new(
-                *account_1.addresses().await?[0].address(),
-                amount,
-            )?],
+            [SendParams::new(*account_1.addresses().await?[0].address(), amount)?],
             None,
         )
         .await?;
@@ -52,7 +49,7 @@ async fn send_amount_127_outputs() -> Result<()> {
     let tx = account_0
         .send(
             vec![
-                SendAmountParams::new(
+                SendParams::new(
                     *account_1.addresses().await?[0].address(),
                     amount,
                 )?;
@@ -88,7 +85,7 @@ async fn send_amount_custom_input() -> Result<()> {
     let amount = 1_000_000;
     let tx = account_0
         .send(
-            vec![SendAmountParams::new(*account_1.addresses().await?[0].address(), amount)?; 10],
+            vec![SendParams::new(*account_1.addresses().await?[0].address(), amount)?; 10],
             None,
         )
         .await?;
@@ -104,10 +101,7 @@ async fn send_amount_custom_input() -> Result<()> {
     let custom_input = &account_1.unspent_outputs(None).await?[5];
     let tx = account_1
         .send(
-            [SendAmountParams::new(
-                *account_0.addresses().await?[0].address(),
-                amount,
-            )?],
+            [SendParams::new(*account_0.addresses().await?[0].address(), amount)?],
             Some(TransactionOptions {
                 custom_inputs: Some(vec![custom_input.output_id]),
                 ..Default::default()
@@ -177,10 +171,7 @@ async fn send_with_note() -> Result<()> {
     let amount = 1_000_000;
     let tx = account_0
         .send(
-            [SendAmountParams::new(
-                *account_1.addresses().await?[0].address(),
-                amount,
-            )?],
+            [SendParams::new(*account_1.addresses().await?[0].address(), amount)?],
             Some(TransactionOptions {
                 note: Some(String::from("send_with_note")),
                 ..Default::default()

--- a/sdk/tests/wallet/transactions.rs
+++ b/sdk/tests/wallet/transactions.rs
@@ -18,7 +18,7 @@ async fn send_amount() -> Result<()> {
 
     let amount = 1_000_000;
     let tx = account_0
-        .send_amount(
+        .send(
             [SendAmountParams::new(
                 *account_1.addresses().await?[0].address(),
                 amount,
@@ -50,9 +50,9 @@ async fn send_amount_127_outputs() -> Result<()> {
 
     let amount = 1_000_000;
     let tx = account_0
-        .send_amount(
+        .send(
             vec![
-SendAmountParams::new(
+                SendAmountParams::new(
                     *account_1.addresses().await?[0].address(),
                     amount,
                 )?;
@@ -87,7 +87,7 @@ async fn send_amount_custom_input() -> Result<()> {
     // Send 10 outputs to account_1
     let amount = 1_000_000;
     let tx = account_0
-        .send_amount(
+        .send(
             vec![SendAmountParams::new(*account_1.addresses().await?[0].address(), amount)?; 10],
             None,
         )
@@ -103,7 +103,7 @@ async fn send_amount_custom_input() -> Result<()> {
     // Send back with custom provided input
     let custom_input = &account_1.unspent_outputs(None).await?[5];
     let tx = account_1
-        .send_amount(
+        .send(
             [SendAmountParams::new(
                 *account_0.addresses().await?[0].address(),
                 amount,
@@ -176,7 +176,7 @@ async fn send_with_note() -> Result<()> {
 
     let amount = 1_000_000;
     let tx = account_0
-        .send_amount(
+        .send(
             [SendAmountParams::new(
                 *account_1.addresses().await?[0].address(),
                 amount,


### PR DESCRIPTION
# Description of change

Renames some account methods related to sending as described in #586 .

## Links to any relevant issues

#586 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Unit tests