### PR TITLE
Feat/cli: added mnemonic gen from console only

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.0 - 2023-MM-DD
 
+### Changed
+
+- `WalletCommand::Mnemonic` now takes 2 optional arguments to avoid user interaction;
+
 ### Added
 
 - `WalletCommand::Accounts` variant to list all available accounts in a wallet;

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -182,7 +182,8 @@ pub enum AccountCommand {
         token_id: String,
         /// Amount to send, e.g. 1000000.
         amount: String,
-        /// Whether to gift the storage deposit for the output or not, e.g. ` true`.
+        /// Whether to gift the storage deposit for the output or not, e.g. `true`.
+        #[arg(value_parser = clap::builder::BoolishValueParser::new())]
         gift_storage_deposit: Option<bool>,
     },
     /// Send an NFT.

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{builder::BoolishValueParser, Args, Parser, Subcommand};
 use iota_sdk::{
     client::{
         constants::SHIMMER_COIN_TYPE,
@@ -63,7 +63,14 @@ pub enum WalletCommand {
         path: Option<String>,
     },
     /// Generate a random mnemonic.
-    Mnemonic,
+    Mnemonic {
+        // Output the mnemonic to the specified file.
+        #[arg(long)]
+        output_file_name: Option<String>,
+        // Output the mnemonic to the stdout.
+        #[arg(long, num_args = 0..2, default_missing_value = Some("true"), value_parser = BoolishValueParser::new())]
+        output_stdout: Option<bool>,
+    },
     /// Create a new account.
     NewAccount {
         /// Account alias, next available account index if not provided.
@@ -194,9 +201,8 @@ pub async fn migrate_stronghold_snapshot_v2_to_v3_command(path: Option<String>) 
     Ok(())
 }
 
-pub async fn mnemonic_command() -> Result<(), Error> {
-    generate_mnemonic().await?;
-
+pub async fn mnemonic_command(output_file_name: Option<String>, output_stdout: Option<bool>) -> Result<(), Error> {
+    generate_mnemonic(output_file_name, output_stdout).await?;
     Ok(())
 }
 

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -68,7 +68,7 @@ pub enum WalletCommand {
         #[arg(long)]
         output_file_name: Option<String>,
         // Output the mnemonic to the stdout.
-        #[arg(long, num_args = 0..2, default_missing_value = Some("true"), value_parser = BoolishValueParser::new())]
+        #[arg(long, num_args = 0..=1, default_missing_value = Some("true"), value_parser = BoolishValueParser::new())]
         output_stdout: Option<bool>,
     },
     /// Create a new account.

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -121,7 +121,7 @@ pub async fn enter_or_generate_mnemonic() -> Result<Mnemonic, Error> {
         .interact_on(&Term::stderr())?;
 
     let mnemnonic = match selected_choice {
-        0 => generate_mnemonic().await?,
+        0 => generate_mnemonic(None, None).await?,
         1 => enter_mnemonic()?,
         _ => unreachable!(),
     };
@@ -129,28 +129,46 @@ pub async fn enter_or_generate_mnemonic() -> Result<Mnemonic, Error> {
     Ok(mnemnonic)
 }
 
-pub async fn generate_mnemonic() -> Result<Mnemonic, Error> {
+pub async fn generate_mnemonic(
+    output_file_name: Option<String>,
+    output_stdout: Option<bool>,
+) -> Result<Mnemonic, Error> {
     let mnemonic = iota_sdk::client::generate_mnemonic()?;
     println_log_info!("Mnemonic has been generated.");
-    let choices = [
-        "Write it to the console only",
-        "Write it to a file only",
-        "Write it to the console and a file",
-    ];
 
-    let selected_choice = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select how to proceed with it")
-        .items(&choices)
-        .default(0)
-        .interact_on(&Term::stderr())?;
+    let file_path = output_file_name
+        .clone()
+        .unwrap_or(DEFAULT_MNEMONIC_FILE_PATH.to_string());
+
+    let selected_choice = match (output_file_name, output_stdout) {
+        (None, None) => {
+            let choices = [
+                "Write it to the console only",
+                "Write it to a file only",
+                "Write it to the console and a file",
+            ];
+
+            Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Select how to proceed with it")
+                .items(&choices)
+                .default(0)
+                .interact_on(&Term::stderr())?
+        }
+        // Only console
+        (None, Some(true)) => 0,
+        // Only file
+        (Some(_), Some(false)) | (Some(_), None) | (None, Some(false)) => 1,
+        // File and console
+        (Some(_), Some(true)) => 2,
+    };
 
     if [0, 2].contains(&selected_choice) {
         println!("YOUR MNEMONIC:");
         println!("{}", mnemonic.as_ref());
     }
     if [1, 2].contains(&selected_choice) {
-        write_mnemonic_to_file(DEFAULT_MNEMONIC_FILE_PATH, &mnemonic).await?;
-        println_log_info!("Mnemonic has been written to '{DEFAULT_MNEMONIC_FILE_PATH}'.");
+        write_mnemonic_to_file(&file_path, &mnemonic).await?;
+        println_log_info!("Mnemonic has been written to '{file_path}'.");
     }
 
     println_log_info!("IMPORTANT:");

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -136,12 +136,9 @@ pub async fn generate_mnemonic(
     let mnemonic = iota_sdk::client::generate_mnemonic()?;
     println_log_info!("Mnemonic has been generated.");
 
-    let file_path = output_file_name
-        .clone()
-        .unwrap_or(DEFAULT_MNEMONIC_FILE_PATH.to_string());
-
-    let selected_choice = match (output_file_name, output_stdout) {
-        (None, None) => {
+    let selected_choice = match (&output_file_name, &output_stdout) {
+        // Undecided, we give the user a choice
+        (None, None) | (None, Some(false)) => {
             let choices = [
                 "Write it to the console only",
                 "Write it to a file only",
@@ -157,7 +154,7 @@ pub async fn generate_mnemonic(
         // Only console
         (None, Some(true)) => 0,
         // Only file
-        (Some(_), Some(false)) | (Some(_), None) | (None, Some(false)) => 1,
+        (Some(_), Some(false)) | (Some(_), None) => 1,
         // File and console
         (Some(_), Some(true)) => 2,
     };
@@ -167,6 +164,8 @@ pub async fn generate_mnemonic(
         println!("{}", mnemonic.as_ref());
     }
     if [1, 2].contains(&selected_choice) {
+        let file_path = output_file_name.unwrap_or(DEFAULT_MNEMONIC_FILE_PATH.to_string());
+
         write_mnemonic_to_file(&file_path, &mnemonic).await?;
         println_log_info!("Mnemonic has been written to '{file_path}'.");
     }

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -58,8 +58,11 @@ pub async fn new_wallet(cli: WalletCli) -> Result<(Option<Wallet>, Option<String
                 let wallet = sync_command(storage_path, snapshot_path).await?;
                 (Some(wallet), None)
             }
-            WalletCommand::Mnemonic => {
-                mnemonic_command().await?;
+            WalletCommand::Mnemonic {
+                output_file_name,
+                output_stdout,
+            } => {
+                mnemonic_command(output_file_name, output_stdout).await?;
                 return Ok((None, None));
             }
             WalletCommand::NodeInfo => {


### PR DESCRIPTION
# Description of change

Allows getting mnemonic through just command line args

## Links to any relevant issues

fixes [#652](https://github.com/iotaledger/iota-sdk/issues/652)

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Test cases:
- `./wallet mnemonic --output-stdout no` -> Write to default file **DO WE WANT THIS OR BACK TO USER CHOICE**
- `./wallet mnemonic --output-stdout yes` -> Write to console
- `./wallet mnemonic --output-stdout` -> Write to console
- `./wallet mnemonic --output-file-name filename.txt` -> Writes to file
- `./wallet mnemonic --output-file-name filename.txt --output-stdout` -> Writes to file and console
- `./wallet mnemonic` -> Prompts user
