### PR TITLE
Fix `BigInt` serialization in Wasm.

### DIFF
--- a/bindings/nodejs/lib/bindings.ts
+++ b/bindings/nodejs/lib/bindings.ts
@@ -77,7 +77,7 @@ const listenWalletAsync = (
 ): Promise<void> => {
     listenWallet(
         eventTypes,
-        function (err: any, data: string) {
+        function(err: any, data: string) {
             const parsed = JSON.parse(data);
             callback(err, new Event(parsed.accountIndex, parsed.event));
         },
@@ -99,15 +99,6 @@ const callWalletMethodAsync = (
             }
         });
     });
-
-// Allow bigint to be serialized as hex string.
-//
-// Note:
-// Serializing `bigint` to a different format, e.g. to decimal number string
-// must be done manually.
-(BigInt.prototype as any).toJSON = function () {
-    return bigIntToHex(this);
-};
 
 export {
     initLogger,

--- a/bindings/nodejs/lib/bindings.ts
+++ b/bindings/nodejs/lib/bindings.ts
@@ -77,7 +77,7 @@ const listenWalletAsync = (
 ): Promise<void> => {
     listenWallet(
         eventTypes,
-        function(err: any, data: string) {
+        function (err: any, data: string) {
             const parsed = JSON.parse(data);
             callback(err, new Event(parsed.accountIndex, parsed.event));
         },

--- a/bindings/nodejs/lib/bindings.ts
+++ b/bindings/nodejs/lib/bindings.ts
@@ -4,7 +4,7 @@
 import type { WalletEventType } from './types/wallet';
 import { Event } from './types/wallet';
 import type { WalletMethodHandler } from './wallet/wallet-method-handler';
-import { bigIntToHex, __UtilsMethods__ } from './types/utils';
+import { __UtilsMethods__ } from './types/utils';
 import type { SecretManagerMethodHandler } from './secret_manager/secret-manager-method-handler';
 import type { ClientMethodHandler } from './client/client-method-handler';
 

--- a/bindings/nodejs/lib/index.ts
+++ b/bindings/nodejs/lib/index.ts
@@ -5,14 +5,13 @@
 import 'reflect-metadata';
 import { bigIntToHex } from './utils';
 
-
 // Allow bigint to be serialized as hex string.
 //
 // Note:
 // Serializing `bigint` to a different format, e.g. to decimal number string
 // must be done manually.
-(BigInt.prototype as any).toJSON = function() {
-  return bigIntToHex(this);
+(BigInt.prototype as any).toJSON = function () {
+    return bigIntToHex(this);
 };
 
 export * from './client';

--- a/bindings/nodejs/lib/index.ts
+++ b/bindings/nodejs/lib/index.ts
@@ -3,6 +3,17 @@
 
 // Needed for class-transformer json deserialisation
 import 'reflect-metadata';
+import { bigIntToHex } from './utils';
+
+
+// Allow bigint to be serialized as hex string.
+//
+// Note:
+// Serializing `bigint` to a different format, e.g. to decimal number string
+// must be done manually.
+(BigInt.prototype as any).toJSON = function() {
+  return bigIntToHex(this);
+};
 
 export * from './client';
 export * from './secret_manager';

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.2 - 2023-MM-DD
+
+Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.
+
+### Fixed
+
+- Runtime serializtion error of `BigInt` when working with native token amounts;
+
 ## 1.0.1 - 2023-07-25
 
 Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.

--- a/bindings/wasm/lib/bindings.ts
+++ b/bindings/wasm/lib/bindings.ts
@@ -20,15 +20,6 @@ const callUtilsMethod = (method: __UtilsMethods__): any => {
     }
 };
 
-// Allow bigint to be serialized as hex string.
-//
-// Note:
-// Serializing `bigint` to a different format, e.g. to decimal number string
-// must be done manually.
-(BigInt.prototype as any).toJSON = function () {
-    return '0x' + this.toString(16);
-};
-
 export {
     initLogger,
     createClient,

--- a/bindings/wasm/lib/bindings.ts
+++ b/bindings/wasm/lib/bindings.ts
@@ -25,7 +25,7 @@ const callUtilsMethod = (method: __UtilsMethods__): any => {
 // Note:
 // Serializing `bigint` to a different format, e.g. to decimal number string
 // must be done manually.
-(BigInt.prototype as any).toJSON = function() {
+(BigInt.prototype as any).toJSON = function () {
     return '0x' + this.toString(16);
 };
 

--- a/bindings/wasm/lib/bindings.ts
+++ b/bindings/wasm/lib/bindings.ts
@@ -20,6 +20,15 @@ const callUtilsMethod = (method: __UtilsMethods__): any => {
     }
 };
 
+// Allow bigint to be serialized as hex string.
+//
+// Note:
+// Serializing `bigint` to a different format, e.g. to decimal number string
+// must be done manually.
+(BigInt.prototype as any).toJSON = function() {
+    return '0x' + this.toString(16);
+};
+
 export {
     initLogger,
     createClient,


### PR DESCRIPTION
# Description of change

Fixes serialization error in Wasm since `bindings.ts` was modified in node.js but not in Wasm.

Also maybe worth noting that we patch a built-in object to allow the serialization, although it's for `BigInt` "[not explicitly discouraged](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json)"  it might conflict with user patching `BigInt` too (I'm not sure how common is that, probably pretty rare), the solution could be to convert `bigint` values manually to a hex string for the native token amounts everywhere it's used. 

### Note
The issue can be resolved on the current `1.0.1` release by the user manually running: 

```
(BigInt.prototype as any).toJSON = function() {
    return '0x' + this.toString(16);
};
```

## Links to any relevant issues

fixes #924

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

