### PR TITLE
Fix serde feature gating in types

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@ ci-check-nodejs = "check --manifest-path bindings/nodejs/Cargo.toml --all-target
 ci-check-python = "check --manifest-path bindings/python/Cargo.toml --all-targets --lib"
 ci-check-wasm = "check --manifest-path bindings/wasm/Cargo.toml --target wasm32-unknown-unknown --lib"
 ci-check-nostd = "check --no-default-features -F serde -p iota-sdk --target riscv64gc-unknown-none-elf"
+ci-check-types = "check --no-default-features -F std -p iota-sdk"
 
 ci-test = "nextest run --all-features --profile ci --cargo-profile ci -p iota-sdk -p iota-sdk-bindings-core"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,4 +21,4 @@ ci-license = "license-template --template .license_template"
 #
 # - RUSTSEC-2021-0065: https://rustsec.org/advisories/RUSTSEC-2021-0065
 #   - anymap is unmaintained 🤷‍♀️
-ci-audit = "audit --file Cargo.lock --deny warnings --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0065"
+ci-audit = "audit --file Cargo.lock --deny warnings --ignore RUSTSEC-2021-0065"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ ci-check-nodejs = "check --manifest-path bindings/nodejs/Cargo.toml --all-target
 ci-check-python = "check --manifest-path bindings/python/Cargo.toml --all-targets --lib"
 ci-check-wasm = "check --manifest-path bindings/wasm/Cargo.toml --target wasm32-unknown-unknown --lib"
 ci-check-nostd = "check --no-default-features -F serde -p iota-sdk --target riscv64gc-unknown-none-elf"
-ci-check-types = "check --no-default-features -F std -p iota-sdk"
+ci-check-types = "check --no-default-features -p iota-sdk"
 
 ci-test = "nextest run --all-features --profile ci --cargo-profile ci -p iota-sdk -p iota-sdk-bindings-core"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,10 @@ ci-doc = "doc --all-features --no-deps --document-private-items"
 ci-fmt = "fmt --all -- --check"
 ci-toml = "sort --grouped --check"
 ci-udeps = "udeps --all-targets --all-features --backend=depinfo"
+ci-license = "license-template --template .license_template"
+
+# The ignored security advisories:
+#
+# - RUSTSEC-2021-0065: https://rustsec.org/advisories/RUSTSEC-2021-0065
+#   - anymap is unmaintained 🤷‍♀️
+ci-audit = "audit --file Cargo.lock --deny warnings --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0065"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -153,3 +153,17 @@ jobs:
 
       - name: Check
         run: cargo check --no-default-features -F serde -p iota-sdk --target=riscv64gc-unknown-none-elf
+
+  types:
+    name: Check types-only compilation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the Source Code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Check
+        run: cargo check --no-default-features -p iota-sdk

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,7 +92,7 @@ jobs:
           sudo apt-get install libudev-dev libusb-1.0-0-dev
 
       - name: Run Cargo Udeps
-        run: cargo udeps --all-targets --all-features
+        run: cargo ci-udeps
 
   check-format:
     name: Check Format
@@ -112,10 +112,10 @@ jobs:
         run: cargo install --force cargo-license-template
 
       - name: Run Cargo Fmt
-        run: cargo fmt --all -- --check
+        run: cargo ci-fmt
 
       - name: Run cargo-license-template
-        run: cargo license-template --template .license_template
+        run: cargo ci-license
 
   audit:
     name: Perform Security Audit
@@ -132,11 +132,7 @@ jobs:
           install: cargo-audit
 
       - name: Run Cargo Audit
-        # The ignored security advisories:
-        #
-        # - RUSTSEC-2021-0065: https://rustsec.org/advisories/RUSTSEC-2021-0065
-        #   - anymap is unmaintained 🤷‍♀️
-        run: cargo audit --file Cargo.lock --deny warnings --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0065
+        run: cargo ci-audit
 
   no_std:
     name: Check `no_std` compatability
@@ -152,7 +148,7 @@ jobs:
           targets: riscv64gc-unknown-none-elf
 
       - name: Check
-        run: cargo check --no-default-features -F serde -p iota-sdk --target=riscv64gc-unknown-none-elf
+        run: cargo ci-check-wasm
 
   types:
     name: Check types-only compilation
@@ -166,4 +162,4 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Check
-        run: cargo check --no-default-features -p iota-sdk
+        run: cargo ci-check-types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -148,7 +148,7 @@ jobs:
           targets: riscv64gc-unknown-none-elf
 
       - name: Check
-        run: cargo ci-check-wasm
+        run: cargo ci-check-nostd
 
   types:
     name: Check types-only compilation

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -548,7 +548,7 @@ fn merge_unlocks(
                 // address already at this point, because the reference index needs to be lower
                 // than the current block index
                 if !input_address.is_ed25519() {
-                    return Err(Error::MissingInputWithEd25519Address)?;
+                    return Err(Error::MissingInputWithEd25519Address);
                 }
 
                 let unlock = unlocks.next().ok_or(Error::MissingInputWithEd25519Address)?;

--- a/sdk/src/pow/miner.rs
+++ b/sdk/src/pow/miner.rs
@@ -81,7 +81,7 @@ impl MinerBuilder {
     pub fn finish(self) -> Miner {
         Miner {
             num_workers: self.num_workers.unwrap_or_else(num_cpus::get),
-            cancel: self.cancel.unwrap_or_else(MinerCancel::new),
+            cancel: self.cancel.unwrap_or_default(),
         }
     }
 }

--- a/sdk/src/types/api/core/response.rs
+++ b/sdk/src/types/api/core/response.rs
@@ -3,6 +3,8 @@
 
 use alloc::{string::String, vec::Vec};
 
+use serde::{Deserialize, Serialize};
+
 use crate::types::block::{
     output::{dto::OutputDto, OutputId, OutputMetadata, OutputWithMetadata},
     payload::milestone::{option::dto::ReceiptMilestoneOptionDto, MilestoneId},
@@ -12,12 +14,8 @@ use crate::types::block::{
 
 /// Response of GET /api/core/v2/info.
 /// Returns general information about the node.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InfoResponse {
     pub name: String,
     pub version: String,
@@ -30,7 +28,6 @@ pub struct InfoResponse {
     pub features: Vec<String>,
 }
 
-#[cfg(feature = "serde")]
 impl core::fmt::Display for InfoResponse {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", serde_json::to_string_pretty(self).unwrap())
@@ -39,12 +36,8 @@ impl core::fmt::Display for InfoResponse {
 
 /// Returned in [`InfoResponse`].
 /// Status information about the node.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StatusResponse {
     pub is_healthy: bool,
     pub latest_milestone: LatestMilestoneResponse,
@@ -54,46 +47,34 @@ pub struct StatusResponse {
 
 /// Returned in [`StatusResponse`].
 /// Information about the latest milestone.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LatestMilestoneResponse {
     pub index: u32,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<u32>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub milestone_id: Option<MilestoneId>,
 }
 
 /// Returned in [`StatusResponse`].
 /// Information about the confirmed milestone.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConfirmedMilestoneResponse {
     pub index: u32,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<u32>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub milestone_id: Option<MilestoneId>,
 }
 
 /// Returned in [`InfoResponse`].
 /// Pending protocol parameters.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PendingProtocolParameter {
-    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    #[serde(rename = "type")]
     pub kind: u8,
     pub target_milestone_index: u32,
     pub protocol_version: u8,
@@ -102,17 +83,13 @@ pub struct PendingProtocolParameter {
 
 /// Returned in [`InfoResponse`].
 /// Information about the base token.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BaseTokenResponse {
     pub name: String,
     pub ticker_symbol: String,
     pub unit: String,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub subunit: Option<String>,
     pub decimals: u8,
     pub use_metric_prefix: bool,
@@ -120,12 +97,8 @@ pub struct BaseTokenResponse {
 
 /// Returned in [`InfoResponse`].
 /// Metric information about the node.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MetricsResponse {
     pub blocks_per_second: f64,
     pub referenced_blocks_per_second: f64,
@@ -134,35 +107,23 @@ pub struct MetricsResponse {
 
 /// Response of GET /api/core/v2/tips.
 /// Returns non-lazy tips.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TipsResponse {
     pub tips: Vec<BlockId>,
 }
 
 /// Response of POST /api/core/v2/blocks.
 /// Returns the block identifier of the submitted block.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SubmitBlockResponse {
     pub block_id: BlockId,
 }
 
 /// Describes the ledger inclusion state of a transaction.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum LedgerInclusionState {
     Conflicting,
     Included,
@@ -171,40 +132,32 @@ pub enum LedgerInclusionState {
 
 /// Response of GET /api/core/v2/blocks/{block_id}/metadata.
 /// Returns the metadata of a block.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BlockMetadataResponse {
     pub block_id: BlockId,
     pub parents: Vec<BlockId>,
     pub is_solid: bool,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub referenced_by_milestone_index: Option<u32>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub milestone_index: Option<u32>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ledger_inclusion_state: Option<LedgerInclusionState>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conflict_reason: Option<u8>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub white_flag_index: Option<u32>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub should_promote: Option<bool>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub should_reattach: Option<bool>,
 }
 
 /// Response of GET /api/core/v2/outputs/{output_id}.
 /// Returns an output and its metadata.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OutputWithMetadataResponse {
     pub metadata: OutputMetadata,
     pub output: OutputDto,
@@ -226,12 +179,8 @@ impl From<OutputWithMetadata> for OutputWithMetadataResponse {
 }
 
 /// Describes a receipt.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReceiptResponse {
     pub receipt: ReceiptMilestoneOptionDto,
     pub milestone_index: u32,
@@ -240,20 +189,15 @@ pub struct ReceiptResponse {
 /// Response of:
 /// * GET /api/core/v2/receipts/{milestone_index}, returns all stored receipts for the given milestone index.
 /// * GET /api/core/v2/receipts, returns all stored receipts, independent of a milestone index.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ReceiptsResponse {
     pub receipts: Vec<ReceiptResponse>,
 }
 
 /// Response of GET /api/core/v2/treasury.
 /// Returns all information about the treasury.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TreasuryResponse {
     pub milestone_id: MilestoneId,
     pub amount: String,
@@ -261,12 +205,8 @@ pub struct TreasuryResponse {
 
 /// Response of GET /api/core/v2/milestone/{milestone_index}/utxo-changes.
 /// Returns all UTXO changes that happened at a specific milestone.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UtxoChangesResponse {
     pub index: u32,
     pub created_outputs: Vec<OutputId>,
@@ -274,12 +214,8 @@ pub struct UtxoChangesResponse {
 }
 
 /// Describes the heartbeat of a node.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Heartbeat {
     pub solid_milestone_index: u32,
     pub pruned_milestone_index: u32,
@@ -289,12 +225,8 @@ pub struct Heartbeat {
 }
 
 /// Describes metrics of a gossip stream.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Metrics {
     pub new_blocks: u64,
     pub received_blocks: u64,
@@ -310,20 +242,15 @@ pub struct Metrics {
 }
 
 /// Returns all information about the gossip stream with the peer.
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct Gossip {
     pub heartbeat: Heartbeat,
     pub metrics: Metrics,
 }
 
 /// Describes the relation with the peer.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Relation {
     Known,
     Unknown,
@@ -334,43 +261,31 @@ pub enum Relation {
 /// - GET /api/core/v2/peer/{peer_id}
 /// - POST /api/core/v2/peers
 /// Returns information about a peer.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PeerResponse {
     pub id: String,
     pub multi_addresses: Vec<String>,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
     pub relation: Relation,
     pub connected: bool,
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gossip: Option<Gossip>,
 }
 
 /// Response of GET /api/plugins/debug/whiteflag.
 /// Returns the computed merkle tree hash for the given white flag traversal.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WhiteFlagResponse {
     pub merkle_tree_hash: String,
 }
 
 /// Response of GET /api/routes.
 /// Returns the available API route groups of the node.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RoutesResponse {
     pub routes: Vec<String>,
 }

--- a/sdk/src/types/block/address/alias.rs
+++ b/sdk/src/types/block/address/alias.rs
@@ -60,6 +60,7 @@ impl core::fmt::Debug for AliasAddress {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 

--- a/sdk/src/types/block/address/ed25519.rs
+++ b/sdk/src/types/block/address/ed25519.rs
@@ -49,6 +49,7 @@ impl core::fmt::Debug for Ed25519Address {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 

--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -210,6 +210,7 @@ impl From<&Self> for Address {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::format;
 

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -60,6 +60,7 @@ impl core::fmt::Debug for NftAddress {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 

--- a/sdk/src/types/block/core.rs
+++ b/sdk/src/types/block/core.rs
@@ -13,13 +13,10 @@ use packable::{
 };
 
 use super::protocol::ProtocolParameters;
-use crate::types::{
-    block::{
-        parent::Parents,
-        payload::{OptionalPayload, Payload},
-        BlockId, Error, PROTOCOL_VERSION,
-    },
-    ValidationParams,
+use crate::types::block::{
+    parent::Parents,
+    payload::{OptionalPayload, Payload},
+    BlockId, Error, PROTOCOL_VERSION,
 };
 
 /// A builder to build a [`Block`].
@@ -253,6 +250,7 @@ fn verify_payload(payload: Option<&Payload>) -> Result<(), Error> {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 
@@ -261,7 +259,7 @@ pub(crate) mod dto {
     use super::*;
     use crate::types::{
         block::{payload::dto::PayloadDto, Error},
-        TryFromDto,
+        TryFromDto, ValidationParams,
     };
 
     /// The block object that nodes gossip around in the network.

--- a/sdk/src/types/block/input/mod.rs
+++ b/sdk/src/types/block/input/mod.rs
@@ -82,6 +82,7 @@ impl Input {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/input/treasury.rs
+++ b/sdk/src/types/block/input/treasury.rs
@@ -50,6 +50,7 @@ impl core::fmt::Debug for TreasuryInput {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 

--- a/sdk/src/types/block/input/utxo.rs
+++ b/sdk/src/types/block/input/utxo.rs
@@ -49,6 +49,7 @@ impl core::fmt::Debug for UtxoInput {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 

--- a/sdk/src/types/block/macro.rs
+++ b/sdk/src/types/block/macro.rs
@@ -98,6 +98,7 @@ macro_rules! impl_id {
         }
     };
 }
+#[cfg(feature = "serde")]
 pub(crate) use impl_id;
 
 /// Convenience macro to serialize types to string via serde.

--- a/sdk/src/types/block/mod.rs
+++ b/sdk/src/types/block/mod.rs
@@ -35,14 +35,16 @@ pub mod signature;
 /// A module that provides types and syntactic validations of unlocks.
 pub mod unlock;
 
+pub(crate) use r#macro::create_bitflags;
 #[cfg(feature = "serde")]
-pub(crate) use r#macro::string_serde_impl;
-pub(crate) use r#macro::{create_bitflags, impl_id};
+pub(crate) use r#macro::{impl_id, string_serde_impl};
 
+#[cfg(feature = "serde")]
+pub use self::core::dto::BlockDto;
 pub use self::{
     block_id::BlockId,
     convert::ConvertTo,
-    core::{dto::BlockDto, Block, BlockBuilder},
+    core::{Block, BlockBuilder},
     error::Error,
 };
 

--- a/sdk/src/types/block/output/alias.rs
+++ b/sdk/src/types/block/output/alias.rs
@@ -706,6 +706,7 @@ fn verify_unlock_conditions(unlock_conditions: &UnlockConditions, alias_id: &Ali
     verify_allowed_unlock_conditions(unlock_conditions, AliasOutput::ALLOWED_UNLOCK_CONDITIONS)
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::{
         boxed::Box,

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::collections::BTreeSet;
 
 use packable::Packable;
 
@@ -333,8 +333,12 @@ fn verify_features_packable<const VERIFY: bool>(blocks: &Features, _: &ProtocolP
     verify_features::<VERIFY>(blocks)
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
-    use alloc::string::{String, ToString};
+    use alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    };
 
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/feature/issuer.rs
+++ b/sdk/src/types/block/output/feature/issuer.rs
@@ -26,6 +26,7 @@ impl IssuerFeature {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -74,6 +74,7 @@ impl core::fmt::Debug for MetadataFeature {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::boxed::Box;
 

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -38,12 +38,12 @@ pub enum Feature {
 
 impl PartialOrd for Feature {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.kind().partial_cmp(&other.kind())
+        Some(self.cmp(other))
     }
 }
 impl Ord for Feature {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        self.kind().cmp(&other.kind())
     }
 }
 
@@ -284,6 +284,7 @@ mod test {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::format;
 

--- a/sdk/src/types/block/output/feature/sender.rs
+++ b/sdk/src/types/block/output/feature/sender.rs
@@ -26,6 +26,7 @@ impl SenderFeature {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/feature/tag.rs
+++ b/sdk/src/types/block/output/feature/tag.rs
@@ -66,6 +66,7 @@ impl core::fmt::Debug for TagFeature {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::boxed::Box;
 

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -1,10 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::cmp::Ordering;
 
 use packable::{
@@ -613,8 +610,12 @@ fn verify_unlock_conditions(unlock_conditions: &UnlockConditions) -> Result<(), 
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
-    use alloc::string::{String, ToString};
+    use alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    };
 
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -28,7 +28,6 @@ pub mod nft;
 ///
 pub mod unlock_condition;
 
-use alloc::string::ToString;
 use core::ops::RangeInclusive;
 
 use derive_more::From;
@@ -68,10 +67,7 @@ pub use self::{
     unlock_condition::{UnlockCondition, UnlockConditions},
 };
 use super::protocol::ProtocolParameters;
-use crate::types::{
-    block::{address::Address, semantic::ValidationContext, Error},
-    ValidationParams,
-};
+use crate::types::block::{address::Address, semantic::ValidationContext, Error};
 
 /// The maximum number of outputs of a transaction.
 pub const OUTPUT_COUNT_MAX: u16 = 128;
@@ -501,8 +497,12 @@ fn minimum_storage_deposit(address: &Address, rent_structure: RentStructure, tok
         .amount()
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
-    use alloc::{format, string::String};
+    use alloc::{
+        format,
+        string::{String, ToString},
+    };
 
     use serde::{Deserialize, Serialize, Serializer};
     use serde_json::Value;
@@ -516,10 +516,9 @@ pub mod dto {
         token_scheme::dto::{SimpleTokenSchemeDto, TokenSchemeDto},
         treasury::dto::TreasuryOutputDto,
     };
-    use crate::types::{block::Error, TryFromDto};
+    use crate::types::{block::Error, TryFromDto, ValidationParams};
 
-    #[derive(Clone, Debug, From)]
-    #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+    #[derive(Clone, Debug, From, Deserialize)]
     pub enum OutputBuilderAmountDto {
         Amount(String),
         MinimumStorageDeposit(RentStructure),

--- a/sdk/src/types/block/output/native_token.rs
+++ b/sdk/src/types/block/output/native_token.rs
@@ -20,7 +20,7 @@ use crate::types::block::{output::TokenId, Error};
 #[packable(unpack_error = Error)]
 pub struct NativeToken {
     // Identifier of the native token.
-    #[serde(rename = "id")]
+    #[cfg_attr(feature = "serde", serde(rename = "id"))]
     token_id: TokenId,
     // Amount of native tokens.
     #[packable(verify_with = verify_amount)]
@@ -53,12 +53,12 @@ impl NativeToken {
 
 impl PartialOrd for NativeToken {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.token_id.partial_cmp(&other.token_id)
+        Some(self.cmp(other))
     }
 }
 impl Ord for NativeToken {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        self.token_id.cmp(&other.token_id)
     }
 }
 

--- a/sdk/src/types/block/output/native_token.rs
+++ b/sdk/src/types/block/output/native_token.rs
@@ -20,7 +20,7 @@ use crate::types::block::{output::TokenId, Error};
 #[packable(unpack_error = Error)]
 pub struct NativeToken {
     // Identifier of the native token.
-    #[cfg_attr(feature = "serde", serde(rename = "id"))]
+    #[serde(rename = "id")]
     token_id: TokenId,
     // Amount of native tokens.
     #[packable(verify_with = verify_amount)]

--- a/sdk/src/types/block/output/native_token.rs
+++ b/sdk/src/types/block/output/native_token.rs
@@ -20,7 +20,7 @@ use crate::types::block::{output::TokenId, Error};
 #[packable(unpack_error = Error)]
 pub struct NativeToken {
     // Identifier of the native token.
-    #[serde(rename = "id")]
+    #[cfg_attr(feature = "serde", serde(rename = "id"))]
     token_id: TokenId,
     // Amount of native tokens.
     #[packable(verify_with = verify_amount)]

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::collections::BTreeSet;
 
 use packable::{
     error::{UnpackError, UnpackErrorExt},
@@ -483,8 +483,12 @@ fn verify_unlock_conditions(unlock_conditions: &UnlockConditions, nft_id: &NftId
     verify_allowed_unlock_conditions(unlock_conditions, NftOutput::ALLOWED_UNLOCK_CONDITIONS)
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
-    use alloc::string::{String, ToString};
+    use alloc::{
+        string::{String, ToString},
+        vec::Vec,
+    };
 
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/token_scheme/mod.rs
+++ b/sdk/src/types/block/output/token_scheme/mod.rs
@@ -33,6 +33,7 @@ impl TokenScheme {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use derive_more::From;
     use serde::{Deserialize, Serialize};

--- a/sdk/src/types/block/output/token_scheme/simple.rs
+++ b/sdk/src/types/block/output/token_scheme/simple.rs
@@ -116,6 +116,7 @@ fn verify_supply(minted_tokens: &U256, melted_tokens: &U256, maximum_supply: &U2
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/treasury.rs
+++ b/sdk/src/types/block/output/treasury.rs
@@ -1,10 +1,7 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{
-    block::{protocol::ProtocolParameters, Error},
-    ValidationParams,
-};
+use crate::types::block::{protocol::ProtocolParameters, Error};
 
 /// [`TreasuryOutput`] is an output which holds the treasury of a network.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, packable::Packable)]
@@ -52,13 +49,14 @@ fn verify_amount_packable<const VERIFY: bool>(
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::types::{block::Error, TryFromDto};
+    use crate::types::{block::Error, TryFromDto, ValidationParams};
 
     /// Describes a treasury output.
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/sdk/src/types/block/output/unlock_condition/address.rs
+++ b/sdk/src/types/block/output/unlock_condition/address.rs
@@ -26,6 +26,7 @@ impl AddressUnlockCondition {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/expiration.rs
+++ b/sdk/src/types/block/output/unlock_condition/expiration.rs
@@ -64,6 +64,7 @@ fn verify_timestamp<const VERIFY: bool>(timestamp: &u32, _: &()) -> Result<(), E
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/governor_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/governor_address.rs
@@ -28,6 +28,7 @@ impl GovernorAddressUnlockCondition {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/immutable_alias_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/immutable_alias_address.rs
@@ -47,6 +47,7 @@ fn verify_alias_address<const VERIFY: bool>(address: &Address, _: &()) -> Result
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -29,10 +29,7 @@ pub use self::{
     state_controller_address::StateControllerAddressUnlockCondition,
     storage_deposit_return::StorageDepositReturnUnlockCondition, timelock::TimelockUnlockCondition,
 };
-use crate::types::{
-    block::{address::Address, create_bitflags, protocol::ProtocolParameters, Error},
-    ValidationParams,
-};
+use crate::types::block::{address::Address, create_bitflags, protocol::ProtocolParameters, Error};
 
 ///
 #[derive(Clone, Eq, PartialEq, Hash, From)]
@@ -55,12 +52,12 @@ pub enum UnlockCondition {
 
 impl PartialOrd for UnlockCondition {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.kind().partial_cmp(&other.kind())
+        Some(self.cmp(other))
     }
 }
 impl Ord for UnlockCondition {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        self.kind().cmp(&other.kind())
     }
 }
 
@@ -496,6 +493,7 @@ mod test {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::format;
 
@@ -510,7 +508,7 @@ pub mod dto {
         storage_deposit_return::dto::StorageDepositReturnUnlockConditionDto, timelock::dto::TimelockUnlockConditionDto,
     };
     use super::*;
-    use crate::types::{block::Error, TryFromDto};
+    use crate::types::{block::Error, TryFromDto, ValidationParams};
 
     #[derive(Clone, Debug, Eq, PartialEq, From)]
     pub enum UnlockConditionDto {

--- a/sdk/src/types/block/output/unlock_condition/state_controller_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/state_controller_address.rs
@@ -28,6 +28,7 @@ impl StateControllerAddressUnlockCondition {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
+++ b/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
@@ -1,10 +1,7 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{
-    block::{address::Address, output::verify_output_amount, protocol::ProtocolParameters, Error},
-    ValidationParams,
-};
+use crate::types::block::{address::Address, output::verify_output_amount, protocol::ProtocolParameters, Error};
 
 /// Defines the amount of IOTAs used as storage deposit that have to be returned to the return [`Address`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, packable::Packable)]
@@ -61,6 +58,7 @@ fn verify_amount_packable<const VERIFY: bool>(
     verify_amount::<VERIFY>(amount, &protocol_parameters.token_supply())
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::{String, ToString};
 
@@ -69,7 +67,7 @@ pub(crate) mod dto {
     use super::*;
     use crate::types::{
         block::{address::dto::AddressDto, Error},
-        TryFromDto,
+        TryFromDto, ValidationParams,
     };
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/sdk/src/types/block/output/unlock_condition/timelock.rs
+++ b/sdk/src/types/block/output/unlock_condition/timelock.rs
@@ -38,6 +38,7 @@ fn verify_timestamp<const VERIFY: bool>(timestamp: &u32, _: &()) -> Result<(), E
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/payload/milestone/mod.rs
+++ b/sdk/src/types/block/payload/milestone/mod.rs
@@ -27,10 +27,7 @@ pub use self::{
     option::{MilestoneOption, MilestoneOptions, ParametersMilestoneOption, ReceiptMilestoneOption},
 };
 pub(crate) use self::{essence::MilestoneMetadataLength, option::BinaryParametersLength};
-use crate::types::{
-    block::{protocol::ProtocolParameters, signature::Signature, Error},
-    ValidationParams,
-};
+use crate::types::block::{protocol::ProtocolParameters, signature::Signature, Error};
 
 #[derive(Debug)]
 #[allow(missing_docs)]
@@ -161,6 +158,7 @@ fn verify_signatures_packable<const VERIFY: bool>(
     verify_signatures::<VERIFY>(signatures)
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::{boxed::Box, string::ToString};
     use core::str::FromStr;
@@ -174,7 +172,7 @@ pub mod dto {
             block::{
                 parent::Parents, payload::milestone::MilestoneIndex, signature::dto::SignatureDto, BlockId, Error,
             },
-            TryFromDto,
+            TryFromDto, ValidationParams,
         },
         utils::serde::prefix_hex_bytes,
     };

--- a/sdk/src/types/block/payload/milestone/option/mod.rs
+++ b/sdk/src/types/block/payload/milestone/option/mod.rs
@@ -15,10 +15,7 @@ pub use self::{
     parameters::ParametersMilestoneOption,
     receipt::{MigratedFundsEntry, ReceiptMilestoneOption, TailTransactionHash},
 };
-use crate::types::{
-    block::{protocol::ProtocolParameters, Error},
-    ValidationParams,
-};
+use crate::types::block::{protocol::ProtocolParameters, Error};
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, From, Packable)]
@@ -46,12 +43,12 @@ impl MilestoneOption {
 
 impl PartialOrd for MilestoneOption {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.kind().partial_cmp(&other.kind())
+        Some(self.cmp(other))
     }
 }
 impl Ord for MilestoneOption {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
+        self.kind().cmp(&other.kind())
     }
 }
 
@@ -166,6 +163,7 @@ fn verify_unique_sorted_packable<const VERIFY: bool>(
     verify_unique_sorted::<VERIFY>(milestone_options)
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::format;
 
@@ -177,7 +175,7 @@ pub mod dto {
         receipt::dto::{MigratedFundsEntryDto, ReceiptMilestoneOptionDto},
     };
     use super::*;
-    use crate::types::{block::Error, TryFromDto};
+    use crate::types::{block::Error, TryFromDto, ValidationParams};
 
     #[derive(Clone, Debug, Eq, PartialEq, From)]
     pub enum MilestoneOptionDto {

--- a/sdk/src/types/block/payload/milestone/option/parameters.rs
+++ b/sdk/src/types/block/payload/milestone/option/parameters.rs
@@ -66,6 +66,7 @@ impl ParametersMilestoneOption {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
 
     use serde::{Deserialize, Serialize};

--- a/sdk/src/types/block/payload/milestone/option/receipt/migrated_funds_entry.rs
+++ b/sdk/src/types/block/payload/milestone/option/receipt/migrated_funds_entry.rs
@@ -3,11 +3,8 @@
 
 use packable::Packable;
 
-use crate::types::{
-    block::{
-        address::Address, payload::milestone::option::receipt::TailTransactionHash, protocol::ProtocolParameters, Error,
-    },
-    ValidationParams,
+use crate::types::block::{
+    address::Address, payload::milestone::option::receipt::TailTransactionHash, protocol::ProtocolParameters, Error,
 };
 
 /// Describes funds which were migrated from a legacy network.
@@ -76,6 +73,7 @@ fn verify_amount_packable<const VERIFY: bool>(
     verify_amount::<VERIFY>(amount, &protocol_parameters.token_supply())
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::String;
 
@@ -84,7 +82,7 @@ pub(crate) mod dto {
     use super::*;
     use crate::types::{
         block::{address::dto::AddressDto, Error},
-        TryFromDto,
+        TryFromDto, ValidationParams,
     };
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/sdk/src/types/block/payload/milestone/option/receipt/mod.rs
+++ b/sdk/src/types/block/payload/milestone/option/receipt/mod.rs
@@ -14,14 +14,11 @@ use iterator_sorted::is_unique_sorted;
 use packable::{bounded::BoundedU16, prefix::VecPrefix, Packable, PackableExt};
 
 pub use self::{migrated_funds_entry::MigratedFundsEntry, tail_transaction_hash::TailTransactionHash};
-use crate::types::{
-    block::{
-        output::OUTPUT_COUNT_RANGE,
-        payload::{milestone::MilestoneIndex, Payload, TreasuryTransactionPayload},
-        protocol::ProtocolParameters,
-        Error,
-    },
-    ValidationParams,
+use crate::types::block::{
+    output::OUTPUT_COUNT_RANGE,
+    payload::{milestone::MilestoneIndex, Payload, TreasuryTransactionPayload},
+    protocol::ProtocolParameters,
+    Error,
 };
 
 const MIGRATED_FUNDS_ENTRY_RANGE: RangeInclusive<u16> = OUTPUT_COUNT_RANGE;
@@ -151,6 +148,7 @@ fn verify_transaction_packable<const VERIFY: bool>(transaction: &Payload, _: &Pr
     verify_transaction::<VERIFY>(transaction)
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 
@@ -161,7 +159,7 @@ pub(crate) mod dto {
             payload::dto::{PayloadDto, TreasuryTransactionPayloadDto},
             Error,
         },
-        TryFromDto,
+        TryFromDto, ValidationParams,
     };
 
     ///

--- a/sdk/src/types/block/payload/mod.rs
+++ b/sdk/src/types/block/payload/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
     treasury_transaction::TreasuryTransactionPayload,
 };
 use super::protocol::ProtocolParameters;
-use crate::types::{block::Error, ValidationParams};
+use crate::types::block::Error;
 
 /// A generic payload that can represent different types defining block payloads.
 #[derive(Clone, Eq, PartialEq)]
@@ -213,6 +213,7 @@ impl Packable for OptionalPayload {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use serde::{Deserialize, Serialize};
 
@@ -221,7 +222,7 @@ pub mod dto {
         milestone::dto::MilestonePayloadDto, tagged_data::dto::TaggedDataPayloadDto,
         transaction::dto::TransactionPayloadDto, treasury_transaction::dto::TreasuryTransactionPayloadDto,
     };
-    use crate::types::{block::Error, TryFromDto};
+    use crate::types::{block::Error, TryFromDto, ValidationParams};
 
     /// Describes all the different payload types.
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/sdk/src/types/block/payload/tagged_data/mod.rs
+++ b/sdk/src/types/block/payload/tagged_data/mod.rs
@@ -67,6 +67,7 @@ impl core::fmt::Debug for TaggedDataPayload {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/payload/transaction/essence/mod.rs
+++ b/sdk/src/types/block/payload/transaction/essence/mod.rs
@@ -47,6 +47,7 @@ impl TransactionEssence {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/payload/transaction/essence/regular.rs
+++ b/sdk/src/types/block/payload/transaction/essence/regular.rs
@@ -279,6 +279,7 @@ fn verify_payload_packable<const VERIFY: bool>(
     verify_payload::<VERIFY>(payload)
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::{
         boxed::Box,

--- a/sdk/src/types/block/payload/transaction/mod.rs
+++ b/sdk/src/types/block/payload/transaction/mod.rs
@@ -14,10 +14,7 @@ pub use self::{
     essence::{RegularTransactionEssence, RegularTransactionEssenceBuilder, TransactionEssence},
     transaction_id::TransactionId,
 };
-use crate::types::{
-    block::{protocol::ProtocolParameters, unlock::Unlocks, Error},
-    ValidationParams,
-};
+use crate::types::block::{protocol::ProtocolParameters, unlock::Unlocks, Error};
 
 /// A transaction to move funds.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -99,6 +96,7 @@ fn verify_essence_unlocks(essence: &TransactionEssence, unlocks: &Unlocks) -> Re
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::{boxed::Box, vec::Vec};
 
@@ -108,7 +106,7 @@ pub mod dto {
     use super::*;
     use crate::types::{
         block::{unlock::dto::UnlockDto, Error},
-        TryFromDto,
+        TryFromDto, ValidationParams,
     };
 
     /// The payload type to define a value transaction.

--- a/sdk/src/types/block/payload/treasury_transaction/mod.rs
+++ b/sdk/src/types/block/payload/treasury_transaction/mod.rs
@@ -3,14 +3,11 @@
 
 //! Module describing the treasury payload.
 
-use crate::types::{
-    block::{
-        input::{Input, TreasuryInput},
-        output::{Output, TreasuryOutput},
-        protocol::ProtocolParameters,
-        Error,
-    },
-    ValidationParams,
+use crate::types::block::{
+    input::{Input, TreasuryInput},
+    output::{Output, TreasuryOutput},
+    protocol::ProtocolParameters,
+    Error,
 };
 
 /// [`TreasuryTransactionPayload`] represents a transaction which moves funds from the treasury.
@@ -68,6 +65,7 @@ fn verify_output<const VERIFY: bool>(output: &Output, _: &ProtocolParameters) ->
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use serde::{Deserialize, Serialize};
 
@@ -78,7 +76,7 @@ pub mod dto {
             output::dto::{OutputDto, TreasuryOutputDto},
             Error,
         },
-        TryFromDto,
+        TryFromDto, ValidationParams,
     };
 
     /// The payload type to define a treasury transaction.

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -127,6 +127,7 @@ impl Packable for Ed25519Signature {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use alloc::string::String;
 

--- a/sdk/src/types/block/signature/mod.rs
+++ b/sdk/src/types/block/signature/mod.rs
@@ -5,8 +5,6 @@ mod ed25519;
 
 use alloc::boxed::Box;
 
-use derive_more::From;
-
 pub use self::ed25519::Ed25519Signature;
 use crate::types::block::Error;
 
@@ -47,7 +45,9 @@ impl Signature {
     }
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
+    use derive_more::From;
     use serde::{Deserialize, Serialize};
 
     pub use super::ed25519::dto::Ed25519SignatureDto;

--- a/sdk/src/types/block/unlock/alias.rs
+++ b/sdk/src/types/block/unlock/alias.rs
@@ -36,6 +36,7 @@ impl AliasUnlock {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/unlock/mod.rs
+++ b/sdk/src/types/block/unlock/mod.rs
@@ -137,6 +137,7 @@ fn verify_unlocks<const VERIFY: bool>(unlocks: &[Unlock], _: &()) -> Result<(), 
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 pub mod dto {
     use alloc::format;
 

--- a/sdk/src/types/block/unlock/nft.rs
+++ b/sdk/src/types/block/unlock/nft.rs
@@ -36,6 +36,7 @@ impl NftUnlock {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/unlock/reference.rs
+++ b/sdk/src/types/block/unlock/reference.rs
@@ -33,6 +33,7 @@ impl ReferenceUnlock {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/unlock/signature.rs
+++ b/sdk/src/types/block/unlock/signature.rs
@@ -27,6 +27,7 @@ impl SignatureUnlock {
     }
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/mod.rs
+++ b/sdk/src/types/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "serde")]
 pub mod api;
 pub mod block;
 

--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -284,6 +284,7 @@ fn unlock_unused_inputs(accounts: &mut [AccountDetails]) -> crate::wallet::Resul
     Ok(())
 }
 
+#[cfg(feature = "serde")]
 pub(crate) mod dto {
     use serde::Deserialize;
 


### PR DESCRIPTION
# Description of change

This PR fixes compilation without the `serde` feature. Part of the change is to feature gate all API types with `serde` because I don't think they are useful without it anyway. This isn't breaking because everything that was available with the feature enabled is untouched, and without the feature it would not compile.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)