### PR TITLE
Fix prepare_output() with ReturnStrategy::Gift

### DIFF
--- a/.changes/prepare-output.md
+++ b/.changes/prepare-output.md
@@ -1,0 +1,5 @@
+---
+"wallet-nodejs-binding": patch
+---
+
+Fixed `Account::prepareOutput()` when `ReturnStrategy::Gift` is used with an existing NFT output;

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Export ILoggerConfig from types;
 
+### Fixed
+
+- `Account::prepareOutput()` when `ReturnStrategy::Gift` is used with an existing NFT output;
+
 ## 1.0.4 - 2023-08-08
 
 ### Fixed

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Clients` returning the default protocol parameters when multiple `Client` instances are used;
 - Ledger Nano events properly created when preparing transactions using a `SecretManager`;
+- `Account::prepare_output()` when `ReturnStrategy::Gift` is used with an existing NFT output;
 
 ## 1.0.2 - 2023-07-28
 

--- a/sdk/src/wallet/account/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/account/operations/transaction/prepare_output.rs
@@ -110,13 +110,9 @@ where
         let min_storage_deposit_basic_output =
             MinimumStorageDepositBasicOutput::new(rent_structure, token_supply).finish()?;
 
-        let min_required_storage_deposit = if nft_id.is_some() {
-            Output::Nft(first_output.as_nft().clone()).rent_cost(&rent_structure)
-        } else {
-            Output::Basic(first_output.as_basic().clone()).rent_cost(&rent_structure)
-        };
+        let min_required_storage_deposit = first_output.rent_cost(&rent_structure);
 
-        if params.amount > min_storage_deposit_basic_output {
+        if params.amount > min_required_storage_deposit {
             second_output_builder = second_output_builder.with_amount(params.amount);
         }
 

--- a/sdk/src/wallet/account/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/account/operations/transaction/prepare_output.rs
@@ -111,10 +111,9 @@ where
             MinimumStorageDepositBasicOutput::new(rent_structure, token_supply).finish()?;
 
         let min_required_storage_deposit = if nft_id.is_some() {
-            let min_storage_deposit_nft_output = Output::Nft(first_output.as_nft().clone()).rent_cost(&rent_structure);
-            min_storage_deposit_basic_output.max(min_storage_deposit_nft_output)
+            Output::Nft(first_output.as_nft().clone()).rent_cost(&rent_structure)
         } else {
-            min_storage_deposit_basic_output
+            Output::Basic(first_output.as_basic().clone()).rent_cost(&rent_structure)
         };
 
         if params.amount > min_storage_deposit_basic_output {

--- a/sdk/tests/wallet/output_preparation.rs
+++ b/sdk/tests/wallet/output_preparation.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use iota_sdk::{
     types::block::{
         address::{Address, Bech32Address, ToBech32Ext},
-        output::{MinimumStorageDepositBasicOutput, NativeToken, NftId, TokenId},
+        output::{MinimumStorageDepositBasicOutput, NativeToken, NftId, Output, Rent, TokenId},
     },
     wallet::{
         account::{Assets, Features, OutputParams, ReturnStrategy, StorageDeposit, Unlocks},
@@ -763,6 +763,73 @@ async fn prepare_output_only_single_nft() -> Result<()> {
     let balance_1 = account_1.sync(None).await?;
     assert!(balance_1.nfts().is_empty());
     assert_eq!(balance_1.base_coin().total(), 0);
+
+    tear_down(storage_path)
+}
+
+#[ignore]
+#[tokio::test]
+async fn prepare_existing_nft_output_gift() -> Result<()> {
+    let storage_path = "test-storage/prepare_existing_nft_output_gift";
+    setup(storage_path)?;
+
+    let wallet = make_wallet(storage_path, None, None).await?;
+    let accounts = &create_accounts_with_funds(&wallet, 1).await?;
+    let addresses = accounts[0].addresses().await?;
+    let address = addresses[0].address();
+
+    let nft_options = [MintNftParams::new()
+        .with_address(*address)
+        .with_sender(*address)
+        .with_metadata(b"some nft metadata".to_vec())
+        .with_tag(b"some nft tag".to_vec())
+        .with_issuer(*address)
+        .with_immutable_metadata(b"some immutable nft metadata".to_vec())];
+
+    let transaction = accounts[0].mint_nfts(nft_options, None).await.unwrap();
+    accounts[0]
+        .retry_transaction_until_included(&transaction.transaction_id, None, None)
+        .await?;
+
+    let nft_id = *accounts[0].sync(None).await?.nfts().first().unwrap();
+
+    let nft = accounts[0]
+        .prepare_output(
+            OutputParams {
+                recipient_address: *address,
+                amount: 0,
+                assets: Some(Assets {
+                    native_tokens: None,
+                    nft_id: Some(nft_id),
+                }),
+                features: None,
+                unlocks: None,
+                storage_deposit: Some(StorageDeposit {
+                    return_strategy: Some(ReturnStrategy::Gift),
+                    use_excess_if_low: None,
+                }),
+            },
+            None,
+        )
+        .await?
+        .as_nft()
+        .clone();
+
+    let rent_structure = wallet.client().get_rent_structure().await?;
+    let minimum_storage_deposit = Output::Nft(nft.clone()).rent_cost(&rent_structure);
+    assert_eq!(nft.amount(), minimum_storage_deposit);
+
+    assert_eq!(nft.amount(), 52300);
+    assert_eq!(nft.address(), accounts[0].addresses().await?[0].address().as_ref());
+    assert!(nft.features().is_empty());
+    assert_eq!(
+        nft.immutable_features().metadata().unwrap().data(),
+        b"some immutable nft metadata"
+    );
+    assert_eq!(
+        nft.immutable_features().issuer().unwrap().address(),
+        accounts[0].addresses().await?[0].address().as_ref()
+    );
 
     tear_down(storage_path)
 }


### PR DESCRIPTION
# Description of change

Fix `Account::prepare_output()` when `ReturnStrategy::Gift` is used with an existing NFT output

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/1027

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added test

## Change checklist

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
