### PR TITLE
Make `last_sync` a field in `ClientInner`

### DIFF
--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.4 - 2023-MM-DD
+
+### Fixed
+
+- Clients returning the default protocol parameters when multiple Client instances are used;
+
 ## 1.0.3 - 2023-07-31
 
 Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.0.4 - 2023-MM-DD
+## 1.0.4 - 2023-08-01
 
 ### Fixed
 

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk-wasm",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "WebAssembly bindings for the IOTA SDK library",
     "repository": {
         "type": "git",

--- a/sdk/src/client/builder.rs
+++ b/sdk/src/client/builder.rs
@@ -310,6 +310,7 @@ impl ClientBuilder {
                     sender: RwLock::new(mqtt_event_tx),
                     receiver: RwLock::new(mqtt_event_rx),
                 },
+                last_sync: std::sync::Mutex::new(None),
             }),
         };
 

--- a/sdk/src/client/builder.rs
+++ b/sdk/src/client/builder.rs
@@ -310,7 +310,7 @@ impl ClientBuilder {
                     sender: RwLock::new(mqtt_event_tx),
                     receiver: RwLock::new(mqtt_event_rx),
                 },
-                last_sync: std::sync::Mutex::new(None),
+                last_sync: tokio::sync::Mutex::new(None),
             }),
         };
 

--- a/sdk/src/client/core.rs
+++ b/sdk/src/client/core.rs
@@ -54,6 +54,8 @@ pub struct ClientInner {
     pub(crate) pow_worker_count: RwLock<Option<usize>>,
     #[cfg(feature = "mqtt")]
     pub(crate) mqtt: MqttInner,
+    #[cfg(target_family = "wasm")]
+    pub(crate) last_sync: std::sync::Mutex<Option<u32>>,
 }
 
 #[derive(Default)]
@@ -104,11 +106,8 @@ impl ClientInner {
         // create invalid transactions/blocks.
         #[cfg(target_family = "wasm")]
         {
-            lazy_static::lazy_static! {
-                static ref LAST_SYNC: std::sync::Mutex<Option<u32>> = std::sync::Mutex::new(None);
-            };
             let current_time = crate::utils::unix_timestamp_now().as_secs() as u32;
-            if let Some(last_sync) = *LAST_SYNC.lock().unwrap() {
+            if let Some(last_sync) = *self.last_sync.lock().unwrap() {
                 if current_time < last_sync {
                     return Ok(self.network_info.read().await.clone());
                 }
@@ -116,8 +115,7 @@ impl ClientInner {
             let info = self.get_info().await?.node_info;
             let mut client_network_info = self.network_info.write().await;
             client_network_info.protocol_parameters = info.protocol.clone();
-
-            *LAST_SYNC.lock().unwrap() = Some(current_time + CACHE_NETWORK_INFO_TIMEOUT_IN_SECONDS);
+            *self.last_sync.lock().unwrap() = Some(current_time + CACHE_NETWORK_INFO_TIMEOUT_IN_SECONDS);
         }
 
         Ok(self.network_info.read().await.clone())


### PR DESCRIPTION
# Description of change

When using a private tangle with HRP `tst` and multiple client instances in Wasm, the HRP that is returned from `get_network_info` is `smr` on any of the client instances but the first one that calls it.

The issue with the current approach for storing the last sync time is that it is a `static`. It is thus the same across different client instances. For instance, when instantiating `client1` and `client2` and running `client1.get_network_info()`, `client1` will have the fetched protocol params from the node set. It will also update the last synced time to only fetch the params again 60s from now. However, `client2` will not have the fetched protocol params set, but because the last synced time is shared with `client1`, it will also not fetch them on the first call to `get_network_info`. Thus `client2` will return the default protocol parameters from the client, which is `smr` for the HRP.

This PR changes the last sync time from a static to a field in the client, fixing the issue.

## Links to any relevant issues

n/a

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested locally in concert with examples in identity where the issue occurred.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
