### PR TITLE
Properly handle possibly null protocol params

### DIFF
--- a/sdk/src/wallet/migration/migrate_1.rs
+++ b/sdk/src/wallet/migration/migrate_1.rs
@@ -140,11 +140,11 @@ fn migrate_account(account: &mut serde_json::Value) -> Result<()> {
 }
 
 fn migrate_client_options(client_options: &mut serde_json::Value) -> Result<()> {
-    let protocol_parameters = &mut client_options["protocolParameters"];
+    if let Some(protocol_parameters) = &mut client_options.get_mut("protocolParameters") {
+        ConvertHrp::check(&mut protocol_parameters["bech32_hrp"])?;
 
-    ConvertHrp::check(&mut protocol_parameters["bech32_hrp"])?;
-
-    rename_keys(&mut protocol_parameters["rent_structure"]);
+        rename_keys(&mut protocol_parameters["rent_structure"]);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
# Description of change

This fixes a problem where the migrations assume that the protocol params exist on the client options.

## Links to any relevant issues

Closes #1089

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

New test `check_existing_db_5` with missing params.