### PR TITLE
Create nextest CI profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,7 @@ ci-check-python = "check --manifest-path bindings/python/Cargo.toml --all-target
 ci-check-wasm = "check --manifest-path bindings/wasm/Cargo.toml --target wasm32-unknown-unknown --lib"
 ci-check-nostd = "check --no-default-features -F serde -p iota-sdk --target riscv64gc-unknown-none-elf"
 
-ci-test = "nextest run --all-features --no-fail-fast --cargo-profile ci --test-threads num-cpus --retries 2 -p iota-sdk -p iota-sdk-bindings-core"
+ci-test = "nextest run --all-features --profile ci --cargo-profile ci -p iota-sdk -p iota-sdk-bindings-core"
 
 ci-clippy = "clippy --all-targets --all-features -- -D warnings"
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+fail-fast = false
+retries = 2
+test-threads = "num-cpus"
+slow-timeout = { period = "60s", terminate-after = 2 }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [develop, production]
     paths:
-      - ".github/workflows/core.yml"
+      - ".github/workflows/build-and-test.yml"
       - ".github/actions/**"
       - "**.rs" # Include all rust files
       - "**Cargo.toml" # Include all Cargo.toml files
@@ -13,7 +13,7 @@ on:
   pull_request:
     branches: [develop, production]
     paths:
-      - ".github/workflows/core.yml"
+      - ".github/workflows/build-and-test.yml"
       - ".github/actions/**"
       - "**.rs" # Include all rust files
       - "**Cargo.toml" # Include all Cargo.toml files

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,4 +53,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: nextest
-          args: run --all-features --no-fail-fast --cargo-profile ci --test-threads "num-cpus" --retries 2 -p iota-sdk -p iota-sdk-bindings-core
+          args: run --all-features --profile ci --cargo-profile ci -p iota-sdk -p iota-sdk-bindings-core

--- a/.github/workflows/private-tangle-tests.yml
+++ b/.github/workflows/private-tangle-tests.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: nextest
-          args: run --tests --all-features --no-fail-fast --run-ignored ignored-only --cargo-profile ci --retries 2 -p iota-sdk -p iota-sdk-bindings-core
+          args: run --tests --all-features --run-ignored ignored-only --profile ci --cargo-profile ci -p iota-sdk -p iota-sdk-bindings-core
 
       - name: Tear down private tangle
         if: always()


### PR DESCRIPTION
# Description of change

Creates a config file with a CI profile for `nextest`. This adds two flags that weren't used before:

- `failure-output = "immediate-final"` (this will print failed test output at the bottom of the logs in addition to above, for convenience)
- `slow-timeout = { period = "60s", terminate-after = 2 }`

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)
