### PR TITLE
Add IRC27 and IRC30 metadata utilities

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -140,6 +140,8 @@ tokio = { version = "1.31.0", default-features = false, features = [
 default = ["client", "wallet", "tls"]
 
 events = []
+irc_27 = ["url", "serde"]
+irc_30 = ["url", "serde"]
 ledger_nano = ["iota-ledger-nano"]
 mqtt = ["std", "regex", "rumqttc", "dep:once_cell"]
 participation = ["storage"]

--- a/sdk/src/client/api/block_builder/input_selection/core/transition.rs
+++ b/sdk/src/client/api/block_builder/input_selection/core/transition.rs
@@ -54,7 +54,7 @@ impl InputSelection {
         }
 
         // Remove potential sender feature because it will not be needed anymore as it only needs to be verified once.
-        let features = input.features().iter().cloned().filter(|feature| !feature.is_sender());
+        let features = input.features().iter().filter(|feature| !feature.is_sender()).cloned();
 
         let mut builder = AliasOutputBuilder::from(input)
             .with_alias_id(alias_id)
@@ -101,7 +101,7 @@ impl InputSelection {
         }
 
         // Remove potential sender feature because it will not be needed anymore as it only needs to be verified once.
-        let features = input.features().iter().cloned().filter(|feature| !feature.is_sender());
+        let features = input.features().iter().filter(|feature| !feature.is_sender()).cloned();
 
         let output = NftOutputBuilder::from(input)
             .with_nft_id(nft_id)

--- a/sdk/src/types/block/address/bech32.rs
+++ b/sdk/src/types/block/address/bech32.rs
@@ -137,7 +137,7 @@ impl<T: AsRef<str> + Send> ConvertTo<Hrp> for T {
 }
 
 /// An address and its network type.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, AsRef, Deref)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, AsRef, Deref, Ord, PartialOrd)]
 pub struct Bech32Address {
     pub(crate) hrp: Hrp,
     #[as_ref]

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -74,13 +74,15 @@ impl core::fmt::Debug for MetadataFeature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "irc_27")]
 pub(crate) mod irc_27 {
     use alloc::collections::{BTreeMap, BTreeSet};
 
     use getset::Getters;
     use serde::{Deserialize, Serialize};
     use url::Url;
+    use alloc::string::String;
+    use alloc::borrow::ToOwned;
 
     use super::*;
     use crate::types::block::address::Bech32Address;
@@ -289,11 +291,12 @@ pub(crate) mod irc_27 {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "irc_30")]
 pub(crate) mod irc_30 {
     use getset::Getters;
     use serde::{Deserialize, Serialize};
     use url::Url;
+    use alloc::string::String;
 
     use super::*;
 

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -19,6 +19,29 @@ pub struct MetadataFeature(
     BoxedSlicePrefix<u8, MetadataFeatureLength>,
 );
 
+macro_rules! impl_from_vec {
+    ($type:ty) => {
+        impl TryFrom<$type> for MetadataFeature {
+            type Error = Error;
+
+            fn try_from(value: $type) -> Result<Self, Self::Error> {
+                Vec::<u8>::from(value).try_into()
+            }
+        }
+    };
+}
+impl_from_vec!(&str);
+impl_from_vec!(String);
+impl_from_vec!(&[u8]);
+
+impl<const N: usize> TryFrom<[u8; N]> for MetadataFeature {
+    type Error = Error;
+
+    fn try_from(value: [u8; N]) -> Result<Self, Self::Error> {
+        value.to_vec().try_into()
+    }
+}
+
 impl TryFrom<Vec<u8>> for MetadataFeature {
     type Error = Error;
 
@@ -51,8 +74,8 @@ impl MetadataFeature {
 
     /// Creates a new [`MetadataFeature`].
     #[inline(always)]
-    pub fn new(data: impl Into<Vec<u8>>) -> Result<Self, Error> {
-        Self::try_from(data.into())
+    pub fn new<T: TryInto<Self>>(data: T) -> Result<Self, T::Error> {
+        data.try_into()
     }
 
     /// Returns the data.

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -187,7 +187,6 @@ pub(crate) mod irc_27 {
 
     #[derive(Clone, Debug, Serialize, Deserialize, Getters, PartialEq, Eq)]
     #[getset(get = "pub")]
-
     pub struct Attribute {
         trait_type: String,
         value: serde_json::Value,
@@ -306,13 +305,13 @@ pub(crate) mod irc_30 {
     pub struct Irc30Metadata {
         /// The human-readable name of the native token.
         name: String,
-        /// The human-readable description of the token.
-        description: String,
         /// The symbol/ticker of the token.
         symbol: String,
         /// Number of decimals the token uses (divide the token amount by 10^decimals to get its user representation).
+        decimals: u32,
+        /// The human-readable description of the token.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        decimals: Option<u32>,
+        description: Option<String>,
         /// URL pointing to more resources about the token.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         url: Option<Url>,
@@ -325,20 +324,20 @@ pub(crate) mod irc_30 {
     }
 
     impl Irc30Metadata {
-        pub fn new(name: impl Into<String>, description: impl Into<String>, symbol: impl Into<String>) -> Self {
+        pub fn new(name: impl Into<String>, symbol: impl Into<String>, decimals: u32) -> Self {
             Self {
                 name: name.into(),
-                description: description.into(),
                 symbol: symbol.into(),
-                decimals: Default::default(),
+                decimals,
+                description: Default::default(),
                 url: Default::default(),
                 logo_url: Default::default(),
                 logo: Default::default(),
             }
         }
 
-        pub fn with_decimals(mut self, decimals: u32) -> Self {
-            self.decimals.replace(decimals);
+        pub fn with_description(mut self, description: impl Into<String>) -> Self {
+            self.description.replace(description.into());
             self
         }
 
@@ -389,10 +388,10 @@ pub(crate) mod irc_30 {
             let metadata_deser = serde_json::from_value::<Irc30Metadata>(json.clone()).unwrap();
             let metadata = Irc30Metadata::new(
                 "FooCoin",
-                "FooCoin is the utility and governance token of FooLand, a revolutionary protocol in the play-to-earn crypto gaming field.",
-                "FOO",
+                
+                "FOO",3
             )
-            .with_decimals(3)
+            .with_description("FooCoin is the utility and governance token of FooLand, a revolutionary protocol in the play-to-earn crypto gaming field.")
             .with_url("https://foocoin.io".parse().unwrap())
             .with_logo_url("https://ipfs.io/ipfs/QmR36VFfo1hH2RAwVs4zVJ5btkopGip5cW7ydY4jUQBrkR".parse().unwrap());
             assert_eq!(metadata, metadata_deser);

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{ops::RangeInclusive, str::FromStr};
 
 use packable::{bounded::BoundedU16, prefix::BoxedSlicePrefix};

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -13,6 +13,11 @@ use derive_more::{Deref, From};
 use iterator_sorted::is_unique_sorted;
 use packable::{bounded::BoundedU8, prefix::BoxedSlicePrefix, Packable};
 
+#[cfg(feature = "serde")]
+pub use self::metadata::{
+    irc_27::{Attribute, Irc27Metadata},
+    irc_30::Irc30Metadata,
+};
 pub use self::{issuer::IssuerFeature, metadata::MetadataFeature, sender::SenderFeature, tag::TagFeature};
 pub(crate) use self::{metadata::MetadataFeatureLength, tag::TagFeatureLength};
 use crate::types::block::{create_bitflags, Error};

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -13,11 +13,10 @@ use derive_more::{Deref, From};
 use iterator_sorted::is_unique_sorted;
 use packable::{bounded::BoundedU8, prefix::BoxedSlicePrefix, Packable};
 
-#[cfg(feature = "serde")]
-pub use self::metadata::{
-    irc_27::{Attribute, Irc27Metadata},
-    irc_30::Irc30Metadata,
-};
+#[cfg(feature = "irc_27")]
+pub use self::metadata::irc_27::{Attribute, Irc27Metadata};
+#[cfg(feature = "irc_30")]
+pub use self::metadata::irc_30::Irc30Metadata;
 pub use self::{issuer::IssuerFeature, metadata::MetadataFeature, sender::SenderFeature, tag::TagFeature};
 pub(crate) use self::{metadata::MetadataFeatureLength, tag::TagFeatureLength};
 use crate::types::block::{create_bitflags, Error};

--- a/sdk/tests/client/input_selection/nft_outputs.rs
+++ b/sdk/tests/client/input_selection/nft_outputs.rs
@@ -1188,9 +1188,16 @@ fn changed_immutable_metadata() {
     let protocol_parameters = protocol_parameters();
     let nft_id_1 = NftId::from_str(NFT_ID_1).unwrap();
 
+    let metadata = iota_sdk::types::block::output::feature::Irc27Metadata::new(
+        "image/jpeg",
+        "https://mywebsite.com/my-nft-files-1.jpeg".parse().unwrap(),
+        "name",
+    )
+    .with_issuer_name("Alice");
+
     let nft_output =
         NftOutputBuilder::new_with_minimum_storage_deposit(*protocol_parameters.rent_structure(), nft_id_1)
-            .with_immutable_features(MetadataFeature::new([1, 2, 3]))
+            .with_immutable_features(MetadataFeature::try_from(metadata))
             .add_unlock_condition(AddressUnlockCondition::new(
                 Address::try_from_bech32(BECH32_ADDRESS_ED25519_0).unwrap(),
             ))
@@ -1203,14 +1210,17 @@ fn changed_immutable_metadata() {
         chain: None,
     }];
 
+    let metadata =
+        iota_sdk::types::block::output::feature::Irc30Metadata::new("name", "description", "symbol").with_decimals(5);
+
     // New nft output with changed immutable metadata feature
-    let updated_alias_output = NftOutputBuilder::from(nft_output.as_nft())
+    let updated_nft_output = NftOutputBuilder::from(nft_output.as_nft())
         .with_minimum_storage_deposit(*protocol_parameters.rent_structure())
-        .with_immutable_features(MetadataFeature::new([4, 5, 6]))
+        .with_immutable_features(MetadataFeature::try_from(metadata))
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
 
-    let outputs = [updated_alias_output];
+    let outputs = [updated_nft_output];
 
     let selected = InputSelection::new(
         inputs,
@@ -1219,6 +1229,8 @@ fn changed_immutable_metadata() {
         protocol_parameters,
     )
     .select();
+
+    println!("{selected:?}");
 
     assert!(matches!(
         selected,

--- a/sdk/tests/client/input_selection/nft_outputs.rs
+++ b/sdk/tests/client/input_selection/nft_outputs.rs
@@ -1188,12 +1188,15 @@ fn changed_immutable_metadata() {
     let protocol_parameters = protocol_parameters();
     let nft_id_1 = NftId::from_str(NFT_ID_1).unwrap();
 
+    #[cfg(feature = "irc_27")]
     let metadata = iota_sdk::types::block::output::feature::Irc27Metadata::new(
         "image/jpeg",
         "https://mywebsite.com/my-nft-files-1.jpeg".parse().unwrap(),
         "file 1",
     )
     .with_issuer_name("Alice");
+    #[cfg(not(feature = "irc_27"))]
+    let metadata = [1, 2, 3];
 
     let nft_output =
         NftOutputBuilder::new_with_minimum_storage_deposit(*protocol_parameters.rent_structure(), nft_id_1)
@@ -1210,12 +1213,15 @@ fn changed_immutable_metadata() {
         chain: None,
     }];
 
+    #[cfg(feature = "irc_27")]
     let metadata = iota_sdk::types::block::output::feature::Irc27Metadata::new(
         "image/jpeg",
         "https://mywebsite.com/my-nft-files-2.jpeg".parse().unwrap(),
         "file 2",
     )
     .with_issuer_name("Alice");
+    #[cfg(not(feature = "irc_27"))]
+    let metadata = [4, 5, 6];
 
     // New nft output with changed immutable metadata feature
     let updated_nft_output = NftOutputBuilder::from(nft_output.as_nft())

--- a/sdk/tests/client/input_selection/nft_outputs.rs
+++ b/sdk/tests/client/input_selection/nft_outputs.rs
@@ -1191,7 +1191,7 @@ fn changed_immutable_metadata() {
     let metadata = iota_sdk::types::block::output::feature::Irc27Metadata::new(
         "image/jpeg",
         "https://mywebsite.com/my-nft-files-1.jpeg".parse().unwrap(),
-        "name",
+        "file 1",
     )
     .with_issuer_name("Alice");
 
@@ -1210,8 +1210,12 @@ fn changed_immutable_metadata() {
         chain: None,
     }];
 
-    let metadata =
-        iota_sdk::types::block::output::feature::Irc30Metadata::new("name", "description", "symbol").with_decimals(5);
+    let metadata = iota_sdk::types::block::output::feature::Irc27Metadata::new(
+        "image/jpeg",
+        "https://mywebsite.com/my-nft-files-2.jpeg".parse().unwrap(),
+        "file 2",
+    )
+    .with_issuer_name("Alice");
 
     // New nft output with changed immutable metadata feature
     let updated_nft_output = NftOutputBuilder::from(nft_output.as_nft())
@@ -1229,8 +1233,6 @@ fn changed_immutable_metadata() {
         protocol_parameters,
     )
     .select();
-
-    println!("{selected:?}");
 
     assert!(matches!(
         selected,


### PR DESCRIPTION
# Description of change

This PR adds two kinds of NFT Immutable Metadata schemas. These can be created and used directly as a `MetadataFeature` in the immutable features of an NFT.

## Links to any relevant issues

Closes #504 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

I added tests for serialization, and used the metadata in a separate NFT test. However, there is an issue with that test. The input selection returns an `Err(InsufficientAmount { found: 302000, required: 490500 })` when it should return `UnfulfillableRequirement`.