### PR TITLE
Nodes: fix getNetworkId() and types

### DIFF
--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -198,7 +198,7 @@ pub(crate) async fn call_client_method_internal(client: &Client, method: ClientM
         }
         ClientMethod::GetNode => Response::Node(client.get_node().await?),
         ClientMethod::GetNetworkInfo => Response::NetworkInfo(client.get_network_info().await?),
-        ClientMethod::GetNetworkId => Response::NetworkId(client.get_network_id().await?),
+        ClientMethod::GetNetworkId => Response::NetworkId(client.get_network_id().await?.to_string()),
         ClientMethod::GetBech32Hrp => Response::Bech32Hrp(client.get_bech32_hrp().await?),
         ClientMethod::GetMinPowScore => Response::MinPowScore(client.get_min_pow_score().await?),
         ClientMethod::GetTipsInterval => Response::TipsInterval(client.get_tips_interval().await),

--- a/bindings/core/src/response.rs
+++ b/bindings/core/src/response.rs
@@ -71,7 +71,7 @@ pub enum Response {
     NetworkInfo(NetworkInfo),
     /// Response for:
     /// - [`GetNetworkId`](crate::method::ClientMethod::GetNetworkId)
-    NetworkId(u64),
+    NetworkId(String),
     /// Response for:
     /// - [`GetBech32Hrp`](crate::method::ClientMethod::GetBech32Hrp)
     Bech32Hrp(Hrp),

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.11 - 2023-09-14
+
+### Fixed
+
+- `Client::getNetworkId()`;
+
 ## 1.0.10 - 2023-09-12
 
 ### Changed

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Client::getNetworkId()` return type;
-- `Transaction::networkId` type;
+- `RegularTransactionEssence::networkId` type;
 - `FilterOptions::outputTypes` type;
 
 ## 1.0.10 - 2023-09-12

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Client::getNetworkId()`;
+- `Client::getNetworkId()` return type;
 - `Transaction::networkId` type;
 - `FilterOptions::outputTypes` type;
 

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Client::getNetworkId()`;
+- `Transaction::networkId` type;
+- `FilterOptions::outputTypes` type;
 
 ## 1.0.10 - 2023-09-12
 

--- a/bindings/nodejs/lib/client/client.ts
+++ b/bindings/nodejs/lib/client/client.ts
@@ -370,7 +370,7 @@ export class Client {
     /**
      * Get the ID of the network the node is connected to.
      */
-    async getNetworkId(): Promise<number> {
+    async getNetworkId(): Promise<string> {
         const response = await this.methodHandler.callMethod({
             name: 'getNetworkId',
         });

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -44,7 +44,7 @@ abstract class TransactionEssence {
  */
 class RegularTransactionEssence extends TransactionEssence {
     /// The unique value denoting whether the block was meant for mainnet, testnet, or a private network.
-    networkId: number;
+    networkId: string;
     inputsCommitment: HexEncodedString;
 
     @Type(() => Input, {
@@ -71,7 +71,7 @@ class RegularTransactionEssence extends TransactionEssence {
      *
      */
     constructor(
-        networkId: number,
+        networkId: string,
         inputsCommitment: HexEncodedString,
         inputs: Input[],
         outputs: Output[],

--- a/bindings/nodejs/lib/types/wallet/account.ts
+++ b/bindings/nodejs/lib/types/wallet/account.ts
@@ -198,7 +198,7 @@ export interface FilterOptions {
     /** Filter all outputs where the booked milestone index is above the specified timestamp */
     upperBoundBookedTimestamp?: number;
     /** Filter all outputs for the provided types (Basic = 3, Alias = 4, Foundry = 5, NFT = 6) */
-    outputTypes?: Uint8Array;
+    outputTypes?: number[];
     /** Return all alias outputs matching these IDs. */
     aliasIds?: AliasId[];
     /** Return all foundry outputs matching these IDs. */

--- a/bindings/nodejs/lib/types/wallet/transaction-options.ts
+++ b/bindings/nodejs/lib/types/wallet/transaction-options.ts
@@ -1,8 +1,10 @@
 // Copyright 2021-2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+import { AliasId } from '../block';
 import { TaggedDataPayload } from '../block/payload/tagged';
 import { Burn } from '../client';
+import { HexEncodedString } from '../utils';
 import { AccountAddress } from './address';
 
 /** Options for creating a transaction. */
@@ -63,13 +65,13 @@ export type CustomAddress = {
 /** Options for creating Native Tokens. */
 export interface CreateNativeTokenParams {
     /** The Alias ID of the corresponding Foundry. */
-    aliasId?: string;
+    aliasId?: AliasId;
     /** Hex encoded number */
     circulatingSupply: bigint;
     /** Hex encoded number */
     maximumSupply: bigint;
     /** Hex encoded bytes */
-    foundryMetadata?: string;
+    foundryMetadata?: HexEncodedString;
 }
 
 /** Options for minting NFTs. */
@@ -81,13 +83,13 @@ export interface MintNftParams {
     /** Bech32 encoded sender address **/
     sender?: string;
     /** Hex encoded bytes */
-    metadata?: string;
+    metadata?: HexEncodedString;
     /** Hex encoded bytes */
-    tag?: string;
+    tag?: HexEncodedString;
     /** Bech32 encoded issuer address **/
     issuer?: string;
     /** Hex encoded bytes */
-    immutableMetadata?: string;
+    immutableMetadata?: HexEncodedString;
 }
 
 /** Options for the alias output creation */
@@ -97,9 +99,9 @@ export interface AliasOutputParams {
      */
     address?: string;
     /** Hex encoded bytes */
-    immutableMetadata?: string;
+    immutableMetadata?: HexEncodedString;
     /** Hex encoded bytes */
-    metadata?: string;
+    metadata?: HexEncodedString;
     /** Hex encoded bytes */
-    stateMetadata?: string;
+    stateMetadata?: HexEncodedString;
 }

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "Node.js binding to the IOTA SDK library",
     "main": "out/index.js",
     "types": "out/index.d.ts",

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,11 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.0.7 - 2023-09-14
-
-Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.
-
-## 1.0.6 - 2023-MM-DD
+## 1.0.6 - 2023-09-14
 
 Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.
 

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.7 - 2023-09-14
+
+Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.
+
 ## 1.0.6 - 2023-MM-DD
 
 Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk-wasm",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "WebAssembly bindings for the IOTA SDK library",
     "repository": {
         "type": "git",


### PR DESCRIPTION
# Description of change

Fix getNetworkId(), if parsed as number it can be wrong because it's a u64
Also fixed
- `Transaction::networkId` type;
- `FilterOptions::outputTypes` type;

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running an example with client.getNetworkId() which returned a wrong value before
