### PR TITLE
Remove promote functions

### DIFF
--- a/bindings/core/src/method/client.rs
+++ b/bindings/core/src/method/client.rs
@@ -309,19 +309,6 @@ pub enum ClientMethod {
         /// Block ID
         block_id: BlockId,
     },
-    /// Promotes a block. The method should validate if a promotion is necessary through get_block. If not, the
-    /// method should error out and should not allow unnecessary promotions.
-    #[serde(rename_all = "camelCase")]
-    Promote {
-        /// Block ID
-        block_id: BlockId,
-    },
-    /// Promote a block without checking if it should be promoted
-    #[serde(rename_all = "camelCase")]
-    PromoteUnchecked {
-        /// Block ID
-        block_id: BlockId,
-    },
 
     //////////////////////////////////////////////////////////////////////
     // Utils

--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -300,14 +300,6 @@ pub(crate) async fn call_client_method_internal(client: &Client, method: ClientM
             let (block_id, block) = client.reattach_unchecked(&block_id).await?;
             Response::Reattached((block_id, BlockDto::from(&block)))
         }
-        ClientMethod::Promote { block_id } => {
-            let (block_id, block) = client.promote(&block_id).await?;
-            Response::Promoted((block_id, BlockDto::from(&block)))
-        }
-        ClientMethod::PromoteUnchecked { block_id } => {
-            let (block_id, block) = client.promote_unchecked(&block_id).await?;
-            Response::Promoted((block_id, BlockDto::from(&block)))
-        }
         ClientMethod::HexToBech32 { hex, bech32_hrp } => {
             Response::Bech32Address(client.hex_to_bech32(&hex, bech32_hrp).await?)
         }

--- a/bindings/core/src/response.rs
+++ b/bindings/core/src/response.rs
@@ -156,10 +156,6 @@ pub enum Response {
     /// - [`ReattachUnchecked`](crate::method::ClientMethod::ReattachUnchecked)
     Reattached((BlockId, BlockDto)),
     /// Response for:
-    /// - [`Promote`](crate::method::ClientMethod::Promote)
-    /// - [`PromoteUnchecked`](crate::method::ClientMethod::PromoteUnchecked)
-    Promoted((BlockId, BlockDto)),
-    /// Response for:
     /// - [`Bech32ToHex`](crate::method::UtilsMethod::Bech32ToHex)
     Bech32ToHex(String),
     /// Response for:

--- a/bindings/nodejs/lib/client/client.ts
+++ b/bindings/nodejs/lib/client/client.ts
@@ -704,36 +704,6 @@ export class Client {
     }
 
     /**
-     * Promotes a block. The method should validate if a promotion is necessary through get_block. If not, the
-     * method should error out and should not allow unnecessary promotions.
-     */
-    async promote(blockId: BlockId): Promise<[BlockId, Block]> {
-        const response = await this.methodHandler.callMethod({
-            name: 'promote',
-            data: {
-                blockId,
-            },
-        });
-        const parsed = JSON.parse(response) as Response<[BlockId, Block]>;
-        const block = plainToInstance(Block, parsed.payload[1]);
-        return [parsed.payload[0], block];
-    }
-    /**
-     * Promote a block without checking if it should be promoted
-     */
-    async promoteUnchecked(blockId: BlockId): Promise<[BlockId, Block]> {
-        const response = await this.methodHandler.callMethod({
-            name: 'promoteUnchecked',
-            data: {
-                blockId,
-            },
-        });
-        const parsed = JSON.parse(response) as Response<[BlockId, Block]>;
-        const block = plainToInstance(Block, parsed.payload[1]);
-        return [parsed.payload[0], block];
-    }
-
-    /**
      * Returns the unhealthy nodes.
      */
     async unhealthyNodes(): Promise<Set<INode>> {

--- a/bindings/nodejs/lib/types/client/bridge/client.ts
+++ b/bindings/nodejs/lib/types/client/bridge/client.ts
@@ -303,20 +303,6 @@ export interface __ReattachUncheckedMethod__ {
     };
 }
 
-export interface __PromoteMethod__ {
-    name: 'promote';
-    data: {
-        blockId: BlockId;
-    };
-}
-
-export interface __PromoteUncheckedMethod__ {
-    name: 'promoteUnchecked';
-    data: {
-        blockId: BlockId;
-    };
-}
-
 export interface __UnhealthyNodesMethod__ {
     name: 'unhealthyNodes';
 }

--- a/bindings/nodejs/lib/types/client/bridge/index.ts
+++ b/bindings/nodejs/lib/types/client/bridge/index.ts
@@ -45,8 +45,6 @@ import type {
     __RetryUntilIncludedMethod__,
     __ReattachMethod__,
     __ReattachUncheckedMethod__,
-    __PromoteMethod__,
-    __PromoteUncheckedMethod__,
     __UnhealthyNodesMethod__,
     __BuildBasicOutputMethod__,
     __BuildAliasOutputMethod__,
@@ -104,8 +102,6 @@ export type __ClientMethods__ =
     | __RetryUntilIncludedMethod__
     | __ReattachMethod__
     | __ReattachUncheckedMethod__
-    | __PromoteMethod__
-    | __PromoteUncheckedMethod__
     | __UnhealthyNodesMethod__
     | __BuildBasicOutputMethod__
     | __BuildAliasOutputMethod__

--- a/bindings/nodejs/tests/client/messageMethods.spec.ts
+++ b/bindings/nodejs/tests/client/messageMethods.spec.ts
@@ -42,22 +42,6 @@ describe.skip('Block methods', () => {
         expect(blockRaw).toBeDefined();
     });
 
-    it('promotes a block', async () => {
-        const tips = await client.getTips();
-
-        // Promote a block without checking if it should be promoted
-        const promoteUnchecked = await client.promoteUnchecked(
-            tips[0],
-        );
-
-        expect(promoteUnchecked[1].parents).toContain(tips[0]);
-
-        // Returns expected error: no need to promote or reattach.
-        await expect(client.promote(tips[0])).rejects.toMatch(
-            'NoNeedPromoteOrReattach',
-        );
-    });
-
     it('reattaches a block', async () => {
         const tips = await client.getTips();
 

--- a/bindings/python/iota_sdk/client/_high_level_api.py
+++ b/bindings/python/iota_sdk/client/_high_level_api.py
@@ -202,34 +202,3 @@ class HighLevelAPI():
         })
         result[1] = Block.from_dict(result[1])
         return result
-
-    def promote(self, block_id: HexStr) -> List[HexStr | Block]:
-        """Promotes a block. The method should validate if a promotion is necessary through get_block.
-        If not, the method should error out and should not allow unnecessary promotions.
-
-        Args:
-            block_id: A block id of a block that should be promoted.
-
-        Returns:
-            The block id and block that promoted the provided block.
-        """
-        result = self._call_method('promote', {
-            'blockId': block_id
-        })
-        result[1] = Block.from_dict(result[1])
-        return result
-
-    def promote_unchecked(self, block_id: HexStr) -> List[HexStr | Block]:
-        """Promote a block without checking if it should be promoted.
-
-        Args:
-            block_id: A block id of a block that should be promoted.
-
-        Returns:
-            The block id and block that promoted the provided block.
-        """
-        result = self._call_method('promoteUnchecked', {
-            'blockId': block_id
-        })
-        result[1] = Block.from_dict(result[1])
-        return result

--- a/sdk/src/client/api/high_level.rs
+++ b/sdk/src/client/api/high_level.rs
@@ -67,11 +67,9 @@ impl Client {
     /// Retries (promotes or reattaches) a block for provided block id. Block should only be
     /// retried only if they are valid and haven't been confirmed for a while.
     pub async fn retry(&self, block_id: &BlockId) -> Result<(BlockId, Block)> {
-        // Get the metadata to check if it needs to promote or reattach
+        // Get the metadata to check if it needs to reattach
         let block_metadata = self.get_block_metadata(block_id).await?;
-        if block_metadata.should_promote.unwrap_or(false) {
-            self.promote_unchecked(block_id).await
-        } else if block_metadata.should_reattach.unwrap_or(false) {
+        if block_metadata.should_reattach.unwrap_or(false) {
             self.reattach_unchecked(block_id).await
         } else {
             Err(Error::NoNeedPromoteOrReattach(block_id.to_string()))
@@ -132,12 +130,9 @@ impl Client {
                         LedgerInclusionState::Conflicting => conflicting = true,
                     };
                 }
-                // Only reattach or promote latest attachment of the block
+                // Only reattach latest attachment of the block
                 if index == block_ids_len - 1 {
-                    if block_metadata.should_promote.unwrap_or(false) {
-                        // Safe to unwrap since we iterate over it
-                        self.promote_unchecked(block_ids.last().unwrap()).await?;
-                    } else if block_metadata.should_reattach.unwrap_or(false) {
+                    if block_metadata.should_reattach.unwrap_or(false) {
                         // Safe to unwrap since we iterate over it
                         let reattached = self.reattach_unchecked(block_ids.last().unwrap()).await?;
                         block_ids.push(reattached.0);
@@ -250,42 +245,6 @@ impl Client {
         let block_id = self.post_block_raw(&reattach_block).await?;
 
         Ok((block_id, reattach_block))
-    }
-
-    /// Promotes a block. The method should validate if a promotion is necessary through get_block. If not, the
-    /// method should error out and should not allow unnecessary promotions.
-    pub async fn promote(&self, block_id: &BlockId) -> Result<(BlockId, Block)> {
-        let metadata = self.get_block_metadata(block_id).await?;
-        if metadata.should_promote.unwrap_or(false) {
-            self.promote_unchecked(block_id).await
-        } else {
-            Err(Error::NoNeedPromoteOrReattach(block_id.to_string()))
-        }
-    }
-
-    /// Promote a block without checking if it should be promoted
-    pub async fn promote_unchecked(&self, block_id: &BlockId) -> Result<(BlockId, Block)> {
-        // Create a new block (zero value block) for which one tip would be the actual block.
-        let mut tips = self.get_tips().await?;
-        if let Some(tip) = tips.first_mut() {
-            *tip = *block_id;
-        }
-
-        let block = self.get_block(block_id).await?;
-
-        let promote_block = self
-            .finish_basic_block_builder(
-                block.issuer_id(),
-                *block.signature(),
-                None,
-                Some(Parents::from_vec(tips)?),
-                None,
-            )
-            .await?;
-
-        let block_id = self.post_block_raw(&promote_block).await?;
-
-        Ok((block_id, promote_block))
     }
 
     /// Returns the local time checked with the timestamp of the latest milestone, if the difference is larger than 5

--- a/sdk/src/client/api/high_level.rs
+++ b/sdk/src/client/api/high_level.rs
@@ -22,7 +22,6 @@ use crate::{
             core::Block,
             input::{Input, UtxoInput, INPUT_COUNT_MAX},
             output::OutputWithMetadata,
-            parent::Parents,
             payload::{
                 transaction::{TransactionEssence, TransactionId},
                 Payload,

--- a/sdk/src/wallet/account/operations/retry.rs
+++ b/sdk/src/wallet/account/operations/retry.rs
@@ -108,12 +108,9 @@ where
                             LedgerInclusionState::Conflicting => conflicting = true,
                         };
                     }
-                    // Only reattach or promote latest attachment of the block
+                    // Only reattach latest attachment of the block
                     if index == block_ids_len - 1 {
-                        if block_metadata.should_promote.unwrap_or(false) {
-                            // Safe to unwrap since we iterate over it
-                            self.client().promote_unchecked(block_ids.last().unwrap()).await?;
-                        } else if block_metadata.should_reattach.unwrap_or(false) {
+                        if block_metadata.should_reattach.unwrap_or(false) {
                             let reattached_block = self
                                 .client()
                                 .finish_basic_block_builder(


### PR DESCRIPTION
# Description of change

Remove promote functions since in 2.0 the confirmation rate is expected to be very high and Mana is necessary to issue a block, therefore it doesn't really make sense anymore to promote blocks 

There are still some comments with "promote", will remove that when changing the retry/reattach functions

## Links to any relevant issues

Part of https://github.com/iotaledger/iota-sdk/issues/934

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
