### PR TITLE
Return Error::TangleInclusion instead of Error::Node(NotFound(_))

### DIFF
--- a/sdk/src/wallet/account/operations/retry.rs
+++ b/sdk/src/wallet/account/operations/retry.rs
@@ -124,6 +124,7 @@ where
                             e,
                             crate::client::Error::Node(crate::client::node_api::error::Error::NotFound(_))
                         ) {
+                            // If no block was found with this transaction id, then it can't get included
                             crate::client::Error::TangleInclusion(block_id.to_string())
                         } else {
                             e

--- a/sdk/src/wallet/account/operations/retry.rs
+++ b/sdk/src/wallet/account/operations/retry.rs
@@ -119,8 +119,9 @@ where
                 // After we checked all our reattached blocks, check if the transaction got reattached in another block
                 // and confirmed
                 if conflicting {
-                    let included_block = self.client().get_included_block(transaction_id).await?;
-                    return Ok(included_block.id());
+                    if let Ok(included_block) = self.client().get_included_block(transaction_id).await {
+                        return Ok(included_block.id());
+                    }
                 }
             }
             Err(crate::client::Error::TangleInclusion(block_id.to_string()).into())

--- a/sdk/src/wallet/account/operations/retry.rs
+++ b/sdk/src/wallet/account/operations/retry.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::secret::SecretManage,
+    client::{secret::SecretManage, Error as ClientError},
     types::{
         api::core::response::LedgerInclusionState,
         block::{
@@ -10,7 +10,10 @@ use crate::{
             Block, BlockId,
         },
     },
-    wallet::account::{types::InclusionState, Account},
+    wallet::{
+        account::{types::InclusionState, Account},
+        Error,
+    },
 };
 
 const DEFAULT_RETRY_UNTIL_INCLUDED_INTERVAL: u64 = 1;
@@ -18,7 +21,7 @@ const DEFAULT_RETRY_UNTIL_INCLUDED_MAX_AMOUNT: u64 = 40;
 
 impl<S: 'static + SecretManage> Account<S>
 where
-    crate::wallet::Error: From<S::Error>,
+    Error: From<S::Error>,
 {
     /// Retries (promotes or reattaches) a block for provided block id until it's included (referenced by a
     /// milestone). This function is re-exported from the client library and default interval is as defined there.
@@ -49,15 +52,13 @@ where
 
         if let Some(transaction) = transaction {
             if transaction.inclusion_state == InclusionState::Confirmed {
-                return transaction
-                    .block_id
-                    .ok_or(crate::wallet::Error::MissingParameter("block id"));
+                return transaction.block_id.ok_or(Error::MissingParameter("block id"));
             }
 
             if transaction.inclusion_state == InclusionState::Conflicting
                 || transaction.inclusion_state == InclusionState::UnknownPruned
             {
-                return Err(crate::client::Error::TangleInclusion(format!(
+                return Err(ClientError::TangleInclusion(format!(
                     "transaction id: {} inclusion state: {:?}",
                     transaction_id, transaction.inclusion_state
                 ))
@@ -120,12 +121,9 @@ where
                 // and confirmed
                 if conflicting {
                     let included_block = self.client().get_included_block(transaction_id).await.map_err(|e| {
-                        if matches!(
-                            e,
-                            crate::client::Error::Node(crate::client::node_api::error::Error::NotFound(_))
-                        ) {
+                        if matches!(e, ClientError::Node(crate::client::node_api::error::Error::NotFound(_))) {
                             // If no block was found with this transaction id, then it can't get included
-                            crate::client::Error::TangleInclusion(block_id.to_string())
+                            ClientError::TangleInclusion(block_id.to_string())
                         } else {
                             e
                         }
@@ -133,9 +131,9 @@ where
                     return Ok(included_block.id());
                 }
             }
-            Err(crate::client::Error::TangleInclusion(block_id.to_string()).into())
+            Err(ClientError::TangleInclusion(block_id.to_string()).into())
         } else {
-            Err(crate::wallet::Error::TransactionNotFound(*transaction_id))
+            Err(Error::TransactionNotFound(*transaction_id))
         }
     }
 }


### PR DESCRIPTION
# Description of change

Return Error::TangleInclusion instead of Error::Node(NotFound(_))
Add conflicting tx test

## Links to any relevant issues

#387 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
