### PR TITLE
chore(examples): remove symlinks

### DIFF
--- a/bindings/nodejs/examples/.env.example
+++ b/bindings/nodejs/examples/.env.example
@@ -1,1 +1,20 @@
-../../../sdk/examples/.env.example
+# This file contains environment variables that are used across all of our SDK examples including the bindings.
+# Make sure to change the mnemonic variables to something new if you want to run the examples from a fresh state
+# and without any interference by other users.
+# You can create a new random mnemonic by running: `cargo run --package cli-wallet -- mnemonic`.
+
+# Mnemonics (Don't ever use them to manage real funds!)
+NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1="endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river"
+NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_2="width scatter jaguar sponsor erosion enable cave since ancient first garden royal luggage exchange ritual exotic play wall clinic ride autumn divert spin exchange"
+# The Wallet database folder used to store account data
+WALLET_DB_PATH="./example-walletdb"
+# The Stronghold snapshot file location used to store secrets
+STRONGHOLD_SNAPSHOT_PATH="./example.stronghold"
+# The password to unlock the Stronghold snapshot file (Don't use it to protect real secrets!)
+STRONGHOLD_PASSWORD="24?drowssap"
+# The node URL to issue transactions with
+NODE_URL="https://api.testnet.shimmer.network"
+# The faucet URL to request test coins from
+FAUCET_URL="https://faucet.testnet.shimmer.network/api/enqueue"
+# The explorer URL to look up transactions, blocks, addresses and more
+EXPLORER_URL="https://explorer.shimmer.network/testnet"

--- a/bindings/python/examples/.env.example
+++ b/bindings/python/examples/.env.example
@@ -1,1 +1,20 @@
-../../../sdk/examples/.env.example
+# This file contains environment variables that are used across all of our SDK examples including the bindings.
+# Make sure to change the mnemonic variables to something new if you want to run the examples from a fresh state
+# and without any interference by other users.
+# You can create a new random mnemonic by running: `cargo run --package cli-wallet -- mnemonic`.
+
+# Mnemonics (Don't ever use them to manage real funds!)
+NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1="endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river"
+NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_2="width scatter jaguar sponsor erosion enable cave since ancient first garden royal luggage exchange ritual exotic play wall clinic ride autumn divert spin exchange"
+# The Wallet database folder used to store account data
+WALLET_DB_PATH="./example-walletdb"
+# The Stronghold snapshot file location used to store secrets
+STRONGHOLD_SNAPSHOT_PATH="./example.stronghold"
+# The password to unlock the Stronghold snapshot file (Don't use it to protect real secrets!)
+STRONGHOLD_PASSWORD="24?drowssap"
+# The node URL to issue transactions with
+NODE_URL="https://api.testnet.shimmer.network"
+# The faucet URL to request test coins from
+FAUCET_URL="https://faucet.testnet.shimmer.network/api/enqueue"
+# The explorer URL to look up transactions, blocks, addresses and more
+EXPLORER_URL="https://explorer.shimmer.network/testnet"

--- a/sdk/src/wallet/bindings/nodejs/examples/.env.example
+++ b/sdk/src/wallet/bindings/nodejs/examples/.env.example
@@ -1,1 +1,20 @@
-../../../../../examples/.env.example
+# This file contains environment variables that are used across all of our SDK examples including the bindings.
+# Make sure to change the mnemonic variables to something new if you want to run the examples from a fresh state
+# and without any interference by other users.
+# You can create a new random mnemonic by running: `cargo run --package cli-wallet -- mnemonic`.
+
+# Mnemonics (Don't ever use them to manage real funds!)
+NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1="endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river"
+NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_2="width scatter jaguar sponsor erosion enable cave since ancient first garden royal luggage exchange ritual exotic play wall clinic ride autumn divert spin exchange"
+# The Wallet database folder used to store account data
+WALLET_DB_PATH="./example-walletdb"
+# The Stronghold snapshot file location used to store secrets
+STRONGHOLD_SNAPSHOT_PATH="./example.stronghold"
+# The password to unlock the Stronghold snapshot file (Don't use it to protect real secrets!)
+STRONGHOLD_PASSWORD="24?drowssap"
+# The node URL to issue transactions with
+NODE_URL="https://api.testnet.shimmer.network"
+# The faucet URL to request test coins from
+FAUCET_URL="https://faucet.testnet.shimmer.network/api/enqueue"
+# The explorer URL to look up transactions, blocks, addresses and more
+EXPLORER_URL="https://explorer.shimmer.network/testnet"


### PR DESCRIPTION
# Description of change

We have to remove the symlinks and use hard copies instead again of the `.env.example` in the bindings examples, because unlike `cp` a file copy in IDEs usually makes a copy of the symlink.

## Links to any relevant issues

None

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
