### PR TITLE
Add Get Issuance Route

### DIFF
--- a/bindings/core/src/method/client.rs
+++ b/bindings/core/src/method/client.rs
@@ -146,8 +146,8 @@ pub enum ClientMethod {
     GetInfo,
     /// Get peers
     GetPeers,
-    /// Get tips
-    GetTips,
+    /// Get issuance
+    GetIssuance,
     /// Post block (JSON)
     PostBlock {
         /// Block

--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -195,7 +195,7 @@ pub(crate) async fn call_client_method_internal(client: &Client, method: ClientM
         ClientMethod::GetNodeInfo { url, auth } => Response::NodeInfo(Client::get_node_info(&url, auth).await?),
         ClientMethod::GetInfo => Response::Info(client.get_info().await?),
         ClientMethod::GetPeers => Response::Peers(client.get_peers().await?),
-        ClientMethod::GetTips => Response::Tips(client.get_tips().await?),
+        ClientMethod::GetIssuance => Response::Issuance(client.get_issuance().await?),
         ClientMethod::PostBlockRaw { block_bytes } => Response::BlockId(
             client
                 .post_block_raw(&Block::unpack_strict(

--- a/bindings/core/src/response.rs
+++ b/bindings/core/src/response.rs
@@ -102,9 +102,6 @@ pub enum Response {
     /// - [`GetPeers`](crate::method::ClientMethod::GetPeers)
     Peers(Vec<PeerResponse>),
     /// Response for:
-    /// - [`GetTips`](crate::method::ClientMethod::GetTips)
-    Tips(Vec<BlockId>),
-    /// Response for:
     /// - [`GetIssuance`](crate::method::ClientMethod::GetIssuance)
     Issuance(IssuanceBlockHeaderResponse),
     /// Response for:

--- a/bindings/core/src/response.rs
+++ b/bindings/core/src/response.rs
@@ -16,7 +16,8 @@ use iota_sdk::{
     types::{
         api::{
             core::response::{
-                BlockMetadataResponse, InfoResponse as NodeInfo, OutputWithMetadataResponse, PeerResponse,
+                BlockMetadataResponse, InfoResponse as NodeInfo, IssuanceBlockHeaderResponse,
+                OutputWithMetadataResponse, PeerResponse,
             },
             plugins::indexer::OutputIdsResponse,
         },
@@ -103,6 +104,9 @@ pub enum Response {
     /// Response for:
     /// - [`GetTips`](crate::method::ClientMethod::GetTips)
     Tips(Vec<BlockId>),
+    /// Response for:
+    /// - [`GetIssuance`](crate::method::ClientMethod::GetIssuance)
+    Issuance(IssuanceBlockHeaderResponse),
     /// Response for:
     /// - [`GetBlock`](crate::method::ClientMethod::GetBlock)
     /// - [`GetIncludedBlock`](crate::method::ClientMethod::GetIncludedBlock)

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -408,8 +408,8 @@ path = "examples/client/node_api_core/01_get_routes.rs"
 required-features = ["client"]
 
 [[example]]
-name = "node_api_core_get_tips"
-path = "examples/client/node_api_core/03_get_tips.rs"
+name = "node_api_core_get_issuance"
+path = "examples/client/node_api_core/03_get_issuance.rs"
 required-features = ["client"]
 
 [[example]]

--- a/sdk/examples/client/block/02_block_custom_parents.rs
+++ b/sdk/examples/client/block/02_block_custom_parents.rs
@@ -8,10 +8,7 @@
 //! cargo run --release --example block_custom_parents
 //! ```
 
-use iota_sdk::{
-    client::{Client, Result},
-    types::block::parent::StrongParents,
-};
+use iota_sdk::client::{Client, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -23,9 +20,9 @@ async fn main() -> Result<()> {
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;
 
-    // Use tips as custom parents.
-    let tips = client.get_tips().await?;
-    println!("Custom tips:\n{tips:#?}");
+    // Use issuance as custom parents.
+    let issuance = client.get_issuance().await?;
+    println!("Issuance:\n{issuance:#?}");
 
     // Create and send the block with custom parents.
     let block = client
@@ -33,7 +30,7 @@ async fn main() -> Result<()> {
             todo!("issuer id"),
             todo!("block signature"),
             todo!("issuing time"),
-            Some(StrongParents::from_vec(tips)?),
+            Some(issuance.strong_parents),
             None,
         )
         .await?;

--- a/sdk/examples/client/get_block.rs
+++ b/sdk/examples/client/get_block.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         .await?;
 
     // Fetch a block ID from the node.
-    let block_id = client.get_tips().await?[0];
+    let block_id = client.get_issuance().await?.strong_parents[0];
 
     // Get the block.
     let block = client.get_block(&block_id).await?;

--- a/sdk/examples/client/node_api_core/03_get_issuance.rs
+++ b/sdk/examples/client/node_api_core/03_get_issuance.rs
@@ -1,11 +1,12 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Returns tips that are ideal for attaching a block by querying its `/api/core/v3/tips` endpoint.
+//! Returns issuance with parents that are ideal for attaching a block by querying
+//! the `/api/core/v3/issuance` endpoint.
 //!
 //! Rename `.env.example` to `.env` first, then run the command:
 //! ```sh
-//! cargo run --release --example node_api_core_get_tips [NODE URL]
+//! cargo run --release --example node_api_core_get_issuance [NODE URL]
 //! ```
 
 use iota_sdk::client::{Client, Result};
@@ -23,10 +24,10 @@ async fn main() -> Result<()> {
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;
 
-    // Get tips.
-    let tips = client.get_issuance().await?.strong_parents;
+    // Get issuance.
+    let issuance = client.get_issuance().await?;
 
-    println!("Tips:\n{tips:#?}");
+    println!("Issuance:\n{issuance:#?}");
 
     Ok(())
 }

--- a/sdk/examples/client/node_api_core/03_get_tips.rs
+++ b/sdk/examples/client/node_api_core/03_get_tips.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     let client = Client::builder().with_node(&node_url)?.finish().await?;
 
     // Get tips.
-    let tips = client.get_tips().await?;
+    let tips = client.get_issuance().await?.strong_parents;
 
     println!("Tips:\n{tips:#?}");
 

--- a/sdk/examples/client/node_api_core/06_get_block.rs
+++ b/sdk/examples/client/node_api_core/06_get_block.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         block_id
     } else {
         // ... fetch one from the node.
-        client.get_tips().await?[0]
+        client.get_issuance().await?.strong_parents[0]
     };
 
     // Get the block.

--- a/sdk/examples/client/node_api_core/07_get_block_raw.rs
+++ b/sdk/examples/client/node_api_core/07_get_block_raw.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         block_id
     } else {
         // ... fetch one from the node.
-        client.get_tips().await?[0]
+        client.get_issuance().await?.strong_parents[0]
     };
 
     // Get the block as raw bytes.

--- a/sdk/examples/client/node_api_core/08_get_block_metadata.rs
+++ b/sdk/examples/client/node_api_core/08_get_block_metadata.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         block_id
     } else {
         // ... fetch one from the node.
-        client.get_tips().await?[0]
+        client.get_issuance().await?.strong_parents[0]
     };
 
     // Send the request.

--- a/sdk/src/client/api/block_builder/mod.rs
+++ b/sdk/src/client/api/block_builder/mod.rs
@@ -27,6 +27,7 @@ impl ClientInner {
             weak_parents,
             shallow_like_parents,
             latest_finalized_slot,
+            commitment,
         } = self.get_issuance().await?;
         let strong_parents = strong_parents.unwrap_or(default_strong_parents);
 
@@ -43,12 +44,10 @@ impl ClientInner {
             issuing_time
         });
 
-        let slot_commitment_id = self.get_slot_commitment_by_index(latest_finalized_slot).await?.id();
-
         Ok(Block::build_basic(
             self.get_protocol_parameters().await?,
             issuing_time,
-            slot_commitment_id,
+            commitment.id(),
             latest_finalized_slot,
             issuer_id,
             strong_parents,

--- a/sdk/src/client/api/block_builder/mod.rs
+++ b/sdk/src/client/api/block_builder/mod.rs
@@ -7,7 +7,10 @@ pub mod transaction;
 pub use self::transaction::verify_semantic;
 use crate::{
     client::{ClientInner, Result},
-    types::block::{core::Block, parent::StrongParents, payload::Payload, signature::Ed25519Signature, IssuerId},
+    types::{
+        api::core::response::IssuanceBlockHeaderResponse,
+        block::{core::Block, parent::StrongParents, payload::Payload, signature::Ed25519Signature, IssuerId},
+    },
 };
 
 impl ClientInner {
@@ -19,11 +22,13 @@ impl ClientInner {
         strong_parents: Option<StrongParents>,
         payload: Option<Payload>,
     ) -> Result<Block> {
-        // Use tips as strong parents if none are provided.
-        let strong_parents = match strong_parents {
-            Some(strong_parents) => strong_parents,
-            None => StrongParents::from_vec(self.get_tips().await?)?,
-        };
+        let IssuanceBlockHeaderResponse {
+            strong_parents: default_strong_parents,
+            weak_parents,
+            shallow_like_parents,
+            latest_finalized_slot,
+        } = self.get_issuance().await?;
+        let strong_parents = strong_parents.unwrap_or(default_strong_parents);
 
         let issuing_time = issuing_time.unwrap_or_else(|| {
             #[cfg(feature = "std")]
@@ -38,8 +43,6 @@ impl ClientInner {
             issuing_time
         });
 
-        let node_info = self.get_info().await?.node_info;
-        let latest_finalized_slot = node_info.status.latest_finalized_slot;
         let slot_commitment_id = self.get_slot_commitment_by_index(latest_finalized_slot).await?.id();
 
         Ok(Block::build_basic(
@@ -51,6 +54,8 @@ impl ClientInner {
             strong_parents,
             signature,
         )
+        .with_weak_parents(weak_parents)
+        .with_shallow_like_parents(shallow_like_parents)
         .with_payload(payload)
         .finish()?)
     }

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -101,7 +101,7 @@ impl ClientInner {
         self.node_manager
             .read()
             .await
-            .get_request::<IssuanceBlockHeaderResponse>(PATH, None, self.get_timeout().await, false, false)
+            .get_request(PATH, None, self.get_timeout().await, false, false)
             .await
     }
 

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -15,8 +15,8 @@ use crate::{
     },
     types::{
         api::core::response::{
-            BlockMetadataResponse, InfoResponse, PeerResponse, RoutesResponse, SubmitBlockResponse, TipsResponse,
-            UtxoChangesResponse,
+            BlockMetadataResponse, InfoResponse, IssuanceBlockHeaderResponse, PeerResponse, RoutesResponse,
+            SubmitBlockResponse, UtxoChangesResponse,
         },
         block::{
             output::{dto::OutputDto, Output, OutputId, OutputMetadata},
@@ -93,19 +93,16 @@ impl ClientInner {
 
     // Blocks routes.
 
-    /// Returns tips that are ideal for attaching a block.
-    /// GET /api/core/v3/tips
-    pub async fn get_tips(&self) -> Result<Vec<BlockId>> {
-        let path = "api/core/v3/tips";
+    /// Returns information that are ideal for attaching a block.
+    /// GET /api/core/v3/blocks/issuance
+    pub async fn get_issuance(&self) -> Result<IssuanceBlockHeaderResponse> {
+        const PATH: &str = "api/core/v3/blocks/issuance";
 
-        let response = self
-            .node_manager
+        self.node_manager
             .read()
             .await
-            .get_request::<TipsResponse>(path, None, self.get_timeout().await, false, false)
-            .await?;
-
-        Ok(response.tips)
+            .get_request::<IssuanceBlockHeaderResponse>(PATH, None, self.get_timeout().await, false, false)
+            .await
     }
 
     /// Returns the BlockId of the submitted block.

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -47,10 +47,10 @@ impl ClientInner {
     /// Returns the health of the node.
     /// GET /health
     pub async fn get_health(&self, url: &str) -> Result<bool> {
-        let path = "health";
+        const PATH: &str = "health";
 
         let mut url = Url::parse(url)?;
-        url.set_path(path);
+        url.set_path(PATH);
         let status = crate::client::node_manager::http_client::HttpClient::new(DEFAULT_USER_AGENT.to_string())
             .get(
                 Node {
@@ -72,12 +72,12 @@ impl ClientInner {
     /// Returns the available API route groups of the node.
     /// GET /api/routes
     pub async fn get_routes(&self) -> Result<RoutesResponse> {
-        let path = "api/routes";
+        const PATH: &str = "api/routes";
 
         self.node_manager
             .read()
             .await
-            .get_request(path, None, self.get_timeout().await, false, false)
+            .get_request(PATH, None, self.get_timeout().await, false, false)
             .await
     }
 
@@ -108,7 +108,7 @@ impl ClientInner {
     /// Returns the BlockId of the submitted block.
     /// POST JSON to /api/core/v3/blocks
     pub async fn post_block(&self, block: &Block) -> Result<BlockId> {
-        let path = "api/core/v3/blocks";
+        const PATH: &str = "api/core/v3/blocks";
         let timeout = self.get_timeout().await;
         let block_dto = BlockDto::from(block);
 
@@ -116,7 +116,7 @@ impl ClientInner {
             .node_manager
             .read()
             .await
-            .post_request_json::<SubmitBlockResponse>(path, timeout, serde_json::to_value(block_dto)?)
+            .post_request_json::<SubmitBlockResponse>(PATH, timeout, serde_json::to_value(block_dto)?)
             .await?;
 
         Ok(response.block_id)
@@ -125,14 +125,14 @@ impl ClientInner {
     /// Returns the BlockId of the submitted block.
     /// POST /api/core/v3/blocks
     pub async fn post_block_raw(&self, block: &Block) -> Result<BlockId> {
-        let path = "api/core/v3/blocks";
+        const PATH: &str = "api/core/v3/blocks";
         let timeout = self.get_timeout().await;
 
         let response = self
             .node_manager
             .read()
             .await
-            .post_request_bytes::<SubmitBlockResponse>(path, timeout, &block.pack_to_vec())
+            .post_request_bytes::<SubmitBlockResponse>(PATH, timeout, &block.pack_to_vec())
             .await?;
 
         Ok(response.block_id)
@@ -339,13 +339,13 @@ impl ClientInner {
 
     /// GET /api/core/v3/peers
     pub async fn get_peers(&self) -> Result<Vec<PeerResponse>> {
-        let path = "api/core/v3/peers";
+        const PATH: &str = "api/core/v3/peers";
 
         let resp = self
             .node_manager
             .read()
             .await
-            .get_request::<Vec<PeerResponse>>(path, None, self.get_timeout().await, false, false)
+            .get_request::<Vec<PeerResponse>>(PATH, None, self.get_timeout().await, false, false)
             .await?;
 
         Ok(resp)

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -93,7 +93,7 @@ impl ClientInner {
 
     // Blocks routes.
 
-    /// Returns information that are ideal for attaching a block.
+    /// Returns information that is ideal for attaching a block in the network.
     /// GET /api/core/v3/blocks/issuance
     pub async fn get_issuance(&self) -> Result<IssuanceBlockHeaderResponse> {
         const PATH: &str = "api/core/v3/blocks/issuance";

--- a/sdk/src/types/api/core/response.rs
+++ b/sdk/src/types/api/core/response.rs
@@ -5,6 +5,7 @@ use alloc::{string::String, vec::Vec};
 
 use crate::types::block::{
     output::{dto::OutputDto, OutputId, OutputMetadata, OutputWithMetadata},
+    parent::{ShallowLikeParents, StrongParents, WeakParents},
     protocol::ProtocolParameters,
     slot::SlotIndex,
     BlockId,
@@ -93,16 +94,24 @@ pub struct BaseTokenResponse {
     pub use_metric_prefix: bool,
 }
 
-/// Response of GET /api/core/v3/tips.
-/// Returns non-lazy tips.
+/// Response of
+/// - GET /api/core/v3/blocks/issuance
+/// Returns information that are ideal for attaching a block.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
-pub struct TipsResponse {
-    pub tips: Vec<BlockId>,
+pub struct IssuanceBlockHeaderResponse {
+    /// Blocks that are strongly directly approved.
+    pub strong_parents: StrongParents,
+    /// Blocks that are weakly directly approved.
+    pub weak_parents: WeakParents,
+    /// Blocks that are directly referenced to adjust opinion.
+    pub shallow_like_parents: ShallowLikeParents,
+    /// The slot index of the latest finalized slot.
+    pub latest_finalized_slot: SlotIndex,
 }
 
 /// Response of POST /api/core/v3/blocks.

--- a/sdk/src/types/api/core/response.rs
+++ b/sdk/src/types/api/core/response.rs
@@ -7,7 +7,7 @@ use crate::types::block::{
     output::{dto::OutputDto, OutputId, OutputMetadata, OutputWithMetadata},
     parent::{ShallowLikeParents, StrongParents, WeakParents},
     protocol::ProtocolParameters,
-    slot::SlotIndex,
+    slot::{SlotCommitment, SlotIndex},
     BlockId,
 };
 
@@ -112,6 +112,8 @@ pub struct IssuanceBlockHeaderResponse {
     pub shallow_like_parents: ShallowLikeParents,
     /// The slot index of the latest finalized slot.
     pub latest_finalized_slot: SlotIndex,
+    /// TODO: help
+    pub commitment: SlotCommitment,
 }
 
 /// Response of POST /api/core/v3/blocks.

--- a/sdk/src/types/api/core/response.rs
+++ b/sdk/src/types/api/core/response.rs
@@ -96,7 +96,7 @@ pub struct BaseTokenResponse {
 
 /// Response of
 /// - GET /api/core/v3/blocks/issuance
-/// Returns information that are ideal for attaching a block.
+/// Information that is ideal for attaching a block in the network.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -112,7 +112,7 @@ pub struct IssuanceBlockHeaderResponse {
     pub shallow_like_parents: ShallowLikeParents,
     /// The slot index of the latest finalized slot.
     pub latest_finalized_slot: SlotIndex,
-    /// TODO: help
+    /// The most recent slot commitment.
     pub commitment: SlotCommitment,
 }
 

--- a/sdk/src/types/block/slot/commitment.rs
+++ b/sdk/src/types/block/slot/commitment.rs
@@ -18,6 +18,9 @@ use crate::{
     serde(rename_all = "camelCase")
 )]
 pub struct SlotCommitment {
+    // The version of the protocol running.
+    #[serde(rename = "version")]
+    protocol_version: u8,
     /// The slot index of this commitment.
     /// It is calculated based on genesis timestamp and the duration of a slot.
     index: SlotIndex,
@@ -36,12 +39,14 @@ pub struct SlotCommitment {
 impl SlotCommitment {
     /// Creates a new [`SlotCommitment`].
     pub fn new(
+        protocol_version: u8,
         index: SlotIndex,
         previous_slot_commitment_id: SlotCommitmentId,
         roots_id: RootsId,
         cumulative_weight: u64,
     ) -> Self {
         Self {
+            protocol_version,
             index,
             previous_slot_commitment_id,
             roots_id,
@@ -88,11 +93,15 @@ mod test {
     use core::str::FromStr;
 
     use super::SlotCommitment;
-    use crate::types::block::slot::{RootsId, SlotCommitmentId, SlotIndex};
+    use crate::types::block::{
+        slot::{RootsId, SlotCommitmentId, SlotIndex},
+        PROTOCOL_VERSION,
+    };
 
     #[test]
     fn test() {
         let commitment = SlotCommitment::new(
+            PROTOCOL_VERSION,
             SlotIndex::new(10),
             SlotCommitmentId::from_str(
                 "0x20e07a0ea344707d69a08b90be7ad14eec8326cf2b8b86c8ec23720fab8dcf8ec43a30e4a8cc3f1f",
@@ -103,7 +112,7 @@ mod test {
         );
         assert_eq!(
             &commitment.id().to_string(),
-            "0xb485446277cc5111d54f443b46d886945d4af64e53c2f04064a7c2ea88fa4e020a00000000000000"
+            "0xc51e3baeebda4e08f1260664f4f3fb73fa287efa49022b230aacb756e71fbbd30a00000000000000"
         )
     }
 }

--- a/sdk/src/types/block/slot/commitment.rs
+++ b/sdk/src/types/block/slot/commitment.rs
@@ -34,6 +34,9 @@ pub struct SlotCommitment {
     /// the switching of a chain.
     #[serde(with = "string")]
     cumulative_weight: u64,
+    /// Reference Mana Cost (RMC) to be used in the slot with index at `index + Max Committable Age`.
+    #[serde(with = "string")]
+    reference_mana_cost: u64,
 }
 
 impl SlotCommitment {
@@ -44,6 +47,7 @@ impl SlotCommitment {
         previous_slot_commitment_id: SlotCommitmentId,
         roots_id: RootsId,
         cumulative_weight: u64,
+        reference_mana_cost: u64,
     ) -> Self {
         Self {
             protocol_version,
@@ -51,6 +55,7 @@ impl SlotCommitment {
             previous_slot_commitment_id,
             roots_id,
             cumulative_weight,
+            reference_mana_cost,
         }
     }
 
@@ -109,10 +114,12 @@ mod test {
             .unwrap(),
             RootsId::from_str("0xcf077d276686ba64c0404b9eb2d15556782113c5a1985f262b70f9964d3bbd7f").unwrap(),
             5,
+            10,
         );
+        // TODO: Independently verify this value
         assert_eq!(
             &commitment.id().to_string(),
-            "0xc51e3baeebda4e08f1260664f4f3fb73fa287efa49022b230aacb756e71fbbd30a00000000000000"
+            "0x2f3ad38aa65d20ede9dcd6a045dccdd3332cf38192c4875308bb77116e8650880a00000000000000"
         )
     }
 }

--- a/sdk/tests/client/node_api/core.rs
+++ b/sdk/tests/client/node_api/core.rs
@@ -35,8 +35,12 @@ async fn test_get_info() {
 
 #[ignore]
 #[tokio::test]
-async fn test_get_tips() {
-    let r = setup_client_with_node_health_ignored().await.get_tips().await.unwrap();
+async fn test_get_issuance() {
+    let r = setup_client_with_node_health_ignored()
+        .await
+        .get_issuance()
+        .await
+        .unwrap();
     println!("{r:#?}");
 }
 


### PR DESCRIPTION
# Description of change

Adds the `get_issuance` node API route to replace `get_tips`.

## Links to any relevant issues

#646
