### PR TITLE
feat(cli): adds hex version of address to `addresses` command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-`WalletCommand::Accounts` variant to list all available accounts in a wallet;
+- `WalletCommand::Accounts` variant to list all available accounts in a wallet;
+- `addresses` now additionally prints the hex version of the address;
 
 ## 1.0.0 - 2023-07-27
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -869,7 +869,14 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 }
 
 async fn print_address(account: &Account, address: &AccountAddress) -> Result<(), Error> {
-    let mut log = format!("Address {}: {}", address.key_index(), address.address());
+    let mut log = format!(
+        "Address {}:\n {:<10}{}\n {:<10}{:?}",
+        address.key_index(),
+        "Bech32:",
+        address.address(),
+        "Hex:",
+        address.address().inner()
+    );
 
     if *address.internal() {
         log = format!("{log}\nChange address");


### PR DESCRIPTION
# Description of change

Adds the hex version of the address when listing the addresses. This allows the user to identify the address in the details of transactions, outputs, etc.
 Another possible solution would be using the `Bech32` format when printing the `Transaction`, `Output` etc. This is not feasible, because  `bech32` requires HRP which is not available during formatting.


## Links to any relevant issues

closes #677 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

manually: 
![image](https://github.com/iotaledger/iota-sdk/assets/20909273/ec4e75b7-78fc-4b88-995f-149f140653ca)


Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
