### PR TITLE
Update bindings with send split

### DIFF
--- a/bindings/core/src/method/account.rs
+++ b/bindings/core/src/method/account.rs
@@ -13,6 +13,7 @@ use iota_sdk::{
         secret::GenerateAddressOptions,
     },
     types::block::{
+        address::Bech32Address,
         output::{dto::OutputDto, OutputId, TokenId},
         payload::transaction::TransactionId,
     },
@@ -269,6 +270,13 @@ pub enum AccountMethod {
     /// Send base coins.
     /// Expected response: [`SentTransaction`](crate::Response::SentTransaction)
     Send {
+        amount: u64,
+        address: Bech32Address,
+        options: Option<TransactionOptionsDto>,
+    },
+    /// Send base coins to multiple addresses, or with additional parameters.
+    /// Expected response: [`SentTransaction`](crate::Response::SentTransaction)
+    SendWithParams {
         params: Vec<SendParams>,
         options: Option<TransactionOptionsDto>,
     },

--- a/bindings/core/src/method_handler/account.rs
+++ b/bindings/core/src/method_handler/account.rs
@@ -263,7 +263,21 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
                 .await?;
             Response::BlockId(block_id)
         }
-        AccountMethod::Send { params, options } => {
+        AccountMethod::Send {
+            amount,
+            address,
+            options,
+        } => {
+            let transaction = account
+                .send(
+                    amount,
+                    address,
+                    options.map(TransactionOptions::try_from_dto).transpose()?,
+                )
+                .await?;
+            Response::SentTransaction(TransactionDto::from(&transaction))
+        }
+        AccountMethod::SendWithParams { params, options } => {
             let transaction = account
                 .send_with_params(params, options.map(TransactionOptions::try_from_dto).transpose()?)
                 .await?;

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `minimumRequiredStorageDeposit()` from `Account` to `Client`;
 - `SecretManagerMethod::SignEd25519`, `SignSecp256k1Ecdsa`, and `SignatureUnlock` now accept newly added `Bip44` type chains;
 - Use `BigInt` instead of strings for token amounts;
+- Split `Account::send` into `send` and `sendWithParams`;
 
 ### Fixed
 

--- a/bindings/nodejs/examples/exchange/5-send-amount.ts
+++ b/bindings/nodejs/examples/exchange/5-send-amount.ts
@@ -39,14 +39,11 @@ async function run() {
         // have a storage deposit return, expiration or are nft/alias/foundry outputs.
         await account.sync({ syncOnlyMostBasicOutputs: true });
 
-        const response = await account.send([
-            {
-                // Replace with the address of your choice!
-                address:
-                    'rms1qrrv7flg6lz5cssvzv2lsdt8c673khad060l4quev6q09tkm9mgtupgf0h0',
-                amount: BigInt(1000000),
-            },
-        ]);
+        const response = await account.send(
+            BigInt(1000000),
+            // Replace with the address of your choice!
+            'rms1qrrv7flg6lz5cssvzv2lsdt8c673khad060l4quev6q09tkm9mgtupgf0h0',
+        );
 
         console.log(response);
 

--- a/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts
+++ b/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts
@@ -33,7 +33,7 @@ async function run() {
             'rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu';
         const amount = BigInt(1);
 
-        const transaction = await account.send(address, amount, {
+        const transaction = await account.send(amount, address, {
             allowMicroAmount: true,
         });
 

--- a/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts
+++ b/bindings/nodejs/examples/how_tos/advanced_transactions/send_micro_transaction.ts
@@ -33,17 +33,9 @@ async function run() {
             'rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu';
         const amount = BigInt(1);
 
-        const transaction = await account.send(
-            [
-                {
-                    address,
-                    amount,
-                },
-            ],
-            {
-                allowMicroAmount: true,
-            },
-        );
+        const transaction = await account.send(address, amount, {
+            allowMicroAmount: true,
+        });
 
         console.log(`Transaction sent: ${transaction.transactionId}`);
 

--- a/bindings/nodejs/examples/how_tos/alias_wallet/transaction.ts
+++ b/bindings/nodejs/examples/how_tos/alias_wallet/transaction.ts
@@ -70,7 +70,7 @@ async function run() {
             mandatoryInputs: [input],
             allowMicroAmount: false,
         };
-        const transaction = await account.send(params, options);
+        const transaction = await account.sendWithParams(params, options);
         await account.retryTransactionUntilIncluded(transaction.transactionId);
         console.log(
             `Transaction with custom input: https://explorer.iota.org/testnet/transaction/${transaction.transactionId}`,

--- a/bindings/nodejs/examples/how_tos/simple_transaction/simple-transaction.ts
+++ b/bindings/nodejs/examples/how_tos/simple_transaction/simple-transaction.ts
@@ -35,12 +35,7 @@ async function run() {
             'rms1qrrv7flg6lz5cssvzv2lsdt8c673khad060l4quev6q09tkm9mgtupgf0h0';
         const amount = BigInt(1000000);
 
-        const response = await account.send([
-            {
-                address,
-                amount,
-            },
-        ]);
+        const response = await account.send(amount, address);
 
         console.log(
             `Block sent: ${process.env.EXPLORER_URL}/block/${response.blockId}`,

--- a/bindings/nodejs/examples/wallet/06-send-micro-transaction.ts
+++ b/bindings/nodejs/examples/wallet/06-send-micro-transaction.ts
@@ -36,7 +36,7 @@ async function run() {
             { address: RECV_ADDRESS, amount: SEND_MICRO_AMOUNT },
         ];
 
-        const transaction = await account.send(params, {
+        const transaction = await account.sendWithParams(params, {
             allowMicroAmount: true,
         });
         console.log(`Transaction sent: ${transaction.transactionId}`);

--- a/bindings/nodejs/lib/types/wallet/bridge/account.ts
+++ b/bindings/nodejs/lib/types/wallet/bridge/account.ts
@@ -247,6 +247,15 @@ export type __RetryTransactionUntilIncludedMethod__ = {
 export type __SendMethod__ = {
     name: 'send';
     data: {
+        amount: string;
+        address: string;
+        options?: TransactionOptions;
+    };
+};
+
+export type __SendWithParamsMethod__ = {
+    name: 'sendWithParams';
+    data: {
         params: SendParams[];
         options?: TransactionOptions;
     };

--- a/bindings/nodejs/lib/types/wallet/bridge/index.ts
+++ b/bindings/nodejs/lib/types/wallet/bridge/index.ts
@@ -32,6 +32,7 @@ import type {
     __RegisterParticipationEventsMethod__,
     __RetryTransactionUntilIncludedMethod__,
     __SendMethod__,
+    __SendWithParamsMethod__,
     __PrepareSendNativeTokensMethod__,
     __PrepareSendNftMethod__,
     __SendOutputsMethod__,
@@ -116,6 +117,7 @@ export type __AccountMethod__ =
     | __RegisterParticipationEventsMethod__
     | __RetryTransactionUntilIncludedMethod__
     | __SendMethod__
+    | __SendWithParamsMethod__
     | __PrepareSendNativeTokensMethod__
     | __PrepareSendNftMethod__
     | __SendOutputsMethod__

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -1002,13 +1002,44 @@ export class Account {
     }
 
     /**
+     * Send base coins to an address.
+     * @param amount Amount of coins.
+     * @param address Receiving address.
+     * @param transactionOptions The options to define a `RemainderValueStrategy`
+     * or custom inputs.
+     * @returns The sent transaction.
+     */
+    async send(
+        amount: bigint | string,
+        address: string,
+        transactionOptions?: TransactionOptions,
+    ): Promise<Transaction> {
+        if (typeof amount === 'bigint') {
+            amount = amount.toString(10);
+        }
+        const response = await this.methodHandler.callAccountMethod(
+            this.meta.index,
+            {
+                name: 'send',
+                data: {
+                    amount,
+                    address,
+                    options: transactionOptions,
+                },
+            },
+        );
+        const parsed = JSON.parse(response) as Response<Transaction>;
+        return plainToInstance(Transaction, parsed.payload);
+    }
+
+    /**
      * Send base coins with amounts from input addresses.
      * @param params Addresses with amounts.
      * @param transactionOptions The options to define a `RemainderValueStrategy`
      * or custom inputs.
      * @returns The sent transaction.
      */
-    async send(
+    async sendWithParams(
         params: SendParams[],
         transactionOptions?: TransactionOptions,
     ): Promise<Transaction> {
@@ -1020,7 +1051,7 @@ export class Account {
         const response = await this.methodHandler.callAccountMethod(
             this.meta.index,
             {
-                name: 'send',
+                name: 'sendWithParams',
                 data: {
                     params,
                     options: transactionOptions,

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Wallet::get_accounts()` now returns `List[Account]`;
 - `OutputData.chain` now is `Optional[Bip44]`;
 - `Wallet()` constructor and `Wallet::set_client_options()` now accept `ClientOptions`;
+- Split `Account::send()` into `send` and `send_with_params`;
 
 ### Removed
 

--- a/bindings/python/examples/exchange/5_send_amount.py
+++ b/bindings/python/examples/exchange/5_send_amount.py
@@ -28,10 +28,10 @@ wallet.set_stronghold_password(os.environ["STRONGHOLD_PASSWORD"])
 balance = account.sync(SyncOptions(sync_only_most_basic_outputs=True))
 print('Balance', balance)
 
-transaction = account.send([SendParams(
-    "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
+transaction = account.send(
     1000000,
-)])
+    "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
+)
 print(transaction)
 print(
     f'Check your block on: {os.environ["EXPLORER_URL"]}/block/{transaction.blockId}')

--- a/bindings/python/examples/how_tos/advanced_transactions/send_micro_transaction.py
+++ b/bindings/python/examples/how_tos/advanced_transactions/send_micro_transaction.py
@@ -23,7 +23,7 @@ params = [{
     "amount": "1",
 }]
 
-transaction = account.send(params, {"allowMicroAmount": True})
+transaction = account.send_with_params(params, {"allowMicroAmount": True})
 print(f'Transaction sent: {transaction.transactionId}')
 
 block_id = account.retry_transaction_until_included(transaction.transactionId)

--- a/bindings/python/examples/how_tos/alias_wallet/transaction.py
+++ b/bindings/python/examples/how_tos/alias_wallet/transaction.py
@@ -40,7 +40,7 @@ params = [SendParams(
 options = {
     'mandatoryInputs': [input],
 }
-transaction = account.send(params, options)
+transaction = account.send_with_params(params, options)
 account.retry_transaction_until_included(transaction.transactionId, None, None)
 print(
     f'Transaction with custom input: https://explorer.shimmer.network/testnet/transaction/{transaction.transactionId}')

--- a/bindings/python/examples/how_tos/simple_transaction/simple_transaction.py
+++ b/bindings/python/examples/how_tos/simple_transaction/simple_transaction.py
@@ -23,5 +23,5 @@ params = [SendParams(
     amount=1000000,
 )]
 
-transaction = account.send(params)
+transaction = account.send_with_params(params)
 print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{transaction.blockId}')

--- a/bindings/python/examples/wallet/transaction_options.py
+++ b/bindings/python/examples/wallet/transaction_options.py
@@ -23,7 +23,7 @@ params = [{
     "amount": "1000000",
 }]
 
-transaction = account.send(params, TransactionOptions(remainder_value_strategy=RemainderValueStrategy.ReuseAddress,
+transaction = account.send_with_params(params, TransactionOptions(remainder_value_strategy=RemainderValueStrategy.ReuseAddress,
                                   note="my first tx", tagged_data_payload=TaggedDataPayload(utf8_to_hex("tag"), utf8_to_hex("data"))))
 print(transaction)
 print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{transaction.blockId}')

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -364,11 +364,22 @@ class Account:
             }
         ))
 
-    def send(self, params: List[SendParams], options: Optional[TransactionOptions] = None) -> Transaction:
+    def send(self, amount: str, address: str, options: Optional[TransactionOptions] = None) -> Transaction:
         """Send base coins.
         """
         return Transaction.from_dict(self._call_account_method(
             'send', {
+                'amount': amount,
+                'address': address,
+                'options': options
+            }
+        ))
+
+    def send_with_params(self, params: List[SendParams], options: Optional[TransactionOptions] = None) -> Transaction:
+        """Send base coins to multiple addresses or with additional parameters.
+        """
+        return Transaction.from_dict(self._call_account_method(
+            'sendWithParams', {
                 'params': params,
                 'options': options
             }


### PR DESCRIPTION
# Description of change

This PR changes the bindings to match the previous send split PR #725.

## Links to any relevant issues

- Closes #586 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
