### PR TITLE
fixed link to examples in readme

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -2,19 +2,27 @@
 
 ## Table of contents
 
-- [Requirements](#requirements)
-- [Getting Started](#getting-started)
-    - [Install the IOTA SDK](#installation-using-a-package-manager)
-- [Client](#client-usage)
-- [Wallet](#wallet-usage)
-- [Examples](#examples)
-- [API Reference](#api-reference)
-- [Available Scripts](#available-scripts)
-    - [`install`](#npm-install-or-yarn-install)
-    - [`build`](#npm-build-or-yarn-build)
-    - [`test`](#npm-test-or-yarn-test)
-- [Important Files and Directories](#important-files-and-directories)
-- [Learn More](#learn-more)
+- [IOTA SDK Library - Node.js binding](#iota-sdk-library---nodejs-binding)
+  - [Table of contents](#table-of-contents)
+  - [Requirements](#requirements)
+    - [Windows](#windows)
+  - [Getting Started](#getting-started)
+    - [Installation Using a Package Manager](#installation-using-a-package-manager)
+      - [npm](#npm)
+      - [Yarn:](#yarn)
+    - [Install the Binding from Source](#install-the-binding-from-source)
+      - [Build nodejs bindings](#build-nodejs-bindings)
+  - [Client Usage](#client-usage)
+  - [Wallet Usage](#wallet-usage)
+  - [Examples](#examples)
+  - [API Reference](#api-reference)
+  - [Available Scripts](#available-scripts)
+    - [`npm install` or `yarn install`](#npm-install-or-yarn-install)
+    - [`npm run build` or `yarn build`](#npm-run-build-or-yarn-build)
+    - [`npm run test` or `yarn test`](#npm-run-test-or-yarn-test)
+    - [`npm run create-api-docs` or `yarn create-api-docs`](#npm-run-create-api-docs-or-yarn-create-api-docs)
+  - [Important Files and Directories](#important-files-and-directories)
+  - [Learn More](#learn-more)
 
 ## Requirements
 
@@ -128,7 +136,7 @@ const wallet = new Wallet(walletOptions);
 
 ## Examples
 
-You can use the provided code [examples](examples) to get acquainted with the IOTA SDK. You can use the following
+You can use the provided code [examples](https://github.com/iotaledger/iota-sdk/tree/develop/bindings/nodejs/examples) to get acquainted with the IOTA SDK. You can use the following
 command to run any example:
 
 ```bash

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -9,7 +9,7 @@
   - [Getting Started](#getting-started)
     - [Installation Using a Package Manager](#installation-using-a-package-manager)
       - [npm](#npm)
-      - [Yarn:](#yarn)
+      - [Yarn](#yarn)
     - [Install the Binding from Source](#install-the-binding-from-source)
       - [Build nodejs bindings](#build-nodejs-bindings)
   - [Client Usage](#client-usage)


### PR DESCRIPTION
# Description of change

The link on readme is incorrect, which reflects on [npm package](https://www.npmjs.com/package/@iota/sdk#examples) as well.
This PR fixes the link.

Also, updates menu to all available sub-links in rest of doc.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
