### PR TITLE
Python: add BlockIssuanceCreditContextInput

### DIFF
--- a/bindings/python/iota_sdk/__init__.py
+++ b/bindings/python/iota_sdk/__init__.py
@@ -17,6 +17,7 @@ from .types.block_builder_options import *
 from .types.burn import *
 from .types.client_options import *
 from .types.common import *
+from .types.context_input import *
 from .types.event import *
 from .types.feature import *
 from .types.filter_options import *

--- a/bindings/python/iota_sdk/client/_high_level_api.py
+++ b/bindings/python/iota_sdk/client/_high_level_api.py
@@ -3,6 +3,7 @@
 
 from typing import List, Optional
 from dataclasses import dataclass
+from iota_sdk.types.block import Block
 from iota_sdk.types.common import HexStr, json
 from iota_sdk.types.output import OutputWithMetadata
 from iota_sdk.types.output_id import OutputId

--- a/bindings/python/iota_sdk/types/context_input.py
+++ b/bindings/python/iota_sdk/types/context_input.py
@@ -1,0 +1,23 @@
+# Copyright 2023 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import IntEnum
+from iota_sdk.types.common import HexStr, json
+
+
+class ContextInputType(IntEnum):
+    """Context input types.
+    """
+    BlockIssuanceCredit = 1
+
+
+@json
+@dataclass
+class BlockIssuanceCreditContextInput:
+    """A Block Issuance Credit (BIC) Context Input provides the VM with context for the value of
+    the BIC vector of a specific slot.
+    """
+    type: int
+    account_id: HexStr

--- a/bindings/python/iota_sdk/types/context_input.py
+++ b/bindings/python/iota_sdk/types/context_input.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from iota_sdk.types.common import HexStr, json
 
@@ -15,9 +15,20 @@ class ContextInputType(IntEnum):
 
 @json
 @dataclass
-class BlockIssuanceCreditContextInput:
+class ContextInput():
+    """Base class for context inputs.
+    """
+    type: int
+
+
+@json
+@dataclass
+class BlockIssuanceCreditContextInput(ContextInput):
     """A Block Issuance Credit (BIC) Context Input provides the VM with context for the value of
     the BIC vector of a specific slot.
     """
-    type: int
     account_id: HexStr
+    type: int = field(
+        default_factory=lambda: int(
+            ContextInputType.BlockIssuanceCredit),
+        init=False)

--- a/bindings/python/iota_sdk/types/feature.py
+++ b/bindings/python/iota_sdk/types/feature.py
@@ -4,6 +4,7 @@
 from enum import IntEnum
 
 from dataclasses import dataclass, field
+from typing import List
 
 from iota_sdk.types.address import Ed25519Address, AccountAddress, NFTAddress
 from iota_sdk.types.common import HexStr, json
@@ -99,4 +100,7 @@ class BlockIssuer(Feature):
     expiry_slot: str
     # TODO Replace with a list of PublicKey types
     public_keys: List[HexStr]
-    type: int = field(default_factory=lambda: int(FeatureType.BlockIssuer), init=False)
+    type: int = field(
+        default_factory=lambda: int(
+            FeatureType.BlockIssuer),
+        init=False)


### PR DESCRIPTION
# Description of change

Added BlockIssuanceCreditInput and some missing imports

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-sdk/issues/904

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the info example doesn't complain about a Python error anymore
