### PR TITLE
Make Allotments unique sorted

### DIFF
--- a/sdk/src/types/block/error.rs
+++ b/sdk/src/types/block/error.rs
@@ -24,12 +24,12 @@ use crate::types::block::{
 #[derive(Debug, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum Error {
+    AllotmentsNotUniqueSorted,
     ConsumedAmountOverflow,
     ConsumedNativeTokensAmountOverflow,
     CreatedAmountOverflow,
     CreatedNativeTokensAmountOverflow,
     Crypto(CryptoError),
-    DuplicateAllotment(AccountId),
     DuplicateSignatureUnlock(u16),
     DuplicateUtxo(UtxoInput),
     ExpirationUnlockConditionZero,
@@ -122,12 +122,12 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::AllotmentsNotUniqueSorted => write!(f, "allotments are not unique and/or sorted"),
             Self::ConsumedAmountOverflow => write!(f, "consumed amount overflow"),
             Self::ConsumedNativeTokensAmountOverflow => write!(f, "consumed native tokens amount overflow"),
             Self::CreatedAmountOverflow => write!(f, "created amount overflow"),
             Self::CreatedNativeTokensAmountOverflow => write!(f, "created native tokens amount overflow"),
             Self::Crypto(e) => write!(f, "cryptographic error: {e}"),
-            Self::DuplicateAllotment(id) => write!(f, "duplicate allotment, account ID: {id}"),
             Self::DuplicateSignatureUnlock(index) => {
                 write!(f, "duplicate signature unlock at index: {index}")
             }

--- a/sdk/src/types/block/mana/allotment.rs
+++ b/sdk/src/types/block/mana/allotment.rs
@@ -21,6 +21,18 @@ pub struct Allotment {
     pub(crate) mana: u64,
 }
 
+impl PartialOrd for Allotment {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Allotment {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.account_id.cmp(&other.account_id)
+    }
+}
+
 impl Allotment {
     pub fn new(account_id: AccountId, mana: u64) -> Result<Self, Error> {
         if mana > MAX_THEORETICAL_MANA {

--- a/sdk/src/types/block/payload/transaction/essence/regular.rs
+++ b/sdk/src/types/block/payload/transaction/essence/regular.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use alloc::vec::Vec;
+use alloc::{collections::BTreeSet, vec::Vec};
 
 use hashbrown::HashSet;
 use packable::{bounded::BoundedU16, prefix::BoxedSlicePrefix, Packable};
@@ -26,7 +26,7 @@ pub struct RegularTransactionEssenceBuilder {
     inputs: Vec<Input>,
     inputs_commitment: InputsCommitment,
     outputs: Vec<Output>,
-    allotments: Vec<Allotment>,
+    allotments: BTreeSet<Allotment>,
     payload: OptionalPayload,
     creation_time: Option<u64>,
 }
@@ -39,7 +39,7 @@ impl RegularTransactionEssenceBuilder {
             inputs: Vec::new(),
             inputs_commitment,
             outputs: Vec::new(),
-            allotments: Vec::new(),
+            allotments: BTreeSet::new(),
             payload: OptionalPayload::default(),
             creation_time: None,
         }
@@ -81,9 +81,15 @@ impl RegularTransactionEssenceBuilder {
         self
     }
 
-    /// Add an allotment to a [`RegularTransactionEssenceBuilder`].
+    /// Add an [`Allotment`] to a [`RegularTransactionEssenceBuilder`].
     pub fn add_allotment(mut self, allotment: Allotment) -> Self {
-        self.allotments.push(allotment);
+        self.allotments.insert(allotment);
+        self
+    }
+
+    /// Replaces an [`Allotment`] of the [`RegularTransactionEssenceBuilder`] with a new one, or adds it.
+    pub fn replace_allotment(mut self, allotment: Allotment) -> Self {
+        self.allotments.replace(allotment);
         self
     }
 
@@ -126,7 +132,7 @@ impl RegularTransactionEssenceBuilder {
             verify_outputs::<true>(&outputs, protocol_parameters)?;
         }
 
-        let allotments = Allotments::from_vec(self.allotments)?;
+        let allotments = Allotments::from_set(self.allotments)?;
 
         verify_payload::<true>(&self.payload)?;
 


### PR DESCRIPTION
# Description of change

This PR fixes the `Allotments` type so that it is unique and sorted by `AccountId` like other similar types.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
