### PR TITLE
Refactor and fix prepare_output()

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add serde default to `{RemainderDataDto, InputSigningDto, OutputDataDto}::chain`;
+- `Account::prepare_output()` for low amounts;
 
 ## 1.0.0-rc.0 - 2023-07-21
 

--- a/sdk/src/wallet/account/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/account/operations/transaction/prepare_output.rs
@@ -218,9 +218,10 @@ where
                     }
                 } else {
                     // Would leave dust behind, so return what's required for a remainder
+                    let remaining = available_base_coin - final_amount;
                     return Err(crate::wallet::Error::InsufficientFunds {
                         available: available_base_coin,
-                        required: available_base_coin + min_storage_deposit_basic_output,
+                        required: available_base_coin + min_storage_deposit_basic_output - remaining,
                     });
                 }
             }

--- a/sdk/src/wallet/account/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/account/operations/transaction/prepare_output.rs
@@ -159,7 +159,6 @@ where
                     // new_amount is enough
                     second_output_builder = second_output_builder.with_amount(new_amount);
                 }
-                // Set a bool to contains_return = true so it can be increased later if needed? Or just get mut
             }
         }
 

--- a/sdk/src/wallet/account/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/account/operations/transaction/prepare_output.rs
@@ -194,8 +194,7 @@ where
                     .unwrap_or_default()
                 {
                     // add remaining amount
-                    let remaining_amount_from_balance = available_base_coin - final_amount;
-                    final_amount += remaining_amount_from_balance;
+                    final_amount += remaining_balance;
                     second_output_builder = second_output_builder.with_amount(final_amount);
 
                     if let Some(sdr) = third_output
@@ -204,7 +203,7 @@ where
                         .storage_deposit_return()
                     {
                         // create a new sdr unlock_condition with the updated amount and replace it
-                        let new_sdr_amount = sdr.amount() + remaining_amount_from_balance;
+                        let new_sdr_amount = sdr.amount() + remaining_balance;
                         second_output_builder =
                             second_output_builder.replace_unlock_condition(StorageDepositReturnUnlockCondition::new(
                                 remainder_address,
@@ -215,10 +214,9 @@ where
                     }
                 } else {
                     // Would leave dust behind, so return what's required for a remainder
-                    let remaining = available_base_coin - final_amount;
                     return Err(crate::wallet::Error::InsufficientFunds {
                         available: available_base_coin,
-                        required: available_base_coin + min_storage_deposit_basic_output - remaining,
+                        required: available_base_coin + min_storage_deposit_basic_output - remaining_balance,
                     });
                 }
             }

--- a/sdk/tests/wallet/output_preparation.rs
+++ b/sdk/tests/wallet/output_preparation.rs
@@ -640,13 +640,15 @@ async fn prepare_output_remainder_dust() -> Result<()> {
             None,
         )
         .await;
-    matches!(result, Err(iota_sdk::wallet::Error::InsufficientFunds{available, required}) if available == balance.base_coin().available() && required == balance.base_coin().available()+minimum_required_storage_deposit-1);
+    assert!(
+        matches!(result, Err(iota_sdk::wallet::Error::InsufficientFunds{available, required}) if available == balance.base_coin().available() && required == 85199)
+    );
 
     let output = account
         .prepare_output(
             OutputParams {
                 recipient_address: *address,
-                amount: 100, // leave more than min. deposit
+                amount: 100, // leave more behind than min. deposit
                 assets: None,
                 features: None,
                 unlocks: None,
@@ -670,7 +672,7 @@ async fn prepare_output_remainder_dust() -> Result<()> {
         .prepare_output(
             OutputParams {
                 recipient_address: *address,
-                amount: 100, // leave more than min. deposit
+                amount: 100, // leave more behind than min. deposit
                 assets: None,
                 features: None,
                 unlocks: None,
@@ -687,7 +689,7 @@ async fn prepare_output_remainder_dust() -> Result<()> {
     output.verify_storage_deposit(rent_structure, token_supply)?;
     // We use excess if leftover is too small, so amount == all available balance
     assert_eq!(output.amount(), 63900);
-    // storage deposit gifted, only address unlock condition
+    // storage deposit returned, address and SDR unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
     // We have ReturnStrategy::Return, so leftover amount gets returned
     let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
@@ -722,7 +724,6 @@ async fn prepare_output_only_single_nft() -> Result<()> {
     let balance = account_1.sync(None).await?;
     assert_eq!(balance.nfts().len(), 1);
 
-    println!("{:?}", balance);
     let nft_data = &account_1.unspent_outputs(None).await?[0];
     // Send NFT back to first account
     let output = account_1


### PR DESCRIPTION
# Description of change

Fixed prepare_output() for low amounts and also check remaining balance always and return an error if it would leave dust behind.
Refactored prepare_output() by adding an enum for the Basic and Nft OutputBuilders so we can have all the prepare_output() logic for both builders at once and don't need it duplicated (bit hard to see in the diff, but basically removed prepare_nft_output() https://github.com/iotaledger/iota-sdk/blob/999bb99002e041cc610f84241804435f88924cfb/sdk/src/wallet/account/operations/transaction/prepare_output.rs#L186-L357 and merged it with the basic outputs preparation).

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the prepare_output tests

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
