### PR TITLE
Add switch CLI command to change accounts

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `WalletCommand::Accounts` variant to list all available accounts in a wallet;
 - `addresses` now additionally prints the hex version of the address;
 - `outputs`, `unspent-outputs` print a list that includes number and type of the output;
+- `Account::switch` command to allow changing accounts quickly;
 
 ### Changed
 

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -7,7 +7,7 @@ use dialoguer::Input;
 use iota_sdk::wallet::{Account, Wallet};
 
 use crate::{
-    account_completion::ACCOUNT_COMPLETION,
+    account_completion::AccountCompletion,
     account_history::AccountHistory,
     command::account::{
         addresses_command, balance_command, burn_native_token_command, burn_nft_command, claim_command,
@@ -64,7 +64,7 @@ pub async fn account_prompt_internal(
     let command: String = Input::new()
         .with_prompt(format!("Account \"{}\"", alias).green().to_string())
         .history_with(history)
-        .completion_with(&ACCOUNT_COMPLETION)
+        .completion_with(&AccountCompletion)
         .interact_text()?;
     match command.as_str() {
         "h" | "help" => print_account_help(),
@@ -182,8 +182,8 @@ pub async fn account_prompt_internal(
                     gift_storage_deposit,
                 } => send_native_token_command(account, address, token_id, amount, gift_storage_deposit).await,
                 AccountCommand::SendNft { address, nft_id } => send_nft_command(account, address, nft_id).await,
-                AccountCommand::Switch { other_account } => {
-                    return Ok(AccountPromptResponse::Switch(wallet.get_account(other_account).await?));
+                AccountCommand::Switch { account_id } => {
+                    return Ok(AccountPromptResponse::Switch(wallet.get_account(account_id).await?));
                 }
                 AccountCommand::Sync => sync_command(account).await,
                 AccountCommand::Transaction { selector } => transaction_command(account, selector).await,

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -25,19 +25,30 @@ use crate::{
 };
 
 // loop on the account prompt
-pub async fn account_prompt(wallet: &Wallet, account: &Account) -> Result<(), Error> {
+pub async fn account_prompt(wallet: &Wallet, mut account: Account) -> Result<(), Error> {
     let mut history = AccountHistory::default();
     loop {
-        match account_prompt_internal(wallet, account, &mut history).await {
-            Ok(true) => {
-                return Ok(());
-            }
+        match account_prompt_internal(wallet, &account, &mut history).await {
+            Ok(res) => match res {
+                AccountPromptResponse::Reprompt => (),
+                AccountPromptResponse::Done => {
+                    return Ok(());
+                }
+                AccountPromptResponse::Switch(new_account) => {
+                    account = new_account;
+                }
+            },
             Err(e) => {
                 println_log_error!("{e}");
             }
-            _ => {}
         }
     }
+}
+
+pub enum AccountPromptResponse {
+    Reprompt,
+    Done,
+    Switch(Account),
 }
 
 // loop on the account prompt
@@ -45,7 +56,7 @@ pub async fn account_prompt_internal(
     wallet: &Wallet,
     account: &Account,
     history: &mut AccountHistory,
-) -> Result<bool, Error> {
+) -> Result<AccountPromptResponse, Error> {
     let alias = {
         let account = account.details().await;
         account.alias().clone()
@@ -77,7 +88,7 @@ pub async fn account_prompt_internal(
                 Ok(account_cli) => account_cli,
                 Err(err) => {
                     println!("{err}");
-                    return Ok(false);
+                    return Ok(AccountPromptResponse::Reprompt);
                 }
             };
             if let Err(err) = match account_cli.command {
@@ -108,7 +119,7 @@ pub async fn account_prompt_internal(
                 AccountCommand::DestroyAlias { alias_id } => destroy_alias_command(account, alias_id).await,
                 AccountCommand::DestroyFoundry { foundry_id } => destroy_foundry_command(account, foundry_id).await,
                 AccountCommand::Exit => {
-                    return Ok(true);
+                    return Ok(AccountPromptResponse::Done);
                 }
                 AccountCommand::Faucet { address, url } => faucet_command(account, address, url).await,
                 AccountCommand::MeltNativeToken { token_id, amount } => {
@@ -171,6 +182,9 @@ pub async fn account_prompt_internal(
                     gift_storage_deposit,
                 } => send_native_token_command(account, address, token_id, amount, gift_storage_deposit).await,
                 AccountCommand::SendNft { address, nft_id } => send_nft_command(account, address, nft_id).await,
+                AccountCommand::Switch { other_account } => {
+                    return Ok(AccountPromptResponse::Switch(wallet.get_account(other_account).await?));
+                }
                 AccountCommand::Sync => sync_command(account).await,
                 AccountCommand::Transaction { selector } => transaction_command(account, selector).await,
                 AccountCommand::Transactions { show_details } => transactions_command(account, show_details).await,
@@ -191,5 +205,5 @@ pub async fn account_prompt_internal(
         }
     }
 
-    Ok(false)
+    Ok(AccountPromptResponse::Reprompt)
 }

--- a/cli/src/account_completion.rs
+++ b/cli/src/account_completion.rs
@@ -3,57 +3,53 @@
 
 use dialoguer::Completion;
 
-pub(crate) struct AccountCompletion<'a> {
-    options: [&'a str; 38],
-}
+pub(crate) struct AccountCompletion;
 
-pub(crate) const ACCOUNT_COMPLETION: AccountCompletion = AccountCompletion {
-    options: [
-        "accounts",
-        "addresses",
-        "balance",
-        "burn-native-token",
-        "burn-nft",
-        "claim",
-        "claimable-outputs",
-        "consolidate",
-        "create-alias-output",
-        "create-native-token",
-        "destroy-alias",
-        "destroy-foundry",
-        "exit",
-        "faucet",
-        "melt-native-token",
-        "mint-native-token",
-        "mint-nft",
-        "new-address",
-        "node-info",
-        "output",
-        "outputs",
-        "send",
-        "send-native-token",
-        "send-nft",
-        "sync",
-        "transaction",
-        "transactions",
-        "tx",
-        "txs",
-        "unspent-outputs",
-        "vote",
-        "stop-participating",
-        "participation-overview",
-        "voting-power",
-        "increase-voting-power",
-        "decrease-voting-power",
-        "voting-output",
-        "help",
-    ],
-};
+pub(crate) const ACCOUNT_COMPLETION: &[&str] = &[
+    "accounts",
+    "addresses",
+    "balance",
+    "burn-native-token",
+    "burn-nft",
+    "claim",
+    "claimable-outputs",
+    "consolidate",
+    "create-alias-output",
+    "create-native-token",
+    "destroy-alias",
+    "destroy-foundry",
+    "exit",
+    "faucet",
+    "melt-native-token",
+    "mint-native-token",
+    "mint-nft",
+    "new-address",
+    "node-info",
+    "output",
+    "outputs",
+    "send",
+    "send-native-token",
+    "send-nft",
+    "switch",
+    "sync",
+    "transaction",
+    "transactions",
+    "tx",
+    "txs",
+    "unspent-outputs",
+    "vote",
+    "stop-participating",
+    "participation-overview",
+    "voting-power",
+    "increase-voting-power",
+    "decrease-voting-power",
+    "voting-output",
+    "help",
+];
 
-impl<'a> Completion for AccountCompletion<'a> {
+impl<'a> Completion for AccountCompletion {
     fn get(&self, input: &str) -> Option<String> {
-        let matches = self
-            .options
+        let matches = ACCOUNT_COMPLETION
             .iter()
             .filter(|option| option.starts_with(input))
             .collect::<Vec<_>>();

--- a/cli/src/account_completion.rs
+++ b/cli/src/account_completion.rs
@@ -47,7 +47,7 @@ pub(crate) const ACCOUNT_COMPLETION: &[&str] = &[
     "help",
 ];
 
-impl<'a> Completion for AccountCompletion {
+impl Completion for AccountCompletion {
     fn get(&self, input: &str) -> Option<String> {
         let matches = ACCOUNT_COMPLETION
             .iter()

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -193,6 +193,8 @@ pub enum AccountCommand {
         /// NFT ID to be sent, e.g. 0xecadf10e6545aa82da4df2dfd2a496b457c8850d2cab49b7464cb273d3dffb07.
         nft_id: String,
     },
+    /// Switch to a different account.
+    Switch { other_account: String },
     /// Synchronize the account.
     Sync,
     /// Show the details of a transaction.

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -19,7 +19,10 @@ use iota_sdk::{
         },
     },
     wallet::{
-        account::{types::AccountAddress, Account, ConsolidationParams, OutputsToClaim, TransactionOptions},
+        account::{
+            types::{AccountAddress, AccountIdentifier},
+            Account, ConsolidationParams, OutputsToClaim, TransactionOptions,
+        },
         CreateNativeTokenParams, MintNftParams, SendNativeTokensParams, SendNftParams, SendParams,
     },
     U256,
@@ -194,7 +197,10 @@ pub enum AccountCommand {
         nft_id: String,
     },
     /// Switch to a different account.
-    Switch { other_account: String },
+    Switch {
+        /// The identifier (alias or index) of the account you want to switch to.
+        account_id: AccountIdentifier,
+    },
     /// Synchronize the account.
     Sync,
     /// Show the details of a transaction.

--- a/cli/src/command/wallet.rs
+++ b/cli/src/command/wallet.rs
@@ -11,7 +11,7 @@ use iota_sdk::{
         stronghold::StrongholdAdapter,
         utils::Password,
     },
-    wallet::{ClientOptions, Wallet},
+    wallet::{account::types::AccountIdentifier, ClientOptions, Wallet},
 };
 use log::LevelFilter;
 
@@ -36,7 +36,7 @@ pub struct WalletCli {
     #[arg(long, value_name = "PATH", env = "STRONGHOLD_SNAPSHOT_PATH", default_value = DEFAULT_STRONGHOLD_SNAPSHOT_PATH)]
     pub stronghold_snapshot_path: String,
     /// Set the account to enter.
-    pub account: Option<String>,
+    pub account: Option<AccountIdentifier>,
     /// Set the log level.
     #[arg(short, long, default_value = DEFAULT_LOG_LEVEL)]
     pub log_level: LevelFilter,
@@ -210,7 +210,7 @@ pub async fn new_account_command(
     storage_path: &Path,
     snapshot_path: &Path,
     alias: Option<String>,
-) -> Result<(Wallet, String), Error> {
+) -> Result<(Wallet, AccountIdentifier), Error> {
     let password = get_password("Stronghold password", !snapshot_path.exists())?;
     let wallet = unlock_wallet(storage_path, snapshot_path, password).await?;
 
@@ -304,7 +304,7 @@ pub async fn unlock_wallet(
     Ok(maybe_wallet?)
 }
 
-pub async fn add_account(wallet: &Wallet, alias: Option<String>) -> Result<String, Error> {
+pub async fn add_account(wallet: &Wallet, alias: Option<String>) -> Result<AccountIdentifier, Error> {
     let mut account_builder = wallet.create_account();
 
     if let Some(alias) = alias {
@@ -312,7 +312,7 @@ pub async fn add_account(wallet: &Wallet, alias: Option<String>) -> Result<Strin
     }
 
     let account = account_builder.finish().await?;
-    let alias = account.details().await.alias().to_string();
+    let alias = AccountIdentifier::Alias(account.details().await.alias().clone());
 
     println_log_info!("Created account \"{alias}\"");
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,7 +50,7 @@ fn logger_init(cli: &WalletCli) -> Result<(), Error> {
 async fn run(cli: WalletCli) -> Result<(), Error> {
     if let (Some(wallet), Some(account)) = new_wallet(cli).await? {
         let account = wallet.get_account(account).await?;
-        account::account_prompt(&wallet, &account).await?;
+        account::account_prompt(&wallet, account).await?;
     }
 
     Ok(())

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -548,7 +548,7 @@ fn merge_unlocks(
                 // address already at this point, because the reference index needs to be lower
                 // than the current block index
                 if !input_address.is_ed25519() {
-                    return Err(Error::MissingInputWithEd25519Address)?;
+                    return Err(Error::MissingInputWithEd25519Address);
                 }
 
                 let unlock = unlocks.next().ok_or(Error::MissingInputWithEd25519Address)?;

--- a/sdk/src/pow/miner.rs
+++ b/sdk/src/pow/miner.rs
@@ -81,7 +81,7 @@ impl MinerBuilder {
     pub fn finish(self) -> Miner {
         Miner {
             num_workers: self.num_workers.unwrap_or_else(num_cpus::get),
-            cancel: self.cancel.unwrap_or_else(MinerCancel::new),
+            cancel: self.cancel.unwrap_or_default(),
         }
     }
 }

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -347,8 +347,8 @@ impl From<u32> for AccountIdentifier {
 impl core::fmt::Display for AccountIdentifier {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            AccountIdentifier::Alias(alias) => alias.fmt(f),
-            AccountIdentifier::Index(index) => index.fmt(f),
+            Self::Alias(alias) => alias.fmt(f),
+            Self::Index(index) => index.fmt(f),
         }
     }
 }

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -311,7 +311,7 @@ impl<'de> Deserialize<'de> for AccountIdentifier {
             None => {
                 let alias_or_index_str = v
                     .as_str()
-                    .ok_or_else(|| D::Error::custom("accountIdentifier is no number or string"))?;
+                    .ok_or_else(|| D::Error::custom("account identifier is not a number or string"))?;
                 Self::from(alias_or_index_str)
             }
         })
@@ -341,5 +341,14 @@ impl From<&String> for AccountIdentifier {
 impl From<u32> for AccountIdentifier {
     fn from(value: u32) -> Self {
         Self::Index(value)
+    }
+}
+
+impl core::fmt::Display for AccountIdentifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AccountIdentifier::Alias(alias) => alias.fmt(f),
+            AccountIdentifier::Index(index) => index.fmt(f),
+        }
     }
 }


### PR DESCRIPTION
# Description of change

This PR adds the `Account::switch` command to allow changing accounts.

## Links to any relevant issues

Closes #487

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```
Account "polpot": help
Command line interface wallet application based on the IOTA SDK

Usage: Account: <COMMAND>

Commands:
  addresses               List the account addresses
  balance                 Print the account balance
  burn-native-token       Burn an amount of native token
  burn-nft                Burn an NFT
  claim                   Claim outputs with storage deposit return, expiration or timelock unlock conditions
  claimable-outputs       Print details about claimable outputs - if there are any
  consolidate             Consolidate all basic outputs into one address
  create-alias-output     Create a new alias output
  create-native-token     Create a native token
  destroy-alias           Destroy an alias
  destroy-foundry         Destroy a foundry
  exit                    Exit the CLI wallet
  faucet                  Request funds from the faucet
  mint-native-token       Mint additional native tokens
  mint-nft                Mint an NFT. IOTA NFT Standard - TIP27: <https://github.com/iotaledger/tips/blob/main/tips/TIP-0027/tip-0027.md>
  melt-native-token       Melt an amount of native token
  new-address             Generate a new address
  node-info               Get information about currently set node
  output                  Display an output
  outputs                 List all outputs
  send                    Send an amount
  send-native-token       Send native tokens. This will create an output with an expiration and storage deposit return unlock condition
  send-nft                Send an NFT
  switch                  Switch to a different account
  sync                    Synchronize the account
  transaction             Show the details of a transaction [aliases: tx]
  transactions            List the account transactions [aliases: txs]
  unspent-outputs         List the account unspent outputs
  vote                    Cast votes for an event
  stop-participating      Stop participating to an event
  participation-overview  Get the participation overview of the account
  voting-power            Get the voting power of the account
  increase-voting-power   Increase the voting power of the account
  decrease-voting-power   Decrease the voting power of the account
  voting-output           Get the voting output of the account
  help                    Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

Account "polpot": switch
error: the following required arguments were not provided:
  <OTHER_ACCOUNT>

Usage: Account: switch <OTHER_ACCOUNT>

For more information, try '--help'.

Account "polpot": switch --help
Switch to a different account

Usage: Account: switch <OTHER_ACCOUNT>

Arguments:
  <OTHER_ACCOUNT>  

Options:
  -h, --help     Print help
  -V, --version  Print version

Account "polpot": switch polpot
Account "polpot": switch hello
wallet error: account "hello" not found
```
