### PR TITLE
Fix `SenderFeature.getSender()` and `IssuerFeature.getIssuer()` in Node.js

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Constructor types in `RegularTransactionEssence`;
+- `SenderFeature.getSender()` and `IssuerFeature.getIssuer()` now return the correct types types;
 
 
 ## 1.0.1 - 2023-07-25

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Constructor types in `RegularTransactionEssence`;
-- `SenderFeature.getSender()` and `IssuerFeature.getIssuer()` now return the correct types types;
+- `SenderFeature.getSender()` and `IssuerFeature.getIssuer()` now return the correct types;
 
 
 ## 1.0.1 - 2023-07-25

--- a/bindings/nodejs/lib/types/block/output/feature.ts
+++ b/bindings/nodejs/lib/types/block/output/feature.ts
@@ -1,7 +1,8 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { Address } from '../address';
+import { Type } from 'class-transformer';
+import { Address, AddressDiscriminator } from '../address';
 
 /**
  * All of the feature block types.
@@ -29,6 +30,9 @@ abstract class Feature {
  * Sender feature.
  */
 class SenderFeature extends Feature {
+    @Type(() => Address, {
+        discriminator: AddressDiscriminator,
+    })
     private address: Address;
     constructor(sender: Address) {
         super(FeatureType.Sender);
@@ -45,6 +49,9 @@ class SenderFeature extends Feature {
  * Issuer feature.
  */
 class IssuerFeature extends Feature {
+    @Type(() => Address, {
+        discriminator: AddressDiscriminator,
+    })
     private address: Address;
     constructor(issuer: Address) {
         super(FeatureType.Issuer);


### PR DESCRIPTION
# Description of change

Both `SenderFeature.getSender()` and `IssuerFeature.getIssuer()` don't return the correct type. 

The Following code 

```typescript

    const client = new Client({
        primaryNode: NODE,
        localPow: true,
    });
    const outputResponse = await client.getOutput("0xeec64141ac0f06f3f810be2e916cb9e4955a4b9ba722744ea8ab0cc1f34ee57c0000");
    const output: NftOutput = outputResponse.output as NftOutput;
    let features = output.getImmutableFeatures();
    let issuer = (features![0] as IssuerFeature).getIssuer().getType();
```

throws an Error because `getType()` is not a function. The reason for that is `getIssuer()` returns an `Object` and not the proper type.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

- Bug fix 


## How the change has been tested

Code above runs without errors.
