### PR TITLE
Call `ledger.set_non_interactive_mode()` only if it's a debug app

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.4.1 - 2023-07-DD
+## 1.0.0-rc.0 - 2023-07-DD
 
 ### Fixed
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.4.1 - 2023-07-DD
+
+### Fixed
+
+- Call `ledger.set_non_interactive_mode()` only if it's a debug app;
+
 ## 0.4.0 - 2023-07-14
 
 ### Added

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -153,9 +153,11 @@ impl SecretManage for LedgerSecretManager {
 
         // get ledger
         let ledger = get_ledger(coin_type, bip32_account, self.is_simulator).map_err(Error::from)?;
-        ledger
-            .set_non_interactive_mode(self.non_interactive)
-            .map_err(Error::from)?;
+        if ledger.is_debug_app() {
+            ledger
+                .set_non_interactive_mode(self.non_interactive)
+                .map_err(Error::from)?;
+        }
 
         let addresses = ledger
             .get_addresses(options.ledger_nano_prompt, bip32, address_indexes.len())
@@ -195,9 +197,11 @@ impl SecretManage for LedgerSecretManager {
         let lock = self.mutex.lock().await;
 
         let ledger = get_ledger(coin_type, account_index, self.is_simulator).map_err(Error::from)?;
-        ledger
-            .set_non_interactive_mode(self.non_interactive)
-            .map_err(Error::from)?;
+        if ledger.is_debug_app() {
+            ledger
+                .set_non_interactive_mode(self.non_interactive)
+                .map_err(Error::from)?;
+        }
 
         log::debug!("[LEDGER] prepare_blind_signing");
         log::debug!("[LEDGER] {:?} {:?}", bip32_index, msg);
@@ -273,9 +277,11 @@ impl SecretManage for LedgerSecretManager {
         let lock = self.mutex.lock().await;
 
         let ledger = get_ledger(coin_type, bip32_account, self.is_simulator).map_err(Error::from)?;
-        ledger
-            .set_non_interactive_mode(self.non_interactive)
-            .map_err(Error::from)?;
+        if ledger.is_debug_app() {
+            ledger
+                .set_non_interactive_mode(self.non_interactive)
+                .map_err(Error::from)?;
+        }
         let blind_signing = needs_blind_signing(prepared_transaction, ledger.get_buffer_size());
 
         // if essence + bip32 input indices are larger than the buffer size or the essence contains


### PR DESCRIPTION
# Description of change

Call `ledger.set_non_interactive_mode()` only if it's a debug app

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

In my brain :trollface: 

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
