### PR TITLE
fix: Prevent webpack loading bindings when importing UTXOInput type

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,7 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.0.4 - 2023-MM-DD
+## 1.0.5 - YYYY-MM-DD
+
+
+## 1.0.4 - 2023-08-03
+
+### Changed
+
+- Prevent loading of bindings when importing UTXOInput type (changed UTXOInput.fromOutputId implementation)
 
 ### Fixed
 

--- a/bindings/nodejs/lib/index.ts
+++ b/bindings/nodejs/lib/index.ts
@@ -3,6 +3,8 @@
 
 // Needed for class-transformer json deserialisation
 import 'reflect-metadata';
+import { callUtilsMethod } from './bindings';
+import { OutputId, UTXOInput } from './types';
 import { bigIntToHex } from './utils';
 
 // Allow bigint to be serialized as hex string.
@@ -13,6 +15,23 @@ import { bigIntToHex } from './utils';
 (BigInt.prototype as any).toJSON = function () {
     return bigIntToHex(this);
 };
+
+// Assign the util method on UTXOInput here,
+// to prevent loading bindings (callUtilsMethod) when importing UTXOInput just for typing.
+Object.assign(UTXOInput, {
+    /**
+     * Creates a `UTXOInput` from an output id.
+     */
+    fromOutputId(outputId: OutputId): UTXOInput {
+        const input = callUtilsMethod({
+            name: 'outputIdToUtxoInput',
+            data: {
+                outputId,
+            },
+        });
+        return new UTXOInput(input.transactionId, input.transactionOutputIndex);
+    },
+});
 
 export * from './client';
 export * from './secret_manager';

--- a/bindings/nodejs/lib/types/block/input/input.ts
+++ b/bindings/nodejs/lib/types/block/input/input.ts
@@ -69,14 +69,15 @@ class UTXOInput extends Input {
      */
     static fromOutputId(outputId: OutputId): UTXOInput {
         const source = outputId.startsWith("0x") ? outputId.substring(2) : outputId;
-        const inputHexLe = source.slice(64);
-        const chunks = [inputHexLe.substring(0, 2), inputHexLe.substring(2)];
-        const separated = chunks.map(n => parseInt(n, 16))
-        const buf = Uint8Array.from(separated).buffer;
-        const view = new DataView(buf);
+        const indexHexLe = source.slice(64);
+        const chunks = [indexHexLe.substring(0, 2), indexHexLe.substring(2)];
+        const buffer = Uint8Array.from(
+            chunks.map(n => parseInt(n, 16))
+        ).buffer;
+        const indexData = new DataView(buffer);
 
         const transactionId = source.substring(0, source.length - 4);
-        const transactionOutputIndex = view.getUint16(0, true);
+        const transactionOutputIndex = indexData.getUint16(0, true);
 
         return new UTXOInput(`0x${transactionId}`, transactionOutputIndex);
     }

--- a/bindings/nodejs/lib/types/block/input/input.ts
+++ b/bindings/nodejs/lib/types/block/input/input.ts
@@ -68,11 +68,13 @@ class UTXOInput extends Input {
      * Creates a `UTXOInput` from an output id.
      */
     static fromOutputId(outputId: OutputId): UTXOInput {
-        const source = outputId.startsWith("0x") ? outputId.substring(2) : outputId;
+        const source = outputId.startsWith('0x')
+            ? outputId.substring(2)
+            : outputId;
         const indexHexLe = source.slice(64);
         const chunks = [indexHexLe.substring(0, 2), indexHexLe.substring(2)];
         const buffer = Uint8Array.from(
-            chunks.map(n => parseInt(n, 16))
+            chunks.map((n) => parseInt(n, 16)),
         ).buffer;
         const indexData = new DataView(buffer);
 

--- a/bindings/nodejs/lib/types/block/input/input.ts
+++ b/bindings/nodejs/lib/types/block/input/input.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { callUtilsMethod } from '../../../bindings';
 import { HexEncodedString } from '../../utils';
 import { OutputId } from '../output';
 
@@ -69,13 +68,17 @@ class UTXOInput extends Input {
      * Creates a `UTXOInput` from an output id.
      */
     static fromOutputId(outputId: OutputId): UTXOInput {
-        const input = callUtilsMethod({
-            name: 'outputIdToUtxoInput',
-            data: {
-                outputId,
-            },
-        });
-        return new UTXOInput(input.transactionId, input.transactionOutputIndex);
+        const source = outputId.startsWith("0x") ? outputId.substring(2) : outputId;
+        const inputHexLe = source.slice(64);
+        const chunks = [inputHexLe.substring(0, 2), inputHexLe.substring(2)];
+        const separated = chunks.map(n => parseInt(n, 16))
+        const buf = Uint8Array.from(separated).buffer;
+        const view = new DataView(buf);
+
+        const transactionId = source.substring(0, source.length - 4);
+        const transactionOutputIndex = view.getUint16(0, true);
+
+        return new UTXOInput(`0x${transactionId}`, transactionOutputIndex);
     }
 }
 

--- a/bindings/nodejs/lib/types/block/input/input.ts
+++ b/bindings/nodejs/lib/types/block/input/input.ts
@@ -67,21 +67,10 @@ class UTXOInput extends Input {
     /**
      * Creates a `UTXOInput` from an output id.
      */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     static fromOutputId(outputId: OutputId): UTXOInput {
-        const source = outputId.startsWith('0x')
-            ? outputId.substring(2)
-            : outputId;
-        const indexHexLe = source.slice(64);
-        const chunks = [indexHexLe.substring(0, 2), indexHexLe.substring(2)];
-        const buffer = Uint8Array.from(
-            chunks.map((n) => parseInt(n, 16)),
-        ).buffer;
-        const indexData = new DataView(buffer);
-
-        const transactionId = source.substring(0, source.length - 4);
-        const transactionOutputIndex = indexData.getUint16(0, true);
-
-        return new UTXOInput(`0x${transactionId}`, transactionOutputIndex);
+        // Implementation injected in lib/index.ts, as it uses bindings.
+        return null as unknown as UTXOInput;
     }
 }
 

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Node.js binding to the IOTA SDK library",
     "main": "out/index.js",
     "types": "out/index.d.ts",


### PR DESCRIPTION
# Description of change

- Moved `UTXOInput#fromOutputId` static function to `lib/index.ts` to be attached dynamically.

Prevents webpack loading bindings when just importing UTXOInput type.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested the static function manually with some outputId cases.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes
