### PR TITLE
Replace `|` with `Union` type for Python 3.9 compatibility

### DIFF
--- a/.github/workflows/bindings-python.yml
+++ b/.github/workflows/bindings-python.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
 
     steps:
       - name: Checkout the Source Code
@@ -77,7 +77,7 @@ jobs:
       matrix:
         # os: [windows-latest, macos-latest, ubuntu-latest]
         os: [windows-latest, ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.9"]
 
     steps:
       - name: Checkout the Source Code

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.0.2 - 2023-MM-DD
+## 1.0.2 - 2023-09-12
 
 ### Added
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ClientOptions::maxParallelApiRequests`;
 
+### Changed
+
+- Replaced `|` with `Union` type for Python 3.9 compatibility;
+
 ### Fixed
 
 - `Utils::parse_bech32_address()`;

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -17,7 +17,7 @@ Python binding to the [iota-sdk library](/README.md).
 
 ## Requirements
 
-- [Python 3.10+](https://www.python.org)
+- [Python 3.9+](https://www.python.org)
 - [pip ^21.x](https://pypi.org/project/pip)
 - `Rust` and `Cargo` to compile the binding. Install
   them [here](https://doc.rust-lang.org/cargo/getting-started/installation.html).

--- a/bindings/python/iota_sdk/client/_high_level_api.py
+++ b/bindings/python/iota_sdk/client/_high_level_api.py
@@ -7,7 +7,7 @@ from iota_sdk.types.common import HexStr
 from iota_sdk.types.output import OutputWithMetadata
 from iota_sdk.types.output_id import OutputId
 from iota_sdk.types.common import CoinType
-from typing import List, Optional
+from typing import List, Optional, Union
 from dacite import from_dict
 
 
@@ -128,7 +128,7 @@ class HighLevelAPI():
         })
         return [Block.from_dict(block) for block in blocks]
 
-    def retry(self, block_id: HexStr) -> List[HexStr | Block]:
+    def retry(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Retries (promotes or reattaches) a block for provided block id. Block should only be
         retried only if they are valid and haven't been confirmed for a while.
 
@@ -143,7 +143,7 @@ class HighLevelAPI():
         return result
 
     def retry_until_included(
-            self, block_id: HexStr, interval: Optional[int] = None, max_attempts: Optional[int] = None) -> List[List[HexStr | Block]]:
+            self, block_id: HexStr, interval: Optional[int] = None, max_attempts: Optional[int] = None) -> List[List[Union[HexStr, Block]]]:
         """Retries (promotes or reattaches) a block for provided block id until it's included (referenced by a
         milestone). Default interval is 5 seconds and max attempts is 40. Returns the included block at first
         position and additional reattached blocks.
@@ -169,8 +169,8 @@ class HighLevelAPI():
                              for block_id_and_block in result]
         return blockIdsAndBlocks
 
-    def consolidate_funds(self, secret_manager: LedgerNanoSecretManager | MnemonicSecretManager | SeedSecretManager |
-                          StrongholdSecretManager, generate_addresses_options: GenerateAddressesOptions) -> str:
+    def consolidate_funds(self, secret_manager: Union[LedgerNanoSecretManager, MnemonicSecretManager, SeedSecretManager,
+                          StrongholdSecretManager], generate_addresses_options: GenerateAddressesOptions) -> str:
         """Function to consolidate all funds from a range of addresses to the address with the lowest index in that range.
         Returns the address to which the funds got consolidated, if any were available.
 
@@ -198,7 +198,7 @@ class HighLevelAPI():
             'amount': amount
         })
 
-    def reattach(self, block_id: HexStr) -> List[HexStr | Block]:
+    def reattach(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Reattaches blocks for a provided block id. Blocks can be reattached only if they are valid and
         haven't been confirmed for a while .
 
@@ -214,7 +214,7 @@ class HighLevelAPI():
         result[1] = Block.from_dict(result[1])
         return result
 
-    def reattach_unchecked(self, block_id: HexStr) -> List[HexStr | Block]:
+    def reattach_unchecked(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Reattach a block without checking if it should be reattached.
 
         Args:
@@ -229,7 +229,7 @@ class HighLevelAPI():
         result[1] = Block.from_dict(result[1])
         return result
 
-    def promote(self, block_id: HexStr) -> List[HexStr | Block]:
+    def promote(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Promotes a block. The method should validate if a promotion is necessary through get_block.
         If not, the method should error out and should not allow unnecessary promotions.
 
@@ -245,7 +245,7 @@ class HighLevelAPI():
         result[1] = Block.from_dict(result[1])
         return result
 
-    def promote_unchecked(self, block_id: HexStr) -> List[HexStr | Block]:
+    def promote_unchecked(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Promote a block without checking if it should be promoted.
 
         Args:

--- a/bindings/python/iota_sdk/client/_high_level_api.py
+++ b/bindings/python/iota_sdk/client/_high_level_api.py
@@ -214,7 +214,8 @@ class HighLevelAPI():
         result[1] = Block.from_dict(result[1])
         return result
 
-    def reattach_unchecked(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
+    def reattach_unchecked(
+            self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Reattach a block without checking if it should be reattached.
 
         Args:
@@ -245,7 +246,8 @@ class HighLevelAPI():
         result[1] = Block.from_dict(result[1])
         return result
 
-    def promote_unchecked(self, block_id: HexStr) -> List[Union[HexStr, Block]]:
+    def promote_unchecked(
+            self, block_id: HexStr) -> List[Union[HexStr, Block]]:
         """Promote a block without checking if it should be promoted.
 
         Args:

--- a/bindings/python/iota_sdk/client/_node_core_api.py
+++ b/bindings/python/iota_sdk/client/_node_core_api.py
@@ -8,7 +8,7 @@ from iota_sdk.types.output import OutputWithMetadata, OutputMetadata
 from iota_sdk.types.output_id import OutputId
 from iota_sdk.types.payload import MilestonePayload
 from iota_sdk.types.utxo_changes import UtxoChanges
-from typing import List
+from typing import List, Union
 from dacite import from_dict
 
 
@@ -97,7 +97,7 @@ class NodeCoreAPI():
             'blockBytes': block_bytes
         })
 
-    def get_output(self, output_id: OutputId | HexStr) -> OutputWithMetadata:
+    def get_output(self, output_id: Union[OutputId, HexStr]) -> OutputWithMetadata:
         """Get the output corresponding to the given output id.
 
         Returns:
@@ -109,8 +109,7 @@ class NodeCoreAPI():
             'outputId': output_id_str
         }))
 
-    def get_output_metadata(self, output_id: OutputId |
-                            HexStr) -> OutputMetadata:
+    def get_output_metadata(self, output_id: Union[OutputId, HexStr]) -> OutputMetadata:
         """Get the output metadata corresponding to the given output id.
 
         Returns:

--- a/bindings/python/iota_sdk/client/_node_core_api.py
+++ b/bindings/python/iota_sdk/client/_node_core_api.py
@@ -97,7 +97,8 @@ class NodeCoreAPI():
             'blockBytes': block_bytes
         })
 
-    def get_output(self, output_id: Union[OutputId, HexStr]) -> OutputWithMetadata:
+    def get_output(
+            self, output_id: Union[OutputId, HexStr]) -> OutputWithMetadata:
         """Get the output corresponding to the given output id.
 
         Returns:
@@ -109,7 +110,8 @@ class NodeCoreAPI():
             'outputId': output_id_str
         }))
 
-    def get_output_metadata(self, output_id: Union[OutputId, HexStr]) -> OutputMetadata:
+    def get_output_metadata(
+            self, output_id: Union[OutputId, HexStr]) -> OutputMetadata:
         """Get the output metadata corresponding to the given output id.
 
         Returns:

--- a/bindings/python/iota_sdk/client/client.py
+++ b/bindings/python/iota_sdk/client/client.py
@@ -21,7 +21,7 @@ from iota_sdk.types.transaction_data import PreparedTransactionData
 from json import dumps, loads
 import humps
 from datetime import timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from dacite import from_dict
 
 
@@ -39,7 +39,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
 
     def __init__(
         self,
-        nodes: Optional[str | List[str]] = None,
+        nodes: Optional[Union[str, List[str]]] = None,
         primary_node: Optional[str] = None,
         primary_pow_node: Optional[str] = None,
         permanode: Optional[str] = None,
@@ -359,8 +359,8 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         }))
 
     def build_and_post_block(self,
-                             secret_manager: Optional[LedgerNanoSecretManager | MnemonicSecretManager |
-                                                      SeedSecretManager | StrongholdSecretManager] = None,
+                             secret_manager: Optional[Union[LedgerNanoSecretManager, MnemonicSecretManager,
+                                                      SeedSecretManager, StrongholdSecretManager]] = None,
                              account_index: Optional[int] = None,
                              coin_type: Optional[int] = None,
                              custom_remainder_address: Optional[str] = None,
@@ -371,7 +371,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
                              inputs: Optional[List[Dict[str, Any]]] = None,
                              output: Optional[AddressAndAmount] = None,
                              outputs: Optional[List[Any]] = None,
-                             tag: Optional[HexStr] = None) -> List[HexStr | Block]:
+                             tag: Optional[HexStr] = None) -> List[Union[HexStr, Block]]:
         """Build and post a block.
 
         **Arguments**
@@ -471,8 +471,8 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         return self._call_method('unhealthyNodes')
 
     def prepare_transaction(self,
-                            secret_manager: Optional[LedgerNanoSecretManager | MnemonicSecretManager |
-                                                     SeedSecretManager | StrongholdSecretManager] = None,
+                            secret_manager: Optional[Union[LedgerNanoSecretManager, MnemonicSecretManager,
+                                                     SeedSecretManager, StrongholdSecretManager]] = None,
                             options=None):
         """Prepare a transaction for signing.
 
@@ -485,8 +485,8 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
             'options': options
         }))
 
-    def sign_transaction(self, secret_manager: LedgerNanoSecretManager | MnemonicSecretManager | SeedSecretManager |
-                         StrongholdSecretManager, prepared_transaction_data: PreparedTransactionData) -> TransactionPayload:
+    def sign_transaction(self, secret_manager: Union[LedgerNanoSecretManager, MnemonicSecretManager,
+                                                     SeedSecretManager, StrongholdSecretManager], prepared_transaction_data: PreparedTransactionData) -> TransactionPayload:
         """Sign a transaction.
 
         Args:
@@ -498,7 +498,7 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
             'preparedTransactionData': prepared_transaction_data
         }))
 
-    def submit_payload(self, payload: Payload) -> List[HexStr | Block]:
+    def submit_payload(self, payload: Payload) -> List[Union[HexStr, Block]]:
         """Submit a payload in a block.
 
         Args:

--- a/bindings/python/iota_sdk/secret_manager/secret_manager.py
+++ b/bindings/python/iota_sdk/secret_manager/secret_manager.py
@@ -8,7 +8,7 @@ from iota_sdk.types.transaction_data import PreparedTransactionData
 from iota_sdk.types.payload import TransactionPayload
 from json import dumps, loads
 import humps
-from typing import Optional
+from typing import Optional, Union
 from dacite import from_dict
 
 
@@ -82,8 +82,8 @@ class SecretManagerError(Exception):
 
 
 class SecretManager():
-    def __init__(self, secret_manager: Optional[LedgerNanoSecretManager | MnemonicSecretManager |
-                 SeedSecretManager | StrongholdSecretManager] = None, secret_manager_handle=None):
+    def __init__(self, secret_manager: Optional[Union[LedgerNanoSecretManager, MnemonicSecretManager,
+                 SeedSecretManager, StrongholdSecretManager]] = None, secret_manager_handle=None):
         """Initialize a secret manager.
 
         Args:

--- a/bindings/python/iota_sdk/types/block.py
+++ b/bindings/python/iota_sdk/types/block.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from iota_sdk.types.common import HexStr
 from iota_sdk.types.payload import TaggedDataPayload, TransactionPayload, MilestonePayload
 from iota_sdk.utils import Utils
@@ -25,8 +25,8 @@ class Block:
     protocolVersion: int
     parents: List[HexStr]
     nonce: str
-    payload: Optional[TaggedDataPayload |
-                      TransactionPayload | MilestonePayload] = None
+    payload: Optional[Union[TaggedDataPayload,
+                      TransactionPayload, MilestonePayload]] = None
 
     @classmethod
     def from_dict(cls, block_dict: Dict) -> Block:

--- a/bindings/python/iota_sdk/types/feature.py
+++ b/bindings/python/iota_sdk/types/feature.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Union
 
+
 class FeatureType(IntEnum):
     """Types of features.
 

--- a/bindings/python/iota_sdk/types/feature.py
+++ b/bindings/python/iota_sdk/types/feature.py
@@ -5,7 +5,7 @@ from iota_sdk.types.address import Ed25519Address, AliasAddress, NFTAddress
 from iota_sdk.types.common import HexStr
 from dataclasses import dataclass, field
 from enum import IntEnum
-
+from typing import Union
 
 class FeatureType(IntEnum):
     """Types of features.
@@ -41,7 +41,7 @@ class SenderFeature(Feature):
     Attributes:
         address: A given sender address.
     """
-    address: Ed25519Address | AliasAddress | NFTAddress
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(
         default_factory=lambda: int(
             FeatureType.Sender),
@@ -54,7 +54,7 @@ class IssuerFeature(Feature):
     Attributes:
         address: A given issuer address.
     """
-    address: Ed25519Address | AliasAddress | NFTAddress
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(
         default_factory=lambda: int(
             FeatureType.Issuer),

--- a/bindings/python/iota_sdk/types/output.py
+++ b/bindings/python/iota_sdk/types/output.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from dacite import from_dict
 from iota_sdk.types.common import HexStr
 from iota_sdk.types.feature import SenderFeature, IssuerFeature, MetadataFeature, TagFeature
@@ -89,10 +89,10 @@ class BasicOutput(Output):
             The type of output.
     """
     amount: str
-    unlockConditions: List[AddressUnlockCondition | ExpirationUnlockCondition | StorageDepositReturnUnlockCondition |
-                           TimelockUnlockCondition]
-    features: Optional[List[SenderFeature |
-                            MetadataFeature | TagFeature]] = None
+    unlockConditions: List[Union[AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition,
+                           TimelockUnlockCondition]]
+    features: Optional[List[Union[SenderFeature,
+                            MetadataFeature, TagFeature]]] = None
     nativeTokens: Optional[List[NativeToken]] = None
     type: int = field(
         default_factory=lambda: int(
@@ -129,12 +129,12 @@ class AliasOutput(Output):
     aliasId: HexStr
     stateIndex: int
     foundryCounter: int
-    unlockConditions: List[StateControllerAddressUnlockCondition |
-                           GovernorAddressUnlockCondition]
-    features: Optional[List[SenderFeature |
-                            MetadataFeature]] = None
-    immutableFeatures: Optional[List[IssuerFeature |
-                                     MetadataFeature]] = None
+    unlockConditions: List[Union[StateControllerAddressUnlockCondition,
+                           GovernorAddressUnlockCondition]]
+    features: Optional[List[Union[SenderFeature,
+                            MetadataFeature]]] = None
+    immutableFeatures: Optional[List[Union[IssuerFeature,
+                                     MetadataFeature]]] = None
     stateMetadata: Optional[HexStr] = None
     nativeTokens: Optional[List[NativeToken]] = None
     type: int = field(
@@ -198,12 +198,12 @@ class NftOutput(Output):
     """
     amount: str
     nftId: HexStr
-    unlockConditions: List[AddressUnlockCondition | ExpirationUnlockCondition |
-                           StorageDepositReturnUnlockCondition | TimelockUnlockCondition]
-    features: Optional[List[SenderFeature |
-                            MetadataFeature | TagFeature]] = None
-    immutableFeatures: Optional[List[
-        IssuerFeature | MetadataFeature]] = None
+    unlockConditions: List[Union[AddressUnlockCondition, ExpirationUnlockCondition,
+                           StorageDepositReturnUnlockCondition, TimelockUnlockCondition]]
+    features: Optional[List[Union[SenderFeature,
+                            MetadataFeature, TagFeature]]] = None
+    immutableFeatures: Optional[List[Union[
+        IssuerFeature, MetadataFeature]]] = None
     nativeTokens: Optional[List[NativeToken]] = None
     type: int = field(default_factory=lambda: int(OutputType.Nft), init=False)
 
@@ -257,7 +257,7 @@ class OutputWithMetadata:
     """
 
     metadata: OutputMetadata
-    output: AliasOutput | FoundryOutput | NftOutput | BasicOutput
+    output: Union[AliasOutput, FoundryOutput, NftOutput, BasicOutput]
 
     @classmethod
     def from_dict(cls, dict: Dict) -> OutputWithMetadata:
@@ -277,7 +277,7 @@ class OutputWithMetadata:
 
 
 def output_from_dict(
-        output: Dict[str, any]) -> TreasuryOutput | BasicOutput | AliasOutput | FoundryOutput | NftOutput | Output:
+        output: Dict[str, any]) -> Union[TreasuryOutput, BasicOutput, AliasOutput, FoundryOutput, NftOutput, Output]:
     output_type = OutputType(output['type'])
 
     if output_type == OutputType.Treasury:

--- a/bindings/python/iota_sdk/types/output_data.py
+++ b/bindings/python/iota_sdk/types/output_data.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 from iota_sdk.types.address import Ed25519Address, AliasAddress, NFTAddress
 from iota_sdk.types.common import HexStr
 from iota_sdk.types.output import BasicOutput, AliasOutput, FoundryOutput, NftOutput, OutputMetadata
@@ -27,9 +27,9 @@ class OutputData():
 
     outputId: HexStr
     metadata: OutputMetadata
-    output: AliasOutput | FoundryOutput | NftOutput | BasicOutput
+    output: Union[AliasOutput, FoundryOutput, NftOutput, BasicOutput]
     isSpent: bool
-    address: Ed25519Address | AliasAddress | NFTAddress
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     networkId: str
     remainder: bool
     chain: Optional[Bip44] = None

--- a/bindings/python/iota_sdk/types/payload.py
+++ b/bindings/python/iota_sdk/types/payload.py
@@ -10,7 +10,7 @@ from iota_sdk.types.unlock import SignatureUnlock, ReferenceUnlock
 from dacite import from_dict
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Any, Optional, List
+from typing import Any, Optional, List, Union
 
 
 class PayloadType(IntEnum):
@@ -38,7 +38,7 @@ class RegularTransactionEssence(TransactionEssence):
     networkId: str
     inputsCommitment: HexStr
     inputs: List[UtxoInput]
-    outputs: List[AliasOutput | FoundryOutput | NftOutput | BasicOutput]
+    outputs: List[Union[AliasOutput, FoundryOutput, NftOutput, BasicOutput]]
     payload: Optional[TaggedDataPayload] = None
     type: int = field(default_factory=lambda: 1, init=False)
 
@@ -143,7 +143,7 @@ class TransactionPayload(Payload):
         unlocks: The unlocks of the transaction.
     """
     essence: RegularTransactionEssence
-    unlocks: List[SignatureUnlock | ReferenceUnlock]
+    unlocks: List[Union[SignatureUnlock, ReferenceUnlock]]
     type: int = field(
         default_factory=lambda: int(
             PayloadType.Transaction),

--- a/bindings/python/iota_sdk/types/transaction_data.py
+++ b/bindings/python/iota_sdk/types/transaction_data.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass, asdict
-from typing import Optional, List
+from typing import Optional, List, Union
 from iota_sdk.types.address import Ed25519Address, AliasAddress, NFTAddress
 from iota_sdk.types.output import BasicOutput, AliasOutput, FoundryOutput, NftOutput, OutputMetadata
 from iota_sdk.types.payload import RegularTransactionEssence, TransactionPayload
@@ -19,7 +19,7 @@ class InputSigningData:
         outputMetadata: The output metadata.
         chain: The BIP44 chain for the address to unlock the output.
     """
-    output: AliasOutput | FoundryOutput | NftOutput | BasicOutput
+    output: Union[AliasOutput, FoundryOutput, NftOutput, BasicOutput]
     outputMetadata: OutputMetadata
     chain: Optional[Bip44] = None
 
@@ -43,8 +43,8 @@ class RemainderData:
         address: The remainder address.
         chain: The BIP44 chain for the remainder address.
     """
-    output: AliasOutput | FoundryOutput | NftOutput | BasicOutput
-    address: Ed25519Address | AliasAddress | NFTAddress
+    output: Union[AliasOutput, FoundryOutput, NftOutput, BasicOutput]
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     chain: Optional[Bip44] = None
 
     def as_dict(self):

--- a/bindings/python/iota_sdk/types/transaction_options.py
+++ b/bindings/python/iota_sdk/types/transaction_options.py
@@ -5,7 +5,7 @@ from iota_sdk.types.burn import Burn
 from iota_sdk.types.output_id import OutputId
 from iota_sdk.types.payload import TaggedDataPayload
 from enum import Enum
-from typing import Optional, List
+from typing import Optional, List, Union
 
 
 class RemainderValueStrategyCustomAddress:
@@ -59,7 +59,7 @@ class TransactionOptions():
         allow_micro_amount: Whether to allow sending a micro amount.
     """
 
-    def __init__(self, remainder_value_strategy: Optional[RemainderValueStrategy | RemainderValueStrategyCustomAddress] = None,
+    def __init__(self, remainder_value_strategy: Optional[Union[RemainderValueStrategy, RemainderValueStrategyCustomAddress]] = None,
                  tagged_data_payload: Optional[TaggedDataPayload] = None,
                  custom_inputs: Optional[List[OutputId]] = None,
                  mandatory_inputs: Optional[List[OutputId]] = None,

--- a/bindings/python/iota_sdk/types/unlock_condition.py
+++ b/bindings/python/iota_sdk/types/unlock_condition.py
@@ -4,7 +4,7 @@
 from iota_sdk.types.address import Ed25519Address, AliasAddress, NFTAddress
 from enum import IntEnum
 from dataclasses import dataclass, field
-
+from typing import Union
 
 class UnlockConditionType(IntEnum):
     """Unlock condition variants.
@@ -56,7 +56,7 @@ class AddressUnlockCondition(UnlockCondition):
     Args:
         address: An address unlocked with a private key.
     """
-    address: Ed25519Address | AliasAddress | NFTAddress
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(
         default_factory=lambda: int(
             UnlockConditionType.Address),
@@ -71,7 +71,7 @@ class StorageDepositReturnUnlockCondition(UnlockCondition):
         return_address: The address to return the amount to.
     """
     amount: str
-    returnAddress: Ed25519Address | AliasAddress | NFTAddress
+    returnAddress: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(default_factory=lambda: int(
         UnlockConditionType.StorageDepositReturn), init=False)
 
@@ -97,7 +97,7 @@ class ExpirationUnlockCondition(UnlockCondition):
         return_address: The return address if the output was not claimed in time.
     """
     unixTime: int
-    returnAddress: Ed25519Address | AliasAddress | NFTAddress
+    returnAddress: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(
         default_factory=lambda: int(
             UnlockConditionType.Expiration),
@@ -110,7 +110,7 @@ class StateControllerAddressUnlockCondition(UnlockCondition):
     Args:
         address: The state controller address that owns the output.
     """
-    address: Ed25519Address | AliasAddress | NFTAddress
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(default_factory=lambda: int(
         UnlockConditionType.StateControllerAddress), init=False)
 
@@ -121,7 +121,7 @@ class GovernorAddressUnlockCondition(UnlockCondition):
     Args:
         address: The governor address that owns the output.
     """
-    address: Ed25519Address | AliasAddress | NFTAddress
+    address: Union[Ed25519Address, AliasAddress, NFTAddress]
     type: int = field(default_factory=lambda: int(
         UnlockConditionType.GovernorAddress), init=False)
 

--- a/bindings/python/iota_sdk/types/unlock_condition.py
+++ b/bindings/python/iota_sdk/types/unlock_condition.py
@@ -6,6 +6,7 @@ from enum import IntEnum
 from dataclasses import dataclass, field
 from typing import Union
 
+
 class UnlockConditionType(IntEnum):
     """Unlock condition variants.
 

--- a/bindings/python/iota_sdk/wallet/account.py
+++ b/bindings/python/iota_sdk/wallet/account.py
@@ -19,7 +19,7 @@ from iota_sdk.types.send_params import CreateAliasOutputParams, CreateNativeToke
 from iota_sdk.types.transaction import Transaction
 from iota_sdk.types.transaction_options import TransactionOptions
 from iota_sdk.types.consolidation_params import ConsolidationParams
-from typing import List, Optional
+from typing import List, Optional, Union
 from dacite import from_dict
 from dataclasses import dataclass
 
@@ -334,7 +334,7 @@ class Account:
         ))
 
     def prepare_output(self, params: OutputParams,
-                       transaction_options: Optional[TransactionOptions] = None) -> BasicOutput | NftOutput:
+                       transaction_options: Optional[TransactionOptions] = None) -> Union[BasicOutput, NftOutput]:
         """Prepare an output for sending.
            If the amount is below the minimum required storage deposit, by default the remaining amount will automatically
            be added with a StorageDepositReturn UnlockCondition, when setting the ReturnStrategy to `gift`, the full

--- a/bindings/python/iota_sdk/wallet/prepared_transaction.py
+++ b/bindings/python/iota_sdk/wallet/prepared_transaction.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from iota_sdk.types.transaction import Transaction
 from iota_sdk.types.transaction_data import PreparedTransactionData
 from dacite import from_dict
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, Union
 # Required to prevent circular import
 if TYPE_CHECKING:
     from iota_sdk.wallet.wallet import Account
@@ -22,7 +22,7 @@ class PreparedTransaction:
     def __init__(
         self,
         account: Account,
-        prepared_transaction_data: PreparedTransactionData | Dict
+        prepared_transaction_data: Union[PreparedTransactionData, Dict]
     ):
         """Initalize `Self`.
         """

--- a/bindings/python/iota_sdk/wallet/wallet.py
+++ b/bindings/python/iota_sdk/wallet/wallet.py
@@ -8,7 +8,7 @@ from iota_sdk.types.address import AccountAddress
 from iota_sdk.wallet.account import Account, _call_method_routine
 from iota_sdk.wallet.sync_options import SyncOptions
 from json import dumps
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 
 class Wallet():
@@ -19,7 +19,7 @@ class Wallet():
     """
 
     def __init__(self, storage_path: Optional[str] = None, client_options: Optional[Dict[str, Any]] = None, coin_type: Optional[int] = None,
-                 secret_manager: Optional[LedgerNanoSecretManager | MnemonicSecretManager | SeedSecretManager | StrongholdSecretManager] = None):
+                 secret_manager: Optional[Union[LedgerNanoSecretManager, MnemonicSecretManager, SeedSecretManager, StrongholdSecretManager]] = None):
         """Initialize `self`.
         """
 
@@ -62,7 +62,7 @@ class Wallet():
         )
         return Account(account_data, self.handle)
 
-    def get_account(self, account_id: str | int) -> Account:
+    def get_account(self, account_id: Union[str, int]) -> Account:
         """Get the account associated with the given account ID or index.
         """
         account_data = self._call_method(
@@ -92,7 +92,7 @@ class Wallet():
             message['data'] = data
         return message
 
-    def get_account_data(self, account_id: str | int):
+    def get_account_data(self, account_id: Union[str, int]):
         """Get account data associated with the given account ID or index.
         """
         return self._call_method(

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -9,7 +9,7 @@ from setuptools_rust import RustExtension
 def get_py_version_cfgs():
     # For now each Cfg Py_3_X flag is interpreted as "at least 3.X"
     version = sys.version_info[0:3]
-    py3_min = 8
+    py3_min = 9
     out_cfg = []
     for minor in range(py3_min, version[1] + 1):
         out_cfg.append("--cfg=Py_3_%d" % minor)


### PR DESCRIPTION
# Description of change

Replace `|` with `Union` type for Python 3.9 compatibility

## Links to any relevant issues

Closes #1202 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running an example with 3.9
