### PR TITLE
Fix: added default to fix custom serde impl

### DIFF
--- a/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
@@ -24,13 +24,13 @@ pub struct CreateAliasParams {
     /// address of the account
     pub address: Option<Bech32Address>,
     /// Immutable alias metadata
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     pub immutable_metadata: Option<Vec<u8>>,
     /// Alias metadata
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     pub metadata: Option<Vec<u8>>,
     /// Alias state metadata
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     pub state_metadata: Option<Vec<u8>>,
 }
 

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
@@ -33,7 +33,7 @@ pub struct CreateNativeTokenParams {
     /// Maximum supply
     pub maximum_supply: U256,
     /// Foundry metadata
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     pub foundry_metadata: Option<Vec<u8>>,
 }
 

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -34,18 +34,18 @@ pub struct MintNftParams {
     sender: Option<Bech32Address>,
     /// NFT metadata feature.
     #[getset(get = "pub")]
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     metadata: Option<Vec<u8>>,
     /// NFT tag feature.
     #[getset(get = "pub")]
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     tag: Option<Vec<u8>>,
     /// NFT issuer feature.
     #[getset(get = "pub")]
     issuer: Option<Bech32Address>,
     /// NFT immutable metadata feature.
     #[getset(get = "pub")]
-    #[serde(with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
     immutable_metadata: Option<Vec<u8>>,
 }
 


### PR DESCRIPTION
# Description of change

Option usually gets turned into None or Some with custom impl (`option_prefix_hex_vec`)
When not supplying the field (so not `field: none`, but nonexistent in the json)), serde skips the custom "with" and thus the entire field is missing.

the default, adds a None when not supplying the field

Fixes #717 