### PR TITLE
Fix: update naming

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Export ILoggerConfig from types;
+- Added prepareIncreaseVotingPower;
+
+## Changed
+- Deprecate prepareVotingPower;
 
 ## 1.0.4 - 2023-08-08
 

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Account::prepareIncreaseVotingPower`;
 
 ## Changed
+
 - Deprecate prepareVotingPower;
 
 ## 1.0.4 - 2023-08-08

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Deprecate prepareVotingPower;
+- Deprecate `Account::prepareVotingPower`;
 
 ## 1.0.4 - 2023-08-08
 

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Export ILoggerConfig from types;
-- Added prepareIncreaseVotingPower;
+- Added `Account::prepareIncreaseVotingPower`;
 
 ## Changed
 - Deprecate prepareVotingPower;

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export ILoggerConfig from types;
+- Export `ILoggerConfig` from types;
 - Added `Account::prepareIncreaseVotingPower`;
 
 ## Changed

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -1415,7 +1415,9 @@ export class Account {
      * @param amount The amount to increase the voting power by.
      * @returns An instance of `PreparedTransaction`.
      */
-    async prepareIncreaseVotingPower(amount: string): Promise<PreparedTransaction> {
+    async prepareIncreaseVotingPower(
+        amount: string,
+    ): Promise<PreparedTransaction> {
         const response = await this.methodHandler.callAccountMethod(
             this.meta.index,
             {

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -1391,22 +1391,7 @@ export class Account {
 
     /** @deprecated use prepareIncreaseVotingPower() instead. */
     async prepareVotingPower(amount: string): Promise<PreparedTransaction> {
-        const response = await this.methodHandler.callAccountMethod(
-            this.meta.index,
-            {
-                name: 'prepareIncreaseVotingPower',
-                data: {
-                    amount,
-                },
-            },
-        );
-        const parsed = JSON.parse(
-            response,
-        ) as Response<PreparedTransactionData>;
-        return new PreparedTransaction(
-            plainToInstance(PreparedTransactionData, parsed.payload),
-            this,
-        );
+        return this.prepareIncreaseVotingPower(amount)
     }
 
     /**

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -1391,7 +1391,7 @@ export class Account {
 
     /** @deprecated use prepareIncreaseVotingPower() instead. */
     async prepareVotingPower(amount: string): Promise<PreparedTransaction> {
-        return this.prepareIncreaseVotingPower(amount)
+        return this.prepareIncreaseVotingPower(amount);
     }
 
     /**

--- a/bindings/nodejs/lib/wallet/account.ts
+++ b/bindings/nodejs/lib/wallet/account.ts
@@ -1389,13 +1389,33 @@ export class Account {
         return JSON.parse(response).payload;
     }
 
+    /** @deprecated use prepareIncreaseVotingPower() instead. */
+    async prepareVotingPower(amount: string): Promise<PreparedTransaction> {
+        const response = await this.methodHandler.callAccountMethod(
+            this.meta.index,
+            {
+                name: 'prepareIncreaseVotingPower',
+                data: {
+                    amount,
+                },
+            },
+        );
+        const parsed = JSON.parse(
+            response,
+        ) as Response<PreparedTransactionData>;
+        return new PreparedTransaction(
+            plainToInstance(PreparedTransactionData, parsed.payload),
+            this,
+        );
+    }
+
     /**
      * Prepare to increase the voting power.
      *
      * @param amount The amount to increase the voting power by.
      * @returns An instance of `PreparedTransaction`.
      */
-    async prepareVotingPower(amount: string): Promise<PreparedTransaction> {
+    async prepareIncreaseVotingPower(amount: string): Promise<PreparedTransaction> {
         const response = await this.methodHandler.callAccountMethod(
             this.meta.index,
             {


### PR DESCRIPTION
# Description of change

The naming of `prepareVotingPower()` isn't consistent with `prepareDecreaseVotingPower()` & the method called through the bindings . I deprecated the previous function and added `prepareIncreaseVotingPower()`

## Links to any relevant issues

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
