### PR TITLE
Add production profile to nodejs bindings

### DIFF
--- a/.changes/missing-production-profile.md
+++ b/.changes/missing-production-profile.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Fixed missing production profile when no prebuild binary is available;

--- a/bindings/nodejs-old/Cargo.toml
+++ b/bindings/nodejs-old/Cargo.toml
@@ -26,3 +26,9 @@ once_cell = { version = "1.18.0", default-features = false }
 serde = { version = "1.0.175", default-features = false }
 serde_json = { version = "1.0.103", default-features = false }
 tokio = { version = "1.29.1", default-features = false }
+
+[profile.production]
+codegen-units = 1
+inherits = "release"
+lto = true
+strip = "symbols"

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.4 - 2023-MM-DD
+
+### Fixed
+
+- Missing production profile when no prebuild binary is available;
+
 ## 1.0.3 - 2023-07-31
 
 ### Fixed

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,3 +25,9 @@ neon = { version = "0.10.1", default-features = false, features = [ "napi-6", "e
 once_cell = { version = "1.18.0", default-features = false }
 serde_json = { version = "1.0.103", default-features = false }
 tokio = { version = "1.29.1", default-features = false }
+
+[profile.production]
+codegen-units = 1
+inherits = "release"
+lto = true
+strip = "symbols"


### PR DESCRIPTION
# Description of change

Add production profile to nodejs bindings, because otherwise an error is returned when building it from npm without a prebuild binary available.

## Links to any relevant issues

#977 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
