### PR TITLE
Fix `TokenSchemeType` serialization for `Utils.computeTokenId` in nodejs

### DIFF
--- a/bindings/core/src/method/utils.rs
+++ b/bindings/core/src/method/utils.rs
@@ -4,7 +4,7 @@
 use derivative::Derivative;
 use iota_sdk::types::block::{
     address::{Bech32Address, Hrp},
-    output::{dto::OutputDto, AliasId, NftId, OutputId, RentStructure, TokenScheme},
+    output::{dto::OutputDto, AliasId, NftId, OutputId, RentStructure},
     payload::{
         dto::MilestonePayloadDto,
         transaction::{
@@ -124,7 +124,7 @@ pub enum UtilsMethod {
     ComputeTokenId {
         alias_id: AliasId,
         serial_number: u32,
-        token_scheme_type: TokenScheme,
+        token_scheme_type: u8,
     },
     /// Computes the hash of a transaction essence.
     HashTransactionEssence {

--- a/bindings/core/src/method_handler/utils.rs
+++ b/bindings/core/src/method_handler/utils.rs
@@ -64,7 +64,7 @@ pub(crate) fn call_utils_method_internal(method: UtilsMethod) -> Result<Response
             serial_number,
             token_scheme_type,
         } => {
-            let foundry_id = FoundryId::build(&AliasAddress::new(alias_id), serial_number, token_scheme_type.kind());
+            let foundry_id = FoundryId::build(&AliasAddress::new(alias_id), serial_number, token_scheme_type);
             Response::TokenId(TokenId::from(foundry_id))
         }
         UtilsMethod::HashTransactionEssence { essence } => Response::Hash(prefix_hex::encode(

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Utils.computeStorageDeposit()`;
+- `Utils.computeTokenId()`
 
 ## 1.0.0-rc.3 - 2023-07-21
 


### PR DESCRIPTION
# Description of change

Fix serialization of `TokenSchemeType`  for `Utils.computeTokenId` in node.js bindings.

## Links to any relevant issues

fixes #855 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

```
Utils.computeTokenId(
        "0x9be5f4577d6379f40f893c03453147bb0736f401c98b23059eb3f770421690f1",
        1,
        TokenSchemeType.Simple,
    );
```
outputs 
```
0x089be5f4577d6379f40f893c03453147bb0736f401c98b23059eb3f770421690f10400000000
``` 
instead of error.

