### PR TITLE
Allow selecting transactions by index

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WalletCommand::Accounts` variant to list all available accounts in a wallet;
 - `addresses` now additionally prints the hex version of the address;
 - `outputs`, `unspent-outputs` print a list that includes number and type of the output;
+- `AccountCommand::Transaction` now accepts either an index or an ID;
 
 ## 1.0.0 - 2023-07-27
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -21,15 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.0 - 2023-MM-DD
 
-### Changed
-
-- `WalletCommand::Mnemonic` now takes 2 optional arguments to avoid user interaction;
-
 ### Added
 
 - `WalletCommand::Accounts` variant to list all available accounts in a wallet;
 - `addresses` now additionally prints the hex version of the address;
 - `outputs`, `unspent-outputs` print a list that includes number and type of the output;
+
+### Changed
+
+- `WalletCommand::Mnemonic` now takes 2 optional arguments to avoid user interaction;
 - `AccountCommand::Transaction` now accepts either an index or an ID;
 
 ## 1.0.0 - 2023-07-27

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -172,7 +172,7 @@ pub async fn account_prompt_internal(
                 } => send_native_token_command(account, address, token_id, amount, gift_storage_deposit).await,
                 AccountCommand::SendNft { address, nft_id } => send_nft_command(account, address, nft_id).await,
                 AccountCommand::Sync => sync_command(account).await,
-                AccountCommand::Transaction { transaction_id } => transaction_command(account, &transaction_id).await,
+                AccountCommand::Transaction { selector } => transaction_command(account, selector).await,
                 AccountCommand::Transactions { show_details } => transactions_command(account, show_details).await,
                 AccountCommand::UnspentOutputs => unspent_outputs_command(account).await,
                 AccountCommand::Vote { event_id, answers } => vote_command(account, event_id, answers).await,

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -199,7 +199,7 @@ pub enum AccountCommand {
     #[clap(visible_alias = "tx")]
     Transaction {
         /// Selector for transaction.
-        /// Either by ID (e.g. 0x84fe6b1796bddc022c9bc40206f0a692f4536b02aa8c13140264e2e01a3b7e4b) or index
+        /// Either by ID (e.g. 0x84fe6b1796bddc022c9bc40206f0a692f4536b02aa8c13140264e2e01a3b7e4b) or index.
         selector: TransactionSelector,
     },
     /// List the account transactions.

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -767,7 +767,7 @@ pub async fn transaction_command(account: &Account, selector: TransactionSelecto
         TransactionSelector::Id(id) => transactions.into_iter().find(|tx| tx.transaction_id == id),
         TransactionSelector::Index(index) => {
             transactions.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-            transactions.into_iter().skip(index).next()
+            transactions.into_iter().nth(index)
         }
     };
 


### PR DESCRIPTION
# Description of change

This PR adds the ability to select transactions in the CLI account by index as well as ID.

## Links to any relevant issues

Closes #659

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
Account "tedbundy": tx --help
Show the details of a transaction

Usage: Account: transaction <SELECTOR>

Arguments:
  <SELECTOR>  Selector for transaction. Either by ID (e.g. 0x84fe6b1796bddc022c9bc40206f0a692f4536b02aa8c13140264e2e01a3b7e4b) or index

Options:
  -h, --help     Print help
  -V, --version  Print version

Account "tedbundy": tx 0
No transaction found
Account "tedbundy": tx 0x84fe6b1796bddc022c9bc40206f0a692f4536b02aa8c13140264e2e01a3b7e4b
No transaction found
Account "tedbundy": tx 0x84fe6b1796bddc022c9bc40206f0a692f4536b02aa8c13140264e2e01a3b7e
error: invalid value '0x84fe6b1796bddc022c9bc40206f0a692f4536b02aa8c13140264e2e01a3b7e' for '<SELECTOR>': block error: hex error: Invalid hex string length for slice: expected 64 got 62

For more information, try '--help'.

Account "tedbundy": tx bleh
error: invalid value 'bleh' for '<SELECTOR>': block error: hex error: Invalid hex prefix: expected `0x` but got `bl`

For more information, try '--help'.

Account "tedbundy": tx 456
No transaction found
```
