### PR TITLE
fix: python bindings and examples

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Account::prepare_output()` deserialization;
+- `Client::build_alias_output()`, `Client::build_nft_output()`, `Client::build_basic_output`, `Client::build_foundry_output` returned type of object;
 
 ## 1.0.0-rc.1 - 2023-07-21
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.0-rc.2 - 2023-xx.xx
+
+### Fixed
+
+- `Account::prepare_output()` deserialization;
+
 ## 1.0.0-rc.1 - 2023-07-21
 
 ### Added

--- a/bindings/python/examples/how_tos/outputs/features.py
+++ b/bindings/python/examples/how_tos/outputs/features.py
@@ -1,4 +1,5 @@
 from iota_sdk import *
+from dataclasses import asdict
 from dotenv import load_dotenv
 import json
 

--- a/bindings/python/examples/how_tos/outputs/features.py
+++ b/bindings/python/examples/how_tos/outputs/features.py
@@ -73,4 +73,4 @@ nft_output = client.build_nft_output(
 )
 outputs.append(nft_output)
 
-print(json.dumps(outputs, indent=2))
+print(json.dumps([asdict(o) for o in outputs], indent=2))

--- a/bindings/python/examples/secret_manager/generate_addresses.py
+++ b/bindings/python/examples/secret_manager/generate_addresses.py
@@ -14,8 +14,7 @@ secret_manager = SecretManager(MnemonicSecretManager(os.environ['MNEMONIC']))
 # Generate public address with default account index and range.
 addresses = secret_manager.generate_ed25519_addresses()
 
-print('List of generated public addresses:', *addresses, sep='\n')
-print()
+print('List of generated public addresses:', *addresses, sep='\n', end='\n\n')
 
 addresses = secret_manager.generate_ed25519_addresses(
     coin_type=CoinType.SHIMMER,
@@ -25,5 +24,4 @@ addresses = secret_manager.generate_ed25519_addresses(
     internal=False,
     bech32_hrp='rms')
 
-print('List of generated public addresses:', *addresses, sep='\n')
-print()
+print('List of generated public addresses:', *addresses, sep='\n', end='\n\n')

--- a/bindings/python/examples/wallet/get_client.py
+++ b/bindings/python/examples/wallet/get_client.py
@@ -2,6 +2,8 @@ from iota_sdk import Wallet
 from dotenv import load_dotenv
 import os
 
+load_dotenv()
+
 # This example gets a client from the wallet.
 
 wallet = Wallet(os.environ['WALLET_DB_PATH'])

--- a/bindings/python/examples/wallet/restore_backup.py
+++ b/bindings/python/examples/wallet/restore_backup.py
@@ -1,5 +1,6 @@
 from iota_sdk import Wallet, CoinType, ClientOptions
 from dotenv import load_dotenv
+from dataclasses import asdict
 import json
 import os
 
@@ -22,4 +23,4 @@ if 'STRONGHOLD_PASSWORD' not in os.environ:
 wallet.restore_backup("backup.stronghold", os.environ['STRONGHOLD_PASSWORD'])
 
 accounts = wallet.get_accounts()
-print(f'Restored accounts: {json.dumps(accounts, indent=4)}')
+print(f'Restored accounts: {json.dumps(asdict(accounts), indent=4)}')

--- a/bindings/python/iota_sdk/client/client.py
+++ b/bindings/python/iota_sdk/client/client.py
@@ -13,7 +13,7 @@ from iota_sdk.types.common import HexStr, Node, AddressAndAmount
 from iota_sdk.types.feature import Feature
 from iota_sdk.types.native_token import NativeToken
 from iota_sdk.types.network_info import NetworkInfo
-from iota_sdk.types.output import Output
+from iota_sdk.types.output import AliasOutput, BasicOutput, FoundryOutput, NftOutput, output_from_dict
 from iota_sdk.types.payload import Payload, TransactionPayload
 from iota_sdk.types.token_scheme import SimpleTokenScheme
 from iota_sdk.types.unlock_condition import UnlockCondition
@@ -180,7 +180,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                            state_metadata: Optional[str] = None,
                            foundry_counter: Optional[int] = None,
                            features: Optional[List[Feature]] = None,
-                           immutable_features: Optional[List[Feature]] = None):
+                           immutable_features: Optional[List[Feature]] = None) -> AliasOutput:
         """Build an AliasOutput.
 
         Args:
@@ -214,7 +214,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         if amount:
             amount = str(amount)
 
-        return from_dict(Output, self._call_method('buildAliasOutput', {
+        return output_from_dict(self._call_method('buildAliasOutput', {
             'aliasId': alias_id,
             'unlockConditions': unlock_conditions,
             'amount': amount,
@@ -230,7 +230,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                            unlock_conditions: List[UnlockCondition],
                            amount: Optional[int] = None,
                            native_tokens: Optional[List[NativeToken]] = None,
-                           features: Optional[List[Feature]] = None):
+                           features: Optional[List[Feature]] = None) -> BasicOutput:
         """Build a BasicOutput.
 
         Args:
@@ -256,7 +256,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         if amount:
             amount = str(amount)
 
-        return from_dict(Output, self._call_method('buildBasicOutput', {
+        return output_from_dict(self._call_method('buildBasicOutput', {
             'unlockConditions': unlock_conditions,
             'amount': amount,
             'nativeTokens': native_tokens,
@@ -270,7 +270,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                              amount: Optional[int] = None,
                              native_tokens: Optional[List[NativeToken]] = None,
                              features: Optional[List[Feature]] = None,
-                             immutable_features: Optional[List[Feature]] = None):
+                             immutable_features: Optional[List[Feature]] = None) -> FoundryOutput:
         """Build a FoundryOutput.
 
         Args:
@@ -302,7 +302,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         if amount:
             amount = str(amount)
 
-        return from_dict(Output, self._call_method('buildFoundryOutput', {
+        return output_from_dict(self._call_method('buildFoundryOutput', {
             'serialNumber': serial_number,
             'tokenScheme': token_scheme.as_dict(),
             'unlockConditions': unlock_conditions,
@@ -318,7 +318,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                          amount: Optional[int] = None,
                          native_tokens: Optional[List[NativeToken]] = None,
                          features: Optional[List[Feature]] = None,
-                         immutable_features: Optional[List[Feature]] = None):
+                         immutable_features: Optional[List[Feature]] = None) -> NftOutput:
         """Build an NftOutput.
 
         Args:
@@ -349,7 +349,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         if amount:
             amount = str(amount)
 
-        return from_dict(Output, self._call_method('buildNftOutput', {
+        return output_from_dict(self._call_method('buildNftOutput', {
             'nftId': nft_id,
             'unlockConditions': unlock_conditions,
             'amount': amount,

--- a/bindings/python/iota_sdk/types/output.py
+++ b/bindings/python/iota_sdk/types/output.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Dict, Optional, List
+
+from dacite import from_dict
 from iota_sdk.types.common import HexStr
 from iota_sdk.types.feature import SenderFeature, IssuerFeature, MetadataFeature, TagFeature
 from iota_sdk.types.native_token import NativeToken
@@ -273,3 +275,21 @@ class OutputWithMetadata:
         config['output'] = self.output.as_dict()
 
         return config
+
+
+def output_from_dict(
+        output: Dict[str, any]) -> TreasuryOutput | BasicOutput | AliasOutput | FoundryOutput | NftOutput | Output:
+    output_type = OutputType(output['type'])
+
+    if output_type == OutputType.Treasury:
+        return from_dict(TreasuryOutput, output)
+    if output_type == OutputType.Basic:
+        return from_dict(BasicOutput, output)
+    if output_type == OutputType.Alias:
+        return from_dict(AliasOutput, output)
+    if output_type == OutputType.Foundry:
+        return from_dict(FoundryOutput, output)
+    if output_type == OutputType.NFT:
+        return from_dict(NftOutput, output)
+
+    return from_dict(Output, output)

--- a/bindings/python/iota_sdk/types/output.py
+++ b/bindings/python/iota_sdk/types/output.py
@@ -288,7 +288,7 @@ def output_from_dict(
         return from_dict(AliasOutput, output)
     if output_type == OutputType.Foundry:
         return from_dict(FoundryOutput, output)
-    if output_type == OutputType.NFT:
+    if output_type == OutputType.Nft:
         return from_dict(NftOutput, output)
 
     return from_dict(Output, output)

--- a/bindings/python/iota_sdk/types/output.py
+++ b/bindings/python/iota_sdk/types/output.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Dict, Optional, List
-
 from dacite import from_dict
 from iota_sdk.types.common import HexStr
 from iota_sdk.types.feature import SenderFeature, IssuerFeature, MetadataFeature, TagFeature

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -12,7 +12,7 @@ from iota_sdk.types.filter_options import FilterOptions
 from iota_sdk.types.native_token import NativeToken
 from iota_sdk.types.output_data import OutputData
 from iota_sdk.types.output_id import OutputId
-from iota_sdk.types.output import AliasOutput, BasicOutput, FoundryOutput, NftOutput, Output, OutputType, TreasuryOutput, output_from_dict
+from iota_sdk.types.output import  BasicOutput, NftOutput, Output, output_from_dict
 from iota_sdk.types.output_params import OutputParams
 from iota_sdk.types.transaction_data import PreparedTransactionData, SignedTransactionData
 from iota_sdk.types.send_params import CreateAliasOutputParams, CreateNativeTokenParams, MintNftParams, SendNativeTokensParams, SendNftParams, SendParams

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -12,7 +12,7 @@ from iota_sdk.types.filter_options import FilterOptions
 from iota_sdk.types.native_token import NativeToken
 from iota_sdk.types.output_data import OutputData
 from iota_sdk.types.output_id import OutputId
-from iota_sdk.types.output import Output
+from iota_sdk.types.output import AliasOutput, BasicOutput, FoundryOutput, NftOutput, Output, OutputType, TreasuryOutput, output_from_dict
 from iota_sdk.types.output_params import OutputParams
 from iota_sdk.types.transaction_data import PreparedTransactionData, SignedTransactionData
 from iota_sdk.types.send_params import CreateAliasOutputParams, CreateNativeTokenParams, MintNftParams, SendNativeTokensParams, SendNftParams, SendParams
@@ -343,12 +343,12 @@ class Account:
            When the assets contain an nft_id, the data from the existing nft output will be used, just with the address
            unlock conditions replaced
         """
-        return from_dict(Output, self._call_account_method(
+        return output_from_dict(self._call_account_method(
             'prepareOutput', {
                 'params': params,
                 'transactionOptions': transaction_options
-            }
-        ))
+            })
+        )
 
     def prepare_send(self, params: List[SendParams],
                      options: Optional[TransactionOptions] = None) -> PreparedTransaction:

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -335,7 +335,7 @@ class Account:
         ))
 
     def prepare_output(self, params: OutputParams,
-                       transaction_options: Optional[TransactionOptions] = None):
+                       transaction_options: Optional[TransactionOptions] = None) -> TreasuryOutput | AliasOutput | BasicOutput | FoundryOutput | NftOutput | Output:
         """Prepare an output for sending.
            If the amount is below the minimum required storage deposit, by default the remaining amount will automatically
            be added with a StorageDepositReturn UnlockCondition, when setting the ReturnStrategy to `gift`, the full

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -12,7 +12,7 @@ from iota_sdk.types.filter_options import FilterOptions
 from iota_sdk.types.native_token import NativeToken
 from iota_sdk.types.output_data import OutputData
 from iota_sdk.types.output_id import OutputId
-from iota_sdk.types.output import  BasicOutput, NftOutput, Output, output_from_dict
+from iota_sdk.types.output import BasicOutput, NftOutput, Output, output_from_dict
 from iota_sdk.types.output_params import OutputParams
 from iota_sdk.types.transaction_data import PreparedTransactionData, SignedTransactionData
 from iota_sdk.types.send_params import CreateAliasOutputParams, CreateNativeTokenParams, MintNftParams, SendNativeTokensParams, SendNftParams, SendParams

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -335,7 +335,7 @@ class Account:
         ))
 
     def prepare_output(self, params: OutputParams,
-                       transaction_options: Optional[TransactionOptions] = None) -> TreasuryOutput | AliasOutput | BasicOutput | FoundryOutput | NftOutput | Output:
+                       transaction_options: Optional[TransactionOptions] = None) -> BasicOutput | NftOutput:
         """Prepare an output for sending.
            If the amount is below the minimum required storage deposit, by default the remaining amount will automatically
            be added with a StorageDepositReturn UnlockCondition, when setting the ReturnStrategy to `gift`, the full


### PR DESCRIPTION
# Description of change

 - fix  `prepare_output` which was returning the `Output` class causing:
 - fix `Client::build_*` to return output of specific type
 -  minor fixes to examples
```
Traceback (most recent call last):
  File "/code/rayven/iota/iota-sdk/bindings/python/examples/wallet/12-prepare_output.py", line 30, in <module>
    transaction = account.send_outputs([output])
  File "/code/rayven/iota/iota-sdk/bindings/python/.venv/lib/python3.10/site-packages/iota_sdk/wallet/account.py", line 513, in send_outputs
    return Transaction.from_dict(self._call_account_method(
  File "/code/rayven/iota/iota-sdk/bindings/python/.venv/lib/python3.10/site-packages/iota_sdk/wallet/common.py", line 53, in wrapper
    response = call_wallet_method(args[0].handle, message)
ValueError: cannot deserialize basic output: missing field `amount` at line 1 column 122
```


Please write a summary of your changes and why you made them. 

## Links to any relevant issues
part of #388 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
