### PR TITLE
Clean up lots of serde field impls and remove unnecessary derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,9 +2424,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prefix-hex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9653998c1c55e1705580cf92d156b57094bbae6c83482d406f2223439cd354a"
+checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
 dependencies = [
  "hex",
  "primitive-types",

--- a/bindings/core/Cargo.toml
+++ b/bindings/core/Cargo.toml
@@ -18,7 +18,7 @@ futures =  { version = "0.3.28", default-features = false }
 iota-crypto = { version = "0.23.0", default-features = false, features = [ "slip10", "bip44" ] }
 log = { version = "0.4.19", default-features = false }
 packable = { version = "0.8.1", default-features = false }
-prefix-hex = { version = "0.7.0", default-features = false }
+prefix-hex = { version = "0.7.1", default-features = false }
 primitive-types = { version = "0.12.1", default-features = false }
 serde = { version = "1.0.171", default-features = false }
 serde_json = { version = "1.0.102", default-features = false }

--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "mqtt")]
+use iota_sdk::client::mqtt::{MqttPayload, Topic};
 use iota_sdk::{
     client::{
         api::{PreparedTransactionData, PreparedTransactionDataDto},
@@ -22,11 +24,6 @@ use iota_sdk::{
         },
     },
 };
-#[cfg(feature = "mqtt")]
-use {
-    iota_sdk::client::mqtt::{MqttPayload, Topic},
-    iota_sdk::types::block::payload::milestone::option::dto::ReceiptMilestoneOptionDto,
-};
 
 use crate::{method::ClientMethod, response::Response, Result};
 
@@ -44,16 +41,17 @@ where
                 topic: String,
                 payload: String,
             }
-            // convert types to DTOs
             let payload = match &topic_event.payload {
                 MqttPayload::Json(val) => serde_json::to_string(&val).expect("failed to serialize MqttPayload::Json"),
                 MqttPayload::Block(block) => {
-                    serde_json::to_string(&BlockDto::from(block)).expect("failed to serialize MqttPayload::Block")
+                    serde_json::to_string(block).expect("failed to serialize MqttPayload::Block")
                 }
-                MqttPayload::MilestonePayload(ms) => serde_json::to_string(&MilestonePayloadDto::from(ms))
-                    .expect("failed to serialize MqttPayload::MilestonePayload"),
-                MqttPayload::Receipt(receipt) => serde_json::to_string(&ReceiptMilestoneOptionDto::from(receipt))
-                    .expect("failed to serialize MqttPayload::Receipt"),
+                MqttPayload::MilestonePayload(ms) => {
+                    serde_json::to_string(ms).expect("failed to serialize MqttPayload::MilestonePayload")
+                }
+                MqttPayload::Receipt(receipt) => {
+                    serde_json::to_string(receipt).expect("failed to serialize MqttPayload::Receipt")
+                }
             };
             let response = MqttResponse {
                 topic: topic_event.topic.clone(),

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ dotenvy = { version = "0.15.7", default-features = false }
 fern-logger = { version = "0.5.0", default-features = false }
 humantime = { version = "2.1.0", default-features = false }
 log = { version = "0.4.19", default-features = false }
-prefix-hex = { version = "0.7.0", default-features = false, features = [ "std" ] }
+prefix-hex = { version = "0.7.1", default-features = false, features = [ "std" ] }
 serde_json = { version = "1.0.102", default-features = false }
 thiserror = { version = "1.0.43", default-features = false }
 tokio = { version = "1.29.1", default-features = false, features = [ "fs" ] }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,10 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated storage types field casing to uniform camelCase;
 - Replaced inappropriate serde impls from `AccountDetails` with fn impls for conversion;
+- `MqttPayload` now uses Dtos;
+- `NodeManagerBuilder` node fields are no longer wrapped in `Option`;
+- Prefix-hex string values replaced with boxed slices in Dtos;
+- `MilestoneEssence::new` now takes generic metadata for convenience;
+- `ParametersMilestoneOption::new` now accepts boxed slice;
 
 ### Removed
 
 - `ProtocolParametersDto`, `NetworkInfoDto`, `OutputMetadataDto` in favor of base types;
+- `serde` derives for types with explicit Dtos;
+- More fields that are considered empty are no longer serialized;
 
 ### Fixed
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -29,7 +29,7 @@ iota-crypto = { version = "0.23.0", default-features = false, features = [ "blak
 iterator-sorted = { version = "0.1.0", default-features = false }
 itertools = { version = "0.11.0", default-features = false, features = [ "use_alloc" ] }
 packable = { version = "0.8.1", default-features = false, features = [ "primitive-types" ] }
-prefix-hex = { version = "0.7.0", default-features = false, features = [ "primitive-types" ] }
+prefix-hex = { version = "0.7.1", default-features = false, features = [ "primitive-types" ] }
 primitive-types = { version = "0.12.1", default-features = false }
 serde = { version = "1.0.171", default-features = false, features = [ "derive" ] }
 serde_json = { version = "1.0.102", default-features = false, features = [ "alloc" ] }

--- a/sdk/src/client/api/types.rs
+++ b/sdk/src/client/api/types.rs
@@ -102,8 +102,7 @@ impl PreparedTransactionData {
 }
 
 /// Helper struct for offline signing
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignedTransactionData {
     /// Signed transaction payload
     pub transaction_payload: TransactionPayload,

--- a/sdk/src/client/builder.rs
+++ b/sdk/src/client/builder.rs
@@ -46,7 +46,7 @@ pub struct ClientBuilder {
     pub remote_pow_timeout: Duration,
     /// The amount of threads to be used for proof of work
     #[cfg(not(target_family = "wasm"))]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pow_worker_count: Option<usize>,
 }
 
@@ -109,11 +109,9 @@ impl ClientBuilder {
             let node: Node = node_dto.into();
             validate_url(node.url)?;
         }
-        if let Some(permanodes) = &self.node_manager_builder.permanodes {
-            for node_dto in permanodes {
-                let node: Node = node_dto.into();
-                validate_url(node.url)?;
-            }
+        for node_dto in &self.node_manager_builder.permanodes {
+            let node: Node = node_dto.into();
+            validate_url(node.url)?;
         }
         Ok(self)
     }

--- a/sdk/src/client/node_api/mqtt/mod.rs
+++ b/sdk/src/client/node_api/mqtt/mod.rs
@@ -195,7 +195,7 @@ fn poll_mqtt(client: &Client, mut event_loop: EventLoop) {
                                         match Block::unpack_verified(payload, protocol_parameters) {
                                             Ok(block) => Ok(TopicEvent {
                                                 topic: p.topic.clone(),
-                                                payload: MqttPayload::Block(block),
+                                                payload: MqttPayload::Block((&block).into()),
                                             }),
                                             Err(e) => {
                                                 warn!("Block unpacking failed: {:?}", e);
@@ -209,7 +209,7 @@ fn poll_mqtt(client: &Client, mut event_loop: EventLoop) {
                                         match Payload::unpack_verified(payload, protocol_parameters) {
                                             Ok(Payload::Milestone(milestone)) => Ok(TopicEvent {
                                                 topic: p.topic.clone(),
-                                                payload: MqttPayload::MilestonePayload(*milestone),
+                                                payload: MqttPayload::MilestonePayload(milestone.as_ref().into()),
                                             }),
                                             Ok(p) => {
                                                 warn!(
@@ -230,7 +230,7 @@ fn poll_mqtt(client: &Client, mut event_loop: EventLoop) {
                                         match ReceiptMilestoneOption::unpack_verified(payload, protocol_parameters) {
                                             Ok(receipt) => Ok(TopicEvent {
                                                 topic: p.topic.clone(),
-                                                payload: MqttPayload::Receipt(receipt),
+                                                payload: MqttPayload::Receipt((&receipt).into()),
                                             }),
                                             Err(e) => {
                                                 warn!("Receipt unpacking failed: {:?}", e);

--- a/sdk/src/client/node_api/mqtt/types.rs
+++ b/sdk/src/client/node_api/mqtt/types.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 
 use super::Error;
 use crate::types::block::{
-    payload::{milestone::ReceiptMilestoneOption, MilestonePayload},
-    Block,
+    payload::{dto::MilestonePayloadDto, milestone::option::dto::ReceiptMilestoneOptionDto},
+    BlockDto,
 };
 
 type TopicHandler = Box<dyn Fn(&TopicEvent) + Send + Sync>;
@@ -36,11 +36,11 @@ pub enum MqttPayload {
     /// In case it contains JSON.
     Json(Value),
     /// In case it contains a `Block` object.
-    Block(Block),
+    Block(BlockDto),
     /// In case it contains a `Milestone` object.
-    MilestonePayload(MilestonePayload),
+    MilestonePayload(MilestonePayloadDto),
     /// In case it contains a `Receipt` object.
-    Receipt(ReceiptMilestoneOption),
+    Receipt(ReceiptMilestoneOptionDto),
 }
 
 /// Mqtt events.

--- a/sdk/src/client/node_manager/mod.rs
+++ b/sdk/src/client/node_manager/mod.rs
@@ -32,7 +32,7 @@ pub struct NodeManager {
     pub(crate) primary_node: Option<Node>,
     primary_pow_node: Option<Node>,
     pub(crate) nodes: HashSet<Node>,
-    permanodes: Option<HashSet<Node>>,
+    permanodes: HashSet<Node>,
     pub(crate) ignore_node_health: bool,
     node_sync_interval: Duration,
     pub(crate) healthy_nodes: RwLock<HashMap<Node, InfoResponse>>,
@@ -73,26 +73,24 @@ impl NodeManager {
         let mut nodes_with_modified_url: Vec<Node> = Vec::new();
 
         if prefer_permanode || (path == "api/core/v2/blocks" && query.is_some()) {
-            if let Some(permanodes) = self.permanodes.clone() {
-                for permanode in permanodes {
-                    if !nodes_with_modified_url.iter().any(|n| n.url == permanode.url) {
-                        nodes_with_modified_url.push(permanode);
-                    }
+            for permanode in &self.permanodes {
+                if !nodes_with_modified_url.iter().any(|n| n.url == permanode.url) {
+                    nodes_with_modified_url.push(permanode.clone());
                 }
             }
         }
 
         if use_pow_nodes {
-            if let Some(pow_node) = self.primary_pow_node.clone() {
+            if let Some(pow_node) = &self.primary_pow_node {
                 if !nodes_with_modified_url.iter().any(|n| n.url == pow_node.url) {
-                    nodes_with_modified_url.push(pow_node);
+                    nodes_with_modified_url.push(pow_node.clone());
                 }
             }
         }
 
-        if let Some(primary_node) = self.primary_node.clone() {
+        if let Some(primary_node) = &self.primary_node {
             if !nodes_with_modified_url.iter().any(|n| n.url == primary_node.url) {
-                nodes_with_modified_url.push(primary_node);
+                nodes_with_modified_url.push(primary_node.clone());
             }
         }
 

--- a/sdk/src/client/node_manager/node.rs
+++ b/sdk/src/client/node_manager/node.rs
@@ -23,6 +23,7 @@ pub struct Node {
     /// Node url.
     pub url: Url,
     /// Node auth options.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<NodeAuth>,
     /// Whether the node is disabled or not.
     #[serde(default)]

--- a/sdk/src/client/secret/types.rs
+++ b/sdk/src/client/secret/types.rs
@@ -149,8 +149,7 @@ impl LedgerNanoStatus {
 }
 
 /// Data for transaction inputs for signing and ordering of unlock blocks
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct InputSigningData {
     /// The output
     pub output: Output,

--- a/sdk/src/types/block/core.rs
+++ b/sdk/src/types/block/core.rs
@@ -101,7 +101,6 @@ impl BlockBuilder {
 
 /// Represent the object that nodes gossip around the network.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Block {
     /// Protocol version of the block.
     protocol_version: u8,
@@ -269,7 +268,7 @@ pub mod dto {
         ///
         pub parents: Vec<String>,
         ///
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub payload: Option<PayloadDto>,
         ///
         pub nonce: String,

--- a/sdk/src/types/block/output/alias.rs
+++ b/sdk/src/types/block/output/alias.rs
@@ -321,7 +321,6 @@ pub(crate) type StateMetadataLength = BoundedU16<0, { AliasOutput::STATE_METADAT
 
 /// Describes an alias account in the ledger that can be controlled by the state and governance controllers.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AliasOutput {
     // Amount of IOTA tokens held by the output.
     amount: u64,
@@ -701,14 +700,22 @@ fn verify_unlock_conditions(unlock_conditions: &UnlockConditions, alias_id: &Ali
 
 #[allow(missing_docs)]
 pub mod dto {
-    use alloc::string::{String, ToString};
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+    };
 
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::types::block::{
-        output::{dto::OutputBuilderAmountDto, feature::dto::FeatureDto, unlock_condition::dto::UnlockConditionDto},
-        Error,
+    use crate::{
+        types::block::{
+            output::{
+                dto::OutputBuilderAmountDto, feature::dto::FeatureDto, unlock_condition::dto::UnlockConditionDto,
+            },
+            Error,
+        },
+        utils::serde::prefix_hex_bytes,
     };
 
     /// Describes an alias account in the ledger that can be controlled by the state and governance controllers.
@@ -727,8 +734,8 @@ pub mod dto {
         // A counter that must increase by 1 every time the alias is state transitioned.
         pub state_index: u32,
         // Metadata that can only be changed by the state controller.
-        #[serde(skip_serializing_if = "String::is_empty", default)]
-        pub state_metadata: String,
+        #[serde(skip_serializing_if = "<[_]>::is_empty", default, with = "prefix_hex_bytes")]
+        pub state_metadata: Box<[u8]>,
         // A counter that denotes the number of foundries created by this alias account.
         pub foundry_counter: u32,
         //
@@ -749,7 +756,7 @@ pub mod dto {
                 native_tokens: value.native_tokens().to_vec(),
                 alias_id: *value.alias_id(),
                 state_index: value.state_index(),
-                state_metadata: prefix_hex::encode(value.state_metadata()),
+                state_metadata: value.state_metadata().into(),
                 foundry_counter: value.foundry_counter(),
                 unlock_conditions: value.unlock_conditions().iter().map(Into::into).collect::<_>(),
                 features: value.features().iter().map(Into::into).collect::<_>(),
@@ -768,10 +775,7 @@ pub mod dto {
             builder = builder.with_state_index(value.state_index);
 
             if !value.state_metadata.is_empty() {
-                builder = builder.with_state_metadata(
-                    prefix_hex::decode::<Vec<_>>(&value.state_metadata)
-                        .map_err(|_| Error::InvalidField("state_metadata"))?,
-                );
+                builder = builder.with_state_metadata(value.state_metadata);
             }
 
             builder = builder.with_foundry_counter(value.foundry_counter);
@@ -804,10 +808,7 @@ pub mod dto {
             builder = builder.with_state_index(value.state_index);
 
             if !value.state_metadata.is_empty() {
-                builder = builder.with_state_metadata(
-                    prefix_hex::decode::<Vec<_>>(&value.state_metadata)
-                        .map_err(|_| Error::InvalidField("state_metadata"))?,
-                );
+                builder = builder.with_state_metadata(value.state_metadata);
             }
 
             builder = builder.with_foundry_counter(value.foundry_counter);

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -292,7 +292,7 @@ mod test {
 
 #[allow(missing_docs)]
 pub mod dto {
-    use alloc::{format, string::ToString};
+    use alloc::format;
 
     use serde::{Deserialize, Serialize, Serializer};
     use serde_json::Value;
@@ -397,11 +397,11 @@ pub mod dto {
                 }),
                 Feature::Metadata(v) => Self::Metadata(MetadataFeatureDto {
                     kind: MetadataFeature::KIND,
-                    data: v.to_string(),
+                    data: v.data().into(),
                 }),
                 Feature::Tag(v) => Self::Tag(TagFeatureDto {
                     kind: TagFeature::KIND,
-                    tag: v.to_string(),
+                    tag: v.tag().into(),
                 }),
             }
         }
@@ -414,12 +414,8 @@ pub mod dto {
             Ok(match value {
                 FeatureDto::Sender(v) => Self::Sender(SenderFeature::new(Address::try_from(v.address)?)),
                 FeatureDto::Issuer(v) => Self::Issuer(IssuerFeature::new(Address::try_from(v.address)?)),
-                FeatureDto::Metadata(v) => Self::Metadata(MetadataFeature::new(
-                    prefix_hex::decode::<Vec<u8>>(&v.data).map_err(|_e| Error::InvalidField("MetadataFeature"))?,
-                )?),
-                FeatureDto::Tag(v) => Self::Tag(TagFeature::new(
-                    prefix_hex::decode::<Vec<u8>>(&v.tag).map_err(|_e| Error::InvalidField("TagFeature"))?,
-                )?),
+                FeatureDto::Metadata(v) => Self::Metadata(MetadataFeature::new(v.data)?),
+                FeatureDto::Tag(v) => Self::Tag(TagFeature::new(v.tag)?),
             })
         }
     }

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -86,7 +86,6 @@ pub(crate) enum OutputBuilderAmount {
 
 /// Contains the generic [`Output`] with associated [`OutputMetadata`].
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputWithMetadata {
     pub(crate) output: Output,
     pub(crate) metadata: OutputMetadata,
@@ -121,11 +120,6 @@ impl OutputWithMetadata {
 
 /// A generic output that can represent different types defining the deposit of funds.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(tag = "type", content = "data")
-)]
 pub enum Output {
     /// A treasury output.
     Treasury(TreasuryOutput),

--- a/sdk/src/types/block/payload/milestone/essence.rs
+++ b/sdk/src/types/block/payload/milestone/essence.rs
@@ -25,7 +25,6 @@ pub(crate) type MilestoneMetadataLength = BoundedU16<{ u16::MIN }, { u16::MAX }>
 /// Essence of a milestone payload.
 /// This is the signed part of a milestone payload.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MilestoneEssence {
     index: MilestoneIndex,
     timestamp: u32,
@@ -49,10 +48,11 @@ impl MilestoneEssence {
         parents: Parents,
         inclusion_merkle_root: MerkleRoot,
         applied_merkle_root: MerkleRoot,
-        metadata: Vec<u8>,
+        metadata: impl Into<Vec<u8>>,
         options: MilestoneOptions,
     ) -> Result<Self, Error> {
         let metadata = metadata
+            .into()
             .into_boxed_slice()
             .try_into()
             .map_err(Error::InvalidMilestoneMetadataLength)?;

--- a/sdk/src/types/block/payload/milestone/option/mod.rs
+++ b/sdk/src/types/block/payload/milestone/option/mod.rs
@@ -19,11 +19,6 @@ use crate::types::block::{protocol::ProtocolParameters, Error};
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, From, Packable)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(tag = "type", content = "data")
-)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidMilestoneOptionKind)]
 #[packable(unpack_visitor = ProtocolParameters)]
@@ -61,7 +56,6 @@ pub(crate) type MilestoneOptionCount = BoundedU8<0, { MilestoneOptions::COUNT_MA
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, Deref, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_error = Error, with = |e| e.unwrap_item_err_or_else(|p| Error::InvalidMilestoneOptionCount(p.into())))]
 #[packable(unpack_visitor = ProtocolParameters)]
 pub struct MilestoneOptions(

--- a/sdk/src/types/block/payload/milestone/option/receipt/migrated_funds_entry.rs
+++ b/sdk/src/types/block/payload/milestone/option/receipt/migrated_funds_entry.rs
@@ -9,7 +9,6 @@ use crate::types::block::{
 
 /// Describes funds which were migrated from a legacy network.
 #[derive(Clone, Debug, Eq, PartialEq, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_visitor = ProtocolParameters)]
 pub struct MigratedFundsEntry {
     tail_transaction_hash: TailTransactionHash,

--- a/sdk/src/types/block/payload/milestone/option/receipt/mod.rs
+++ b/sdk/src/types/block/payload/milestone/option/receipt/mod.rs
@@ -28,7 +28,6 @@ pub(crate) type ReceiptFundsCount =
 
 /// Receipt is a listing of migrated funds.
 #[derive(Clone, Debug, Eq, PartialEq, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_error = Error)]
 #[packable(unpack_visitor = ProtocolParameters)]
 pub struct ReceiptMilestoneOption {

--- a/sdk/src/types/block/payload/milestone/option/receipt/tail_transaction_hash.rs
+++ b/sdk/src/types/block/payload/milestone/option/receipt/tail_transaction_hash.rs
@@ -17,7 +17,6 @@ use crate::types::block::Error;
 
 /// Represents a tail transaction hash of a legacy bundle.
 #[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TailTransactionHash(TritBuf<T5B1Buf>);
 
 impl TailTransactionHash {

--- a/sdk/src/types/block/payload/mod.rs
+++ b/sdk/src/types/block/payload/mod.rs
@@ -33,11 +33,6 @@ use crate::types::block::{protocol::ProtocolParameters, Error};
 
 /// A generic payload that can represent different types defining block payloads.
 #[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(tag = "type", content = "data")
-)]
 pub enum Payload {
     /// A transaction payload.
     Transaction(Box<TransactionPayload>),
@@ -144,7 +139,6 @@ impl Packable for Payload {
 /// Representation of an optional [`Payload`].
 /// Essentially an `Option<Payload>` with a different [`Packable`] implementation, to conform to specs.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OptionalPayload(Option<Payload>);
 
 impl OptionalPayload {

--- a/sdk/src/types/block/payload/transaction/essence/mod.rs
+++ b/sdk/src/types/block/payload/transaction/essence/mod.rs
@@ -13,11 +13,6 @@ use crate::types::block::Error;
 
 /// A generic essence that can represent different types defining transaction essences.
 #[derive(Clone, Debug, Eq, PartialEq, From, packable::Packable)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(tag = "type", content = "data")
-)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidEssenceKind)]
 pub enum TransactionEssence {

--- a/sdk/src/types/block/payload/transaction/essence/regular.rs
+++ b/sdk/src/types/block/payload/transaction/essence/regular.rs
@@ -138,7 +138,6 @@ pub(crate) type OutputCount = BoundedU16<{ *OUTPUT_COUNT_RANGE.start() }, { *OUT
 
 /// A transaction regular essence consuming inputs, creating outputs and carrying an optional payload.
 #[derive(Clone, Debug, Eq, PartialEq, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_error = Error)]
 #[packable(unpack_visitor = ProtocolParameters)]
 pub struct RegularTransactionEssence {

--- a/sdk/src/types/block/payload/transaction/mod.rs
+++ b/sdk/src/types/block/payload/transaction/mod.rs
@@ -18,7 +18,6 @@ use crate::types::block::{protocol::ProtocolParameters, unlock::Unlocks, Error};
 
 /// A transaction to move funds.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransactionPayload {
     essence: TransactionEssence,
     unlocks: Unlocks,

--- a/sdk/src/types/block/payload/treasury_transaction/mod.rs
+++ b/sdk/src/types/block/payload/treasury_transaction/mod.rs
@@ -12,7 +12,6 @@ use crate::types::block::{
 
 /// [`TreasuryTransactionPayload`] represents a transaction which moves funds from the treasury.
 #[derive(Clone, Debug, Eq, PartialEq, packable::Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_visitor = ProtocolParameters)]
 pub struct TreasuryTransactionPayload {
     #[packable(verify_with = verify_input)]

--- a/sdk/src/types/block/unlock/mod.rs
+++ b/sdk/src/types/block/unlock/mod.rs
@@ -81,7 +81,6 @@ pub(crate) type UnlockCount = BoundedU16<{ *UNLOCK_COUNT_RANGE.start() }, { *UNL
 
 /// A collection of unlocks.
 #[derive(Clone, Debug, Eq, PartialEq, Deref, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_error = Error, with = |e| e.unwrap_item_err_or_else(|p| Error::InvalidUnlockCount(p.into())))]
 pub struct Unlocks(#[packable(verify_with = verify_unlocks)] BoxedSlicePrefix<Unlock, UnlockCount>);
 

--- a/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/create_alias.rs
@@ -24,13 +24,13 @@ pub struct CreateAliasParams {
     /// address of the account
     pub address: Option<Bech32Address>,
     /// Immutable alias metadata
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     pub immutable_metadata: Option<Vec<u8>>,
     /// Alias metadata
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     pub metadata: Option<Vec<u8>>,
     /// Alias state metadata
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     pub state_metadata: Option<Vec<u8>>,
 }
 

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/create_native_token.rs
@@ -33,13 +33,12 @@ pub struct CreateNativeTokenParams {
     /// Maximum supply
     pub maximum_supply: U256,
     /// Foundry metadata
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     pub foundry_metadata: Option<Vec<u8>>,
 }
 
 /// The result of a transaction to create a native token
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct CreateNativeTokenTransaction {
     pub token_id: TokenId,
     pub transaction: Transaction,

--- a/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/minting/mint_nfts.rs
@@ -34,18 +34,18 @@ pub struct MintNftParams {
     sender: Option<Bech32Address>,
     /// NFT metadata feature.
     #[getset(get = "pub")]
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     metadata: Option<Vec<u8>>,
     /// NFT tag feature.
     #[getset(get = "pub")]
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     tag: Option<Vec<u8>>,
     /// NFT issuer feature.
     #[getset(get = "pub")]
     issuer: Option<Bech32Address>,
     /// NFT immutable metadata feature.
     #[getset(get = "pub")]
-    #[serde(default, with = "crate::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "crate::utils::serde::option_prefix_hex_bytes")]
     immutable_metadata: Option<Vec<u8>>,
 }
 

--- a/sdk/src/wallet/account/operations/transaction/options.rs
+++ b/sdk/src/wallet/account/operations/transaction/options.rs
@@ -14,22 +14,16 @@ use crate::{
 };
 
 /// Options for transactions
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
 pub struct TransactionOptions {
-    #[serde(default)]
     pub remainder_value_strategy: RemainderValueStrategy,
-    #[serde(default)]
     pub tagged_data_payload: Option<TaggedDataPayload>,
     // If custom inputs are provided only they are used. If also other additional inputs should be used,
     // `mandatory_inputs` should be used instead.
-    #[serde(default)]
     pub custom_inputs: Option<Vec<OutputId>>,
-    #[serde(default)]
     pub mandatory_inputs: Option<Vec<OutputId>>,
     pub burn: Option<Burn>,
     pub note: Option<String>,
-    #[serde(default)]
     pub allow_micro_amount: bool,
 }
 

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -165,8 +165,7 @@ impl OutputData {
 }
 
 /// A transaction with metadata
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Transaction {
     pub payload: TransactionPayload,
     pub block_id: Option<BlockId>,
@@ -182,7 +181,6 @@ pub struct Transaction {
     /// Outputs that are used as input in the transaction. May not be all, because some may have already been deleted
     /// from the node.
     // serde(default) is needed so it doesn't break with old dbs
-    #[serde(default)]
     pub inputs: Vec<OutputWithMetadataResponse>,
 }
 

--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -293,9 +293,12 @@ pub(crate) mod dto {
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct WalletBuilderDto {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub(crate) client_options: Option<ClientOptions>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub(crate) coin_type: Option<u32>,
         #[cfg(feature = "storage")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub(crate) storage_options: Option<StorageOptions>,
     }
 

--- a/sdk/src/wallet/core/operations/client.rs
+++ b/sdk/src/wallet/core/operations/client.rs
@@ -102,26 +102,26 @@ where
             }
         }
 
-        if let Some(permanodes) = &node_manager_builder.permanodes {
-            let mut new_permanodes = HashSet::new();
-            for node in permanodes.iter() {
+        node_manager_builder.permanodes = node_manager_builder
+            .permanodes
+            .into_iter()
+            .map(|node| {
                 let (node_url, disabled) = match &node {
                     NodeDto::Url(node_url) => (node_url, false),
                     NodeDto::Node(node) => (&node.url, node.disabled),
                 };
 
                 if node_url == &url {
-                    new_permanodes.insert(NodeDto::Node(Node {
+                    NodeDto::Node(Node {
                         url: url.clone(),
                         auth: auth.clone(),
                         disabled,
-                    }));
+                    })
                 } else {
-                    new_permanodes.insert(node.clone());
+                    node
                 }
-            }
-            node_manager_builder.permanodes = Some(new_permanodes);
-        }
+            })
+            .collect();
 
         let mut new_nodes = HashSet::new();
         for node in node_manager_builder.nodes.iter() {

--- a/sdk/src/wallet/migration/migrate_1.rs
+++ b/sdk/src/wallet/migration/migrate_1.rs
@@ -37,7 +37,9 @@ impl Migration<crate::wallet::storage::Storage> for Migrate {
         }
 
         if let Some(mut wallet) = storage.get::<serde_json::Value>(WALLET_INDEXATION_KEY).await? {
-            migrate_client_options(&mut wallet["client_options"])?;
+            if let Some(client_options) = wallet.get_mut("client_options") {
+                migrate_client_options(client_options)?;
+            }
             if let Some(storage_options) = wallet.get_mut("storage_options") {
                 ConvertStorageOptions::check(storage_options)?;
             }

--- a/sdk/src/wallet/migration/migrate_4.rs
+++ b/sdk/src/wallet/migration/migrate_4.rs
@@ -1,0 +1,253 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+pub struct Migrate;
+
+#[async_trait]
+impl MigrationData for Migrate {
+    const ID: usize = 4;
+    const SDK_VERSION: &'static str = "1.0.0-rc.0";
+    const DATE: time::Date = time::macros::date!(2023 - 07 - 19);
+}
+
+#[async_trait]
+#[cfg(feature = "storage")]
+impl Migration<crate::wallet::storage::Storage> for Migrate {
+    async fn migrate(storage: &crate::wallet::storage::Storage) -> Result<()> {
+        use crate::wallet::storage::constants::{
+            ACCOUNTS_INDEXATION_KEY, ACCOUNT_INDEXATION_KEY, WALLET_INDEXATION_KEY,
+        };
+
+        if let Some(account_indexes) = storage.get::<Vec<u32>>(ACCOUNTS_INDEXATION_KEY).await? {
+            for account_index in account_indexes {
+                if let Some(mut account) = storage
+                    .get::<serde_json::Value>(&format!("{ACCOUNT_INDEXATION_KEY}{account_index}"))
+                    .await?
+                {
+                    migrate_account(&mut account)?;
+
+                    storage
+                        .set(&format!("{ACCOUNT_INDEXATION_KEY}{account_index}"), &account)
+                        .await?;
+                }
+            }
+        }
+
+        if let Some(mut wallet) = storage.get::<serde_json::Value>(WALLET_INDEXATION_KEY).await? {
+            migrate_wallet(&mut wallet)?;
+
+            storage.set(WALLET_INDEXATION_KEY, &wallet).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "stronghold")]
+impl Migration<crate::client::stronghold::StrongholdAdapter> for Migrate {
+    async fn migrate(storage: &crate::client::stronghold::StrongholdAdapter) -> Result<()> {
+        use crate::{
+            client::storage::StorageAdapter,
+            wallet::core::operations::stronghold_backup::stronghold_snapshot::{ACCOUNTS_KEY, CLIENT_OPTIONS_KEY},
+        };
+
+        if let Some(mut accounts) = storage.get::<Vec<serde_json::Value>>(ACCOUNTS_KEY).await? {
+            for account in &mut accounts {
+                migrate_account(account)?;
+            }
+            storage.set(ACCOUNTS_KEY, &accounts).await?;
+        }
+
+        if let Some(mut client_options) = storage.get::<serde_json::Value>(CLIENT_OPTIONS_KEY).await? {
+            migrate_client_options(&mut client_options)?;
+
+            storage.set(CLIENT_OPTIONS_KEY, &client_options).await?;
+        }
+        Ok(())
+    }
+}
+
+fn migrate_wallet(wallet: &mut serde_json::Value) -> Result<()> {
+    migrate_client_options(&mut wallet["clientOptions"])?;
+    if let Some(storage_opts) = wallet.get_mut("storageOptions") {
+        let storage_opts = storage_opts
+            .as_object_mut()
+            .ok_or(Error::Storage("malformatted storage options".to_owned()))?;
+        check_omitted_opt("encryptionKey", storage_opts)
+    }
+    Ok(())
+}
+
+fn migrate_client_options(client_options: &mut serde_json::Value) -> Result<()> {
+    let client_options = client_options
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted client options".to_owned()))?;
+    check_omitted_opt("powWorkerCount", client_options);
+    check_omitted_opt("latestMilestoneTimestamp", client_options);
+    check_omitted_opt("primaryNode", client_options);
+    check_omitted_opt("primaryPowNode", client_options);
+    check_omitted_list("nodes", client_options);
+    check_omitted_list("permanodes", client_options);
+    if let Some(nodes) = client_options.get_mut("nodes") {
+        migrate_nodes(nodes)?;
+    }
+    if let Some(nodes) = client_options.get_mut("permanodes") {
+        migrate_nodes(nodes)?;
+    }
+    Ok(())
+}
+
+fn migrate_nodes(nodes: &mut serde_json::Value) -> Result<()> {
+    for node in nodes
+        .as_array_mut()
+        .ok_or(Error::Storage("malformatted nodes".to_owned()))?
+    {
+        let node = node
+            .as_object_mut()
+            .ok_or(Error::Storage("malformatted node".to_owned()))?;
+        check_omitted_opt("auth", node);
+    }
+    Ok(())
+}
+
+fn migrate_account(account: &mut serde_json::Value) -> Result<()> {
+    for output_data in account["outputs"]
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted outputs".to_owned()))?
+        .values_mut()
+    {
+        migrate_output(&mut output_data["output"])?;
+    }
+
+    for output_data in account["unspentOutputs"]
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted unspent outputs".to_owned()))?
+        .values_mut()
+    {
+        migrate_output(&mut output_data["output"])?;
+    }
+
+    for transaction in account["transactions"]
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted transactions".to_owned()))?
+        .values_mut()
+    {
+        migrate_transaction(transaction)?;
+    }
+
+    for transaction in account["incomingTransactions"]
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted incoming transactions".to_owned()))?
+        .values_mut()
+    {
+        migrate_transaction(transaction)?;
+    }
+
+    if let Some(foundries) = account.get_mut("nativeTokenFoundries") {
+        for foundry_output in foundries
+            .as_object_mut()
+            .ok_or(Error::Storage("malformatted foundry outputs".to_owned()))?
+            .values_mut()
+        {
+            migrate_output(foundry_output)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn migrate_output(output: &mut serde_json::Value) -> Result<()> {
+    let output = output
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted output".to_owned()))?;
+    check_omitted_str("stateMetadata", output, "0x");
+    check_omitted_list("features", output);
+    check_omitted_list("immutableFeatures", output);
+    if let Some(features) = output.get_mut("features") {
+        for feature in features
+            .as_array_mut()
+            .ok_or(Error::Storage("malformatted features".to_owned()))?
+        {
+            migrate_feature(feature)?;
+        }
+    }
+    if let Some(features) = output.get_mut("immutableFeatures") {
+        for feature in features
+            .as_array_mut()
+            .ok_or(Error::Storage("malformatted immutable features".to_owned()))?
+        {
+            migrate_feature(feature)?;
+        }
+    }
+    Ok(())
+}
+
+fn migrate_transaction(transaction: &mut serde_json::Value) -> Result<()> {
+    let transaction = transaction
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted transaction".to_owned()))?;
+    check_omitted_str("note", transaction, "");
+    check_omitted_str("blockId", transaction, "");
+
+    for output in transaction["payload"]["essence"]["outputs"]
+        .as_array_mut()
+        .ok_or(Error::Storage("malformatted transaction outputs".to_owned()))?
+    {
+        migrate_output(output)?;
+    }
+
+    for input in transaction["inputs"]
+        .as_array_mut()
+        .ok_or(Error::Storage("malformatted transaction inputs".to_owned()))?
+    {
+        migrate_output(&mut input["output"])?;
+    }
+
+    if let Some(payload) = transaction["payload"]["essence"].get_mut("payload") {
+        migrate_payload(payload)?;
+    }
+
+    Ok(())
+}
+
+fn migrate_payload(payload: &mut serde_json::Value) -> Result<()> {
+    let payload = payload
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted payload".to_owned()))?;
+    check_omitted_str("data", payload, "0x");
+    check_omitted_str("tag", payload, "0x");
+    Ok(())
+}
+
+fn migrate_feature(feature: &mut serde_json::Value) -> Result<()> {
+    let feature = feature
+        .as_object_mut()
+        .ok_or(Error::Storage("malformatted feature".to_owned()))?;
+    check_omitted_str("data", feature, "0x");
+    check_omitted_str("tag", feature, "0x");
+    Ok(())
+}
+
+fn check_omitted_str(field: &str, value: &mut serde_json::Map<String, serde_json::Value>, empty_val: &str) {
+    if let Some(f) = value.get(field) {
+        if f.is_null() || matches!(f.as_str(), Some(v) if v == empty_val) {
+            value.remove(field);
+        }
+    }
+}
+
+fn check_omitted_list(field: &str, value: &mut serde_json::Map<String, serde_json::Value>) {
+    if let Some(f) = value.get(field) {
+        if f.is_null() || matches!(f.as_array().map(Vec::as_slice), Some(&[])) {
+            value.remove(field);
+        }
+    }
+}
+
+fn check_omitted_opt(field: &str, value: &mut serde_json::Map<String, serde_json::Value>) {
+    if matches!(value.get(field), Some(f) if f.is_null()) {
+        value.remove(field);
+    }
+}

--- a/sdk/src/wallet/migration/migrate_4.rs
+++ b/sdk/src/wallet/migration/migrate_4.rs
@@ -196,7 +196,7 @@ fn migrate_transaction(transaction: &mut serde_json::Value) -> Result<()> {
         .as_object_mut()
         .ok_or(Error::Storage("malformatted transaction".to_owned()))?;
     check_omitted_str("note", transaction, "");
-    check_omitted_str("blockId", transaction, "");
+    check_omitted_opt("blockId", transaction);
 
     for output in transaction["payload"]["essence"]["outputs"]
         .as_array_mut()

--- a/sdk/src/wallet/migration/mod.rs
+++ b/sdk/src/wallet/migration/mod.rs
@@ -5,6 +5,7 @@ mod migrate_0;
 mod migrate_1;
 mod migrate_2;
 mod migrate_3;
+mod migrate_4;
 
 use std::collections::HashMap;
 
@@ -28,7 +29,7 @@ static MIGRATIONS: Lazy<Map<dyn anymap::any::Any + Send + Sync>> = Lazy::new(|| 
     #[cfg(feature = "storage")]
     {
         use super::storage::Storage;
-        const STORAGE_MIGRATIONS: [(Option<usize>, &'static dyn DynMigration<Storage>); 4] = [
+        const STORAGE_MIGRATIONS: [(Option<usize>, &'static dyn DynMigration<Storage>); 5] = [
             // In order to add a new storage migration, add an entry at the bottom of this list
             // and change the list length above.
             // The entry should be in the form of a key-value pair, from previous migration to next.
@@ -37,13 +38,14 @@ static MIGRATIONS: Lazy<Map<dyn anymap::any::Any + Send + Sync>> = Lazy::new(|| 
             (Some(migrate_0::Migrate::ID), &migrate_1::Migrate),
             (Some(migrate_1::Migrate::ID), &migrate_2::Migrate),
             (Some(migrate_2::Migrate::ID), &migrate_3::Migrate),
+            (Some(migrate_3::Migrate::ID), &migrate_4::Migrate),
         ];
         migrations.insert(std::collections::HashMap::from(STORAGE_MIGRATIONS));
     }
     #[cfg(feature = "stronghold")]
     {
         use crate::client::stronghold::StrongholdAdapter;
-        const BACKUP_MIGRATIONS: [(Option<usize>, &'static dyn DynMigration<StrongholdAdapter>); 4] = [
+        const BACKUP_MIGRATIONS: [(Option<usize>, &'static dyn DynMigration<StrongholdAdapter>); 5] = [
             // In order to add a new backup migration, and add an entry at the bottom of this list
             // and change the list length above.
             // The entry should be in the form of a key-value pair, from previous migration to next.
@@ -52,6 +54,7 @@ static MIGRATIONS: Lazy<Map<dyn anymap::any::Any + Send + Sync>> = Lazy::new(|| 
             (Some(migrate_0::Migrate::ID), &migrate_1::Migrate),
             (Some(migrate_1::Migrate::ID), &migrate_2::Migrate),
             (Some(migrate_2::Migrate::ID), &migrate_3::Migrate),
+            (Some(migrate_3::Migrate::ID), &migrate_4::Migrate),
         ];
         migrations.insert(LatestBackupMigration(BACKUP_MIGRATIONS.last().unwrap().1.version()));
         migrations.insert(std::collections::HashMap::from(BACKUP_MIGRATIONS));

--- a/sdk/src/wallet/storage/options.rs
+++ b/sdk/src/wallet/storage/options.rs
@@ -14,6 +14,7 @@ use crate::wallet::storage::{constants::default_storage_path, StorageKind};
 #[serde(rename_all = "camelCase")]
 pub struct StorageOptions {
     pub(crate) path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) encryption_key: Option<Zeroizing<[u8; 32]>>,
     pub(crate) kind: StorageKind,
 }

--- a/sdk/tests/client/client_builder.rs
+++ b/sdk/tests/client/client_builder.rs
@@ -18,16 +18,12 @@ async fn valid_url() {
 #[tokio::test]
 async fn client_builder() {
     let client_builder_json = r#"{
-        "primaryNode":null,
-        "primaryPowNode":null,
         "nodes":[
             {
                 "url":"http://localhost:14265/",
-                "auth":null,
                 "disabled":false
             }
         ],
-        "permanodes":null,
         "ignoreNodeHealth":true,
         "nodeSyncInterval":{
             "secs":60,
@@ -53,7 +49,6 @@ async fn client_builder() {
         "localPow":true,
         "fallbackToLocalPow":true,
         "tipsInterval":5,
-        "latestMilestoneTimestamp":null,
         "apiTimeout":{
             "secs":15,
             "nanos":0
@@ -61,8 +56,7 @@ async fn client_builder() {
         "remotePowTimeout":{
             "secs":100,
             "nanos":0
-        },
-        "powWorkerCount":null
+        }
     }"#;
 
     let _client_builder = serde_json::from_str::<ClientBuilder>(client_builder_json).unwrap();

--- a/sdk/tests/types/milestone_payload.rs
+++ b/sdk/tests/types/milestone_payload.rs
@@ -33,7 +33,7 @@ fn new_valid() {
                 rand_parents(),
                 rand_merkle_root(),
                 rand_merkle_root(),
-                vec![],
+                [],
                 MilestoneOptions::from_vec(vec![]).unwrap(),
             )
             .unwrap(),
@@ -55,7 +55,7 @@ fn new_invalid_no_signature() {
                 rand_parents(),
                 rand_merkle_root(),
                 rand_merkle_root(),
-                vec![],
+                [],
                 MilestoneOptions::from_vec(vec![]).unwrap(),
             )
             .unwrap(),
@@ -77,7 +77,7 @@ fn new_invalid_too_many_signatures() {
                 rand_parents(),
                 rand_merkle_root(),
                 rand_merkle_root(),
-                vec![],
+                [],
                 MilestoneOptions::from_vec(vec![]).unwrap(),
             )
             .unwrap(),
@@ -100,7 +100,7 @@ fn packed_len() {
             Parents::from_vec(rand_block_ids(4)).unwrap(),
             rand_merkle_root(),
             rand_merkle_root(),
-            vec![0x2a, 0x2a, 0x2a, 0x2a, 0x2a],
+            [0x2a, 0x2a, 0x2a, 0x2a, 0x2a],
             MilestoneOptions::from_vec(vec![]).unwrap(),
         )
         .unwrap(),
@@ -124,7 +124,7 @@ fn pack_unpack_valid() {
             rand_parents(),
             rand_merkle_root(),
             rand_merkle_root(),
-            vec![],
+            [],
             MilestoneOptions::from_vec(vec![]).unwrap(),
         )
         .unwrap(),
@@ -151,7 +151,7 @@ fn getters() {
         rand_parents(),
         rand_merkle_root(),
         rand_merkle_root(),
-        vec![],
+        [],
         MilestoneOptions::from_vec(vec![]).unwrap(),
     )
     .unwrap();

--- a/sdk/tests/types/milestone_payload_essence.rs
+++ b/sdk/tests/types/milestone_payload_essence.rs
@@ -33,7 +33,7 @@ fn new_valid() {
             rand_parents(),
             rand_merkle_root(),
             rand_merkle_root(),
-            vec![],
+            [],
             MilestoneOptions::from_vec(vec![]).unwrap(),
         )
         .is_ok()
@@ -87,7 +87,7 @@ fn getters() {
         parents.clone(),
         inclusion_merkle_root,
         applied_merkle_root,
-        vec![],
+        [],
         options,
     )
     .unwrap();
@@ -128,7 +128,7 @@ fn pack_unpack_valid() {
         rand_parents(),
         rand_merkle_root(),
         rand_merkle_root(),
-        vec![],
+        [],
         MilestoneOptions::from_vec(vec![]).unwrap(),
     )
     .unwrap();

--- a/sdk/tests/types/payload.rs
+++ b/sdk/tests/types/payload.rs
@@ -88,7 +88,7 @@ fn milestone() {
             rand_parents(),
             rand_merkle_root(),
             rand_merkle_root(),
-            vec![],
+            [],
             MilestoneOptions::from_vec(vec![]).unwrap(),
         )
         .unwrap(),

--- a/sdk/tests/utils/serde.rs
+++ b/sdk/tests/utils/serde.rs
@@ -25,7 +25,7 @@ pub struct SerdeOptionStringTest {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SerdeOptionPrefixHexVecTest {
-    #[serde(default, with = "iota_sdk::utils::serde::option_prefix_hex_vec")]
+    #[serde(default, with = "iota_sdk::utils::serde::option_prefix_hex_bytes")]
     pub metadata: Option<Vec<u8>>,
 }
 
@@ -61,7 +61,7 @@ fn serde_option_string() {
 }
 
 #[test]
-fn serde_option_prefix_hex_vec() {
+fn serde_option_prefix_hex_bytes() {
     let metadata = prefix_hex::decode(BLOCK_ID).unwrap();
     let test_1 = SerdeOptionPrefixHexVecTest {
         metadata: Some(metadata),


### PR DESCRIPTION
# Description of change

This PR removes a lot of pointless fields from serialized json, removed serde impls for types with Dtos, and generally tidies up.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
