### PR TITLE
Revert ci profile inherit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug = 0
 incremental = false
 
 [profile.ci]
-inherits = "release"
+inherits = "dev"
 debug = 0
 incremental = false
 


### PR DESCRIPTION
# Description of change

The profile was inadvertently changed to a release profile, which slowed down the test builds a lot.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
