### PR TITLE
same storage and stronghold paths in all examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,16 +11,10 @@
 
 # Storages/databases
 /storage
-alice-database
 test-storage
 wallet/test-storage
-**/walletdb
-offline_walletdb
-online_walletdb
-/pingdb
-/pongdb
+**/*walletdb
 backup
-example-walletdb
 
 # JSON files
 address.json

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -81,7 +81,7 @@ wallet_options = {
 
 secret_manager = StrongholdSecretManager("wallet.stronghold", "some_hopefully_secure_password")
 
-wallet = Wallet('./alice-database', wallet_options, coin_type=CoinType.SHIMMER, secret_manager)
+wallet = Wallet('./alice-walletdb', wallet_options, coin_type=CoinType.SHIMMER, secret_manager)
 
 # Store the mnemonic in the Stronghold snapshot. This only needs to be done once
 account = wallet.store_mnemonic("flame fever pig forward exact dash body idea link scrub tennis minute " +

--- a/bindings/python/examples/how_tos/accounts_and_addresses/check_balance.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/check_balance.py
@@ -1,9 +1,14 @@
 from iota_sdk import Wallet
+from dotenv import load_dotenv
 import json
+import os
 
 # This example checks the balance of an account.
 
-wallet = Wallet('./alice-database')
+# This example uses secrets in environment variables for simplicity which should not be done in production.
+load_dotenv()
+
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/accounts_and_addresses/consolidate_outputs.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/consolidate_outputs.py
@@ -11,7 +11,7 @@ load_dotenv()
 if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception('.env STRONGHOLD_PASSWORD is undefined, see .env.example')
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 wallet.set_stronghold_password(os.environ['STRONGHOLD_PASSWORD'])
 
 account = wallet.get_account('Alice')

--- a/bindings/python/examples/how_tos/accounts_and_addresses/create_account.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/create_account.py
@@ -20,9 +20,9 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")
 
 secret_manager = StrongholdSecretManager(
-    "wallet.stronghold", os.environ['STRONGHOLD_PASSWORD'])
+    os.environ['STRONGHOLD_SNAPSHOT_PATH'], os.environ['STRONGHOLD_PASSWORD'])
 
-wallet = Wallet('./alice-database', client_options, coin_type, secret_manager)
+wallet = Wallet(os.environ['WALLET_DB_PATH'], client_options, coin_type, secret_manager)
 
 if 'NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1' not in os.environ:
     raise Exception(".env mnemonic is undefined, see .env.example")

--- a/bindings/python/examples/how_tos/accounts_and_addresses/create_address.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/create_address.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 # This example generates a new address.
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")

--- a/bindings/python/examples/how_tos/accounts_and_addresses/list_accounts.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/list_accounts.py
@@ -1,8 +1,13 @@
 from iota_sdk import Wallet
+from dotenv import load_dotenv
+import os
 
 # This example lists all accounts in the wallet.
 
-wallet = Wallet('./alice-database')
+# This example uses secrets in environment variables for simplicity which should not be done in production.
+load_dotenv()
+
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 for account in wallet.get_accounts():
     print(account['alias'])

--- a/bindings/python/examples/how_tos/accounts_and_addresses/list_addresses.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/list_addresses.py
@@ -1,8 +1,13 @@
 from iota_sdk import Wallet
+from dotenv import load_dotenv
+import os
 
 # This example lists all addresses in the account.
 
-wallet = Wallet('./alice-database')
+# This example uses secrets in environment variables for simplicity which should not be done in production.
+load_dotenv()
+
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/accounts_and_addresses/list_outputs.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/list_outputs.py
@@ -1,8 +1,13 @@
 from iota_sdk import Wallet
+from dotenv import load_dotenv
+import os
 
 # In this example we will get outputs stored in the account
 
-wallet = Wallet('./alice-database')
+# This example uses secrets in environment variables for simplicity which should not be done in production.
+load_dotenv()
+
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 account.sync()

--- a/bindings/python/examples/how_tos/accounts_and_addresses/list_transactions.py
+++ b/bindings/python/examples/how_tos/accounts_and_addresses/list_transactions.py
@@ -1,8 +1,13 @@
 from iota_sdk import Wallet
+from dotenv import load_dotenv
+import os
 
 # In this example we will list transactions
 
-wallet = Wallet('./alice-database')
+# This example uses secrets in environment variables for simplicity which should not be done in production.
+load_dotenv()
+
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 account.sync({ 'syncIncomingTransactions': True })

--- a/bindings/python/examples/how_tos/advanced_transactions/advanced_transaction.py
+++ b/bindings/python/examples/how_tos/advanced_transactions/advanced_transaction.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 # This example sends a transaction with a timelock.
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/advanced_transactions/claim_transaction.py
+++ b/bindings/python/examples/how_tos/advanced_transactions/claim_transaction.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will claim outputs that have additional unlock conditions as expiration or storage deposit return
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/advanced_transactions/send_micro_transaction.py
+++ b/bindings/python/examples/how_tos/advanced_transactions/send_micro_transaction.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will send an amount below the minimum storage deposit
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/alias/create.py
+++ b/bindings/python/examples/how_tos/alias/create.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will create an alias ouput
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/alias/destroy.py
+++ b/bindings/python/examples/how_tos/alias/destroy.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will destroy an alias output
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/alias_wallet/request_funds.py
+++ b/bindings/python/examples/how_tos/alias_wallet/request_funds.py
@@ -10,7 +10,7 @@ load_dotenv()
 FAUCET_URL = os.environ.get(
     'FAUCET_URL', 'https://faucet.testnet.shimmer.network/api/enqueue')
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 balance = account.sync(None)

--- a/bindings/python/examples/how_tos/alias_wallet/transaction.py
+++ b/bindings/python/examples/how_tos/alias_wallet/transaction.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 sync_options = SyncOptions(alias=AliasSyncOptions(basic_outputs=True))
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/native_tokens/burn.py
+++ b/bindings/python/examples/how_tos/native_tokens/burn.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will burn native tokens
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/native_tokens/create.py
+++ b/bindings/python/examples/how_tos/native_tokens/create.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will create native tokens
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/native_tokens/destroy_foundry.py
+++ b/bindings/python/examples/how_tos/native_tokens/destroy_foundry.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will destroy a foundry
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/native_tokens/melt.py
+++ b/bindings/python/examples/how_tos/native_tokens/melt.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will decrease the native token supply
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/native_tokens/mint.py
+++ b/bindings/python/examples/how_tos/native_tokens/mint.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will mint native tokens
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/native_tokens/send.py
+++ b/bindings/python/examples/how_tos/native_tokens/send.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will send native tokens
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/nfts/burn_nft.py
+++ b/bindings/python/examples/how_tos/nfts/burn_nft.py
@@ -5,7 +5,7 @@ import os
 load_dotenv()
 
 # In this example we will burn an NFT
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")

--- a/bindings/python/examples/how_tos/nfts/mint_nft.py
+++ b/bindings/python/examples/how_tos/nfts/mint_nft.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will mint an nft
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")

--- a/bindings/python/examples/how_tos/nfts/send_nft.py
+++ b/bindings/python/examples/how_tos/nfts/send_nft.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will send an nft
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")

--- a/bindings/python/examples/how_tos/simple_transaction/request_funds.py
+++ b/bindings/python/examples/how_tos/simple_transaction/request_funds.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 FAUCET_URL = os.environ.get('FAUCET_URL', 'https://faucet.testnet.shimmer.network/api/enqueue')
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/how_tos/simple_transaction/simple_transaction.py
+++ b/bindings/python/examples/how_tos/simple_transaction/simple_transaction.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # This example sends a transaction.
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/wallet/12-prepare_output.py
+++ b/bindings/python/examples/wallet/12-prepare_output.py
@@ -7,7 +7,7 @@ load_dotenv()
 
 # In this example we will prepare an output with an address and expiration unlock condition and send it
 
-wallet = Wallet("./alice-database")
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account("Alice")
 

--- a/bindings/python/examples/wallet/13-check-unlock-conditions.py
+++ b/bindings/python/examples/wallet/13-check-unlock-conditions.py
@@ -1,11 +1,12 @@
 from iota_sdk import Wallet, Utils
 from dotenv import load_dotenv
+import os
 
 load_dotenv()
 
 # In this example we check if an output has only an address unlock condition and that the address is from the account.
 
-wallet = Wallet("./alice-database")
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account("Alice")
 

--- a/bindings/python/examples/wallet/backup.py
+++ b/bindings/python/examples/wallet/backup.py
@@ -18,7 +18,7 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")
 
 secret_manager = StrongholdSecretManager(
-    "wallet.stronghold", os.environ['STRONGHOLD_PASSWORD'])
+    os.environ['STRONGHOLD_SNAPSHOT_PATH'], os.environ['STRONGHOLD_PASSWORD'])
 
 wallet = Wallet('./backup-database', client_options,
                     coin_type, secret_manager)

--- a/bindings/python/examples/wallet/create_alias.py
+++ b/bindings/python/examples/wallet/create_alias.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # In this example we will create an alias output
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/wallet/destroy_alias.py
+++ b/bindings/python/examples/wallet/destroy_alias.py
@@ -9,7 +9,7 @@ load_dotenv()
 # TODO: replace with your own values.
 ALIAS_ID = "0x982667c59ade8ab8a99188f4de38c68b97fc2ca7ba28a1e9d8d683996247e152"
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/python/examples/wallet/get_client.py
+++ b/bindings/python/examples/wallet/get_client.py
@@ -1,8 +1,10 @@
 from iota_sdk import Wallet
+from dotenv import load_dotenv
+import os
 
 # This example gets a client from the wallet.
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 client = wallet.get_client()
 

--- a/bindings/python/examples/wallet/logger.py
+++ b/bindings/python/examples/wallet/logger.py
@@ -29,7 +29,7 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
 
 secret_manager = StrongholdSecretManager("wallet.stronghold", os.environ["STRONGHOLD_PASSWORD"])
 
-wallet = Wallet('./alice-database', client_options,
+wallet = Wallet(os.environ['WALLET_DB_PATH'], client_options,
                     coin_type, secret_manager)
 
 if 'NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1' not in os.environ:

--- a/bindings/python/examples/wallet/migrate-stronghold-snapshot-v2-to-v3.py
+++ b/bindings/python/examples/wallet/migrate-stronghold-snapshot-v2-to-v3.py
@@ -1,5 +1,7 @@
 import iota_sdk
 from iota_sdk import Wallet, StrongholdSecretManager, CoinType
+from dotenv import load_dotenv
+import os
 
 v2_path = "../../sdk/tests/wallet/fixtures/v2.stronghold"
 v3_path = "./v3.stronghold"
@@ -11,7 +13,7 @@ coin_type = CoinType.SHIMMER
 try:
     secret_manager = StrongholdSecretManager(v2_path, "current_password")
     # This should fail with error, migration required.
-    wallet = Wallet('./alice-database', client_options, coin_type, secret_manager)
+    wallet = Wallet(os.environ['WALLET_DB_PATH'], client_options, coin_type, secret_manager)
 except ValueError as e:
     print(e)
 
@@ -19,7 +21,7 @@ iota_sdk.migrate_stronghold_snapshot_v2_to_v3(v2_path, "current_password", "wall
 
 secret_manager = StrongholdSecretManager(v3_path, "new_password")
 # This shouldn't fail anymore as snapshot has been migrated.
-wallet = Wallet('./alice-database', client_options, coin_type, secret_manager)
+wallet = Wallet(os.environ['WALLET_DB_PATH'], client_options, coin_type, secret_manager)
 
 account = wallet.create_account('Alice')
 

--- a/bindings/python/examples/wallet/recover_accounts.py
+++ b/bindings/python/examples/wallet/recover_accounts.py
@@ -19,9 +19,9 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
     raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")
 
 secret_manager = StrongholdSecretManager(
-    "wallet.stronghold", os.environ['STRONGHOLD_PASSWORD'])
+    os.environ['STRONGHOLD_SNAPSHOT_PATH'], os.environ['STRONGHOLD_PASSWORD'])
 
-wallet = Wallet('./alice-database', client_options, coin_type, secret_manager)
+wallet = Wallet(os.environ['WALLET_DB_PATH'], client_options, coin_type, secret_manager)
 
 if 'NON_SECURE_USE_OF_DEVELOPMENT_MNEMONIC_1' not in os.environ:
     raise Exception(".env mnemonic is undefined, see .env.example")

--- a/bindings/python/examples/wallet/transaction_options.py
+++ b/bindings/python/examples/wallet/transaction_options.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 # This example sends a transaction with a tagged data payload.
 
-wallet = Wallet('./alice-database')
+wallet = Wallet(os.environ['WALLET_DB_PATH'])
 
 account = wallet.get_account('Alice')
 

--- a/bindings/wasm/examples/node.js
+++ b/bindings/wasm/examples/node.js
@@ -1,13 +1,14 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+require('dotenv').config();
 const console = require('console');
 const fs = require('fs');
 const { Wallet, CoinType, initLogger } = require('../node/lib');
 
 async function run() {
     try {
-        fs.rmdirSync('./alice-database', { recursive: true });
+        fs.rmdirSync(`${process.env.WALLET_DB_PATH}`, { recursive: true });
     } catch (e) {
         // ignore it
     }
@@ -20,7 +21,7 @@ async function run() {
     });
 
     const wallet = new Wallet({
-        storagePath: './alice-database',
+        storagePath: `${process.env.WALLET_DB_PATH}`,
         coinType: CoinType.Shimmer,
         clientOptions: {
             nodes: ['https://api.testnet.shimmer.network'],

--- a/bindings/wasm/examples/node.js
+++ b/bindings/wasm/examples/node.js
@@ -1,14 +1,13 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-require('dotenv').config();
 const console = require('console');
 const fs = require('fs');
 const { Wallet, CoinType, initLogger } = require('../node/lib');
 
 async function run() {
     try {
-        fs.rmdirSync(`${process.env.WALLET_DB_PATH}`, { recursive: true });
+        fs.rmdirSync('./alice-database', { recursive: true });
     } catch (e) {
         // ignore it
     }
@@ -21,7 +20,7 @@ async function run() {
     });
 
     const wallet = new Wallet({
-        storagePath: `${process.env.WALLET_DB_PATH}`,
+        storagePath: './alice-database',
         coinType: CoinType.Shimmer,
         clientOptions: {
             nodes: ['https://api.testnet.shimmer.network'],

--- a/sdk/src/wallet/bindings/nodejs/examples/1-create-account.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/1-create-account.js
@@ -26,7 +26,7 @@ async function run() {
 
 async function createAccountManager() {
     const accountManagerOptions = {
-        storagePath: './alice-database',
+        storagePath: `${process.env.WALLET_DB_PATH}`,
         clientOptions: {
             nodes: [process.env.NODE_URL],
             localPow: true,
@@ -34,7 +34,7 @@ async function createAccountManager() {
         coinType: CoinType.Shimmer,
         secretManager: {
             Stronghold: {
-                snapshotPath: `./wallet.stronghold`,
+                snapshotPath: `${process.env.STRONGHOLD_SNAPSHOT_PATH}`,
                 password: `${process.env.STRONGHOLD_PASSWORD}`,
             },
         },

--- a/sdk/src/wallet/bindings/nodejs/examples/account-manager.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/account-manager.js
@@ -11,7 +11,7 @@ async function getUnlockedManager() {
     }
 
     const manager = new AccountManager({
-        storagePath: './alice-database',
+        storagePath: `${process.env.WALLET_DB_PATH}`,
         clientOptions: {
             nodes: [process.env.NODE_URL],
             localPow: true,
@@ -19,7 +19,7 @@ async function getUnlockedManager() {
         coinType: CoinType.Shimmer,
         secretManager: {
             Stronghold: {
-                snapshotPath: `./wallet.stronghold`,
+                snapshotPath: `${process.env.STRONGHOLD_SNAPSHOT_PATH}`,
                 password: `${process.env.STRONGHOLD_PASSWORD}`,
             },
         },

--- a/sdk/src/wallet/bindings/nodejs/examples/events.ts
+++ b/sdk/src/wallet/bindings/nodejs/examples/events.ts
@@ -32,14 +32,14 @@ async function run() {
     }
     try {
         const walletOptions = {
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
             clientOptions: {
                 nodes: [process.env.NODE_URL],
             },
             coinType: CoinType.Shimmer,
             secretManager: {
                 stronghold: {
-                    snapshotPath: `./wallet.stronghold`,
+                    snapshotPath: `${process.env.STRONGHOLD_SNAPSHOT_PATH}`,
                     password: `${process.env.STRONGHOLD_PASSWORD}`,
                 },
             },

--- a/sdk/src/wallet/bindings/nodejs/examples/exchange/1-create-account.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/exchange/1-create-account.js
@@ -8,7 +8,7 @@ const { AccountManager, CoinType } = require('@iota/wallet');
 async function run() {
     try {
         const accountManagerOptions = {
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
             clientOptions: {
                 nodes: ['https://api.testnet.shimmer.network'],
             },
@@ -17,7 +17,7 @@ async function run() {
             coinType: CoinType.Shimmer,
             secretManager: {
                 Stronghold: {
-                    snapshotPath: `./wallet.stronghold`,
+                    snapshotPath: `${process.env.STRONGHOLD_SNAPSHOT_PATH}`,
                     password: `${process.env.STRONGHOLD_PASSWORD}`,
                 },
             },

--- a/sdk/src/wallet/bindings/nodejs/examples/exchange/2-generate-address.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/exchange/2-generate-address.js
@@ -8,7 +8,7 @@ const { AccountManager } = require('@iota/wallet');
 async function run() {
     try {
         const manager = new AccountManager({
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
         });
 
         await manager.setStrongholdPassword(

--- a/sdk/src/wallet/bindings/nodejs/examples/exchange/3-check-balance.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/exchange/3-check-balance.js
@@ -8,7 +8,7 @@ const { AccountManager } = require('@iota/wallet');
 async function run() {
     try {
         const manager = new AccountManager({
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
         });
 
         const account = await manager.getAccount('Alice');

--- a/sdk/src/wallet/bindings/nodejs/examples/exchange/4-listen-events.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/exchange/4-listen-events.js
@@ -8,7 +8,7 @@ const { AccountManager } = require('@iota/wallet');
 async function run() {
     try {
         const manager = new AccountManager({
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
         });
 
         const callback = function(err, data) {

--- a/sdk/src/wallet/bindings/nodejs/examples/exchange/5-send-amount.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/exchange/5-send-amount.js
@@ -8,7 +8,7 @@ const { AccountManager } = require('@iota/wallet');
 async function run() {
     try {
         const manager = new AccountManager({
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
         });
 
         await manager.setStrongholdPassword(`${process.env.STRONGHOLD_PASSWORD}`)

--- a/sdk/src/wallet/bindings/nodejs/examples/generateAddress.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/generateAddress.js
@@ -25,7 +25,7 @@ async function run() {
 
 async function createAccountManager() {
     const accountManagerOptions = {
-        storagePath: './alice-database',
+        storagePath: `${process.env.WALLET_DB_PATH}`,
         clientOptions: {
             nodes: ['https://api.testnet.shimmer.network'],
             localPow: true,
@@ -33,7 +33,7 @@ async function createAccountManager() {
         coinType: CoinType.Shimmer,
         secretManager: {
             Stronghold: {
-                snapshotPath: `./wallet.stronghold`,
+                snapshotPath: `${process.env.STRONGHOLD_SNAPSHOT_PATH}`,
                 password: `${process.env.STRONGHOLD_PASSWORD}`,
             },
         },

--- a/sdk/src/wallet/bindings/nodejs/examples/ledger_nano.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/ledger_nano.js
@@ -16,7 +16,7 @@ async function run() {
         });
 
         const manager = new AccountManager({
-            storagePath: './alice-database',
+            storagePath: `${process.env.WALLET_DB_PATH}`,
             clientOptions: {
                 nodes: ['https://api.testnet.shimmer.network'],
             },

--- a/sdk/src/wallet/bindings/nodejs/examples/migrate-stronghold-snapshot-v2-to-v3.js
+++ b/sdk/src/wallet/bindings/nodejs/examples/migrate-stronghold-snapshot-v2-to-v3.js
@@ -11,7 +11,7 @@ const v3Path = './v3.stronghold';
 
 async function run() {
     var accountManagerOptions = {
-        storagePath: './alice-database',
+        storagePath: `${process.env.WALLET_DB_PATH}`,
         clientOptions: {
             nodes: [process.env.NODE_URL],
             localPow: true,
@@ -42,7 +42,7 @@ async function run() {
     );
 
     accountManagerOptions = {
-        storagePath: './alice-database',
+        storagePath: `${process.env.WALLET_DB_PATH}`,
         clientOptions: {
             nodes: [process.env.NODE_URL],
             localPow: true,


### PR DESCRIPTION
# Description of change

Makes all examples use the same storage and snapshot paths from `.env`.

## Links to any relevant issues

Closes #688 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

not really because those are just examples, but checked through #388 