### PR TITLE
Fix type of `value` property in `CustomAddress` (Node.js)

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.10 - 2023-mm-dd
+
+### Fixed
+
+- Type of `value` property in `CustomAddress`;
+
 ## 1.0.9 - 2023-09-07
 
 ### Added

--- a/bindings/nodejs/lib/types/wallet/transaction-options.ts
+++ b/bindings/nodejs/lib/types/wallet/transaction-options.ts
@@ -3,6 +3,7 @@
 
 import { TaggedDataPayload } from '../block/payload/tagged';
 import { Burn } from '../client';
+import { AccountAddress } from './address';
 
 /** Options for creating a transaction. */
 export interface TransactionOptions {
@@ -56,7 +57,7 @@ export type ReuseAddress = {
 export type CustomAddress = {
     /** The name of the strategy. */
     strategy: 'CustomAddress';
-    value: string;
+    value: AccountAddress;
 };
 
 /** Options for creating Native Tokens. */


### PR DESCRIPTION
fixes https://github.com/iotaledger/iota-sdk/issues/1060

After this change `CustomAddress` matches the rust side which is also used in `TransactionOptionsDto`
