### PR TITLE
Fix FilterOptions

### DIFF
--- a/.changes/filteroptions.md
+++ b/.changes/filteroptions.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Added optional `FilterOptions::{aliasIds, foundryIds, nftIds}` fields;

--- a/bindings/nodejs-old/types/account.ts
+++ b/bindings/nodejs-old/types/account.ts
@@ -173,4 +173,10 @@ export interface FilterOptions {
     upperBoundBookedTimestamp?: number;
     /** Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6) */
     outputTypes?: Uint8Array;
+    /** Return all alias outputs matching these IDs. */
+    aliasIds?: AliasId[];
+    /** Return all foundry outputs matching these IDs. */
+    foundryIds?: FoundryId[];
+    /** Return all NFT outputs matching these IDs. */
+    nftIds?: NftId[];
 }

--- a/bindings/nodejs-old/types/account.ts
+++ b/bindings/nodejs-old/types/account.ts
@@ -174,9 +174,9 @@ export interface FilterOptions {
     /** Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6) */
     outputTypes?: Uint8Array;
     /** Return all alias outputs matching these IDs. */
-    aliasIds?: AliasId[];
+    aliasIds?: string[];
     /** Return all foundry outputs matching these IDs. */
-    foundryIds?: FoundryId[];
+    foundryIds?: string[];
     /** Return all NFT outputs matching these IDs. */
-    nftIds?: NftId[];
+    nftIds?: string[];
 }

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `TransactionProgressType` export;
 - Optional `CreateAccountPayload::addresses` field;
+- Optional `FilterOptions::{aliasIds, foundryIds, nftIds}` fields;
 
 ### Changed
 

--- a/bindings/nodejs/lib/types/wallet/account.ts
+++ b/bindings/nodejs/lib/types/wallet/account.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AccountAddress, AddressWithUnspentOutputs } from './address';
+import { AliasId, FoundryId, NftId } from '../block/id';
 import type { OutputData } from './output';
 import type { Transaction } from './transaction';
 import { CoinType } from '../../client';
@@ -168,4 +169,10 @@ export interface FilterOptions {
     upperBoundBookedTimestamp?: number;
     /** Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6) */
     outputTypes?: Uint8Array;
+    /** Return all alias outputs matching these IDs. */
+    aliasIds?: AliasId[];
+    /** Return all foundry outputs matching these IDs. */
+    foundryIds?: FoundryId[];
+    /** Return all NFT outputs matching these IDs. */
+    nftIds?: NftId[];
 }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Call `ledger.set_non_interactive_mode()` only if it's a debug app;
+- Don't return other output types if alias/nft/foundry ids are provided in the `FilterOptions` for `Account::{outputs(), unspent_outputs()`;
 
 ## 0.4.0 - 2023-07-14
 

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -367,6 +367,7 @@ impl AccountInner {
                     }
                 }
 
+                // If ids are provided, only return them and no other outputs.
                 if filter.alias_ids.is_none() && filter.foundry_ids.is_none() && filter.nft_ids.is_none() {
                     filtered_outputs.push(output.clone());
                 }

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -367,7 +367,9 @@ impl AccountInner {
                     }
                 }
 
-                filtered_outputs.push(output.clone());
+                if filter.alias_ids.is_none() && filter.foundry_ids.is_none() && filter.nft_ids.is_none() {
+                    filtered_outputs.push(output.clone());
+                }
             }
 
             Ok(filtered_outputs)


### PR DESCRIPTION
# Description of change

Fix FilterOptions types in nodejs and filter logic so now if alias/foundry/nft ids are provided, no other outputs are returned

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running a nodejs example with
```
        const outputs = await account.unspentOutputs({"aliasIds": ['0x2c1c24225905a9cfa8b1ffaa70c7c5815c05ddf9cd7ba0d19a1710c7e028f482']});

        console.log(outputs);
```
now only returned this output, before also basic outputs

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
