### PR TITLE
NodeJS: fix npm installation through prebuild on win32 x64

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -18,7 +18,7 @@
         "prebuild-windows-arm64": "prebuild --runtime napi --target 6 --prepack 'yarn run neon-build-windows-arm64' --strip --arch arm64",
         "neon-build-windows-arm64": "cargo-cp-artifact -ac iota-sdk-nodejs ./index.node -- cargo build --profile=production --message-format=json-render-diagnostics --target aarch64-pc-windows-msvc && node -e \"require('./scripts/move-artifact.js')()\"",
         "rebuild": "node scripts/neon-build && tsc && node scripts/strip.js",
-        "install": "prebuild-install --runtime napi --tag-prefix='iota-sdk-nodejs-v' && tsc || npm run rebuild",
+        "install": "prebuild-install --runtime napi --tag-prefix=iota-sdk-nodejs-v && tsc || npm run rebuild",
         "test": "jest",
         "create-api-docs": "typedoc ./lib/index.ts --githubPages false --disableSources --excludePrivate --excludeInternal --plugin typedoc-plugin-markdown --theme markdown --hideBreadcrumbs --entryDocument api_ref.md --readme none --hideGenerator --sort source-order"
     },


### PR DESCRIPTION
# Description of change

Modified broken install command so that it is correctly interpreted on windows

## Links to any relevant issues

no issues exist

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

I ran `npm install` on the nodejs code with and without the modification (on x64 hardware)

target | before | after
--- | --- | ---
linux | ✔️ | ✔️
win32 | ❌ | ✔️

Here is the relevat output for each test (using `--loglevel verbose`)

- Linux before:
```
> @iota/sdk@1.0.11 install
> prebuild-install --runtime napi --tag-prefix='iota-sdk-nodejs-v' && tsc || npm run rebuild

prebuild-install info begin Prebuild-install version 7.1.1
prebuild-install info looking for local prebuild @ prebuilds/sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info looking for cached prebuild @ /root/.npm/_prebuilds/fad8c5-sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install http request GET https://github.com/iotaledger/iota-sdk/releases/download/iota-sdk-nodejs-v1.0.11/sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install http 200 https://github.com/iotaledger/iota-sdk/releases/download/iota-sdk-nodejs-v1.0.11/sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info downloading to @ /root/.npm/_prebuilds/fad8c5-sdk-v1.0.11-napi-v6-linux-x64.tar.gz.92928-4d448947ab139.tmp
prebuild-install info renaming to @ /root/.npm/_prebuilds/fad8c5-sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info unpacking @ /root/.npm/_prebuilds/fad8c5-sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info unpack resolved to /root/iota-sdk/bindings/nodejs/build/Release/index.node
prebuild-install info install Successfully installed prebuilt binary!
```

- Linux after:
```
> @iota/sdk@1.0.11 install
> prebuild-install --runtime napi --tag-prefix=iota-sdk-nodejs-v && tsc || npm run rebuild

prebuild-install info begin Prebuild-install version 7.1.1
prebuild-install info looking for local prebuild @ prebuilds/sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info looking for cached prebuild @ /root/.npm/_prebuilds/fad8c5-sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info found cached prebuild
prebuild-install info unpacking @ /root/.npm/_prebuilds/fad8c5-sdk-v1.0.11-napi-v6-linux-x64.tar.gz
prebuild-install info unpack resolved to /root/iota-sdk/bindings/nodejs/build/Release/index.node
prebuild-install info install Successfully installed prebuilt binary!
```

- Windows before:
```
> @iota/sdk@1.0.11 install
> prebuild-install --runtime napi --tag-prefix='iota-sdk-nodejs-v' && tsc || npm run rebuild

prebuild-install info begin Prebuild-install version 7.1.1
prebuild-install info looking for local prebuild @ prebuilds\sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install info looking for cached prebuild @ C:\Users\danie\AppData\Local\npm-cache\_prebuilds\f42bda-sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install http request GET https://github.com/iotaledger/iota-sdk/releases/download/'iota-sdk-nodejs-v'1.0.11/sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install http 404 https://github.com/iotaledger/iota-sdk/releases/download/'iota-sdk-nodejs-v'1.0.11/sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install warn install No prebuilt binaries found (target=6 runtime=napi arch=x64 libc= platform=win32)
```

- Windows after:
```
> @iota/sdk@1.0.11 install
> prebuild-install --runtime napi --tag-prefix=iota-sdk-nodejs-v && tsc || npm run rebuild

prebuild-install info begin Prebuild-install version 7.1.1
prebuild-install info looking for local prebuild @ prebuilds\sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install info looking for cached prebuild @ C:\Users\danie\AppData\Local\npm-cache\_prebuilds\a263ce-sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install http request GET https://github.com/iotaledger/iota-sdk/releases/download/iota-sdk-nodejs-v1.0.11/sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install http 200 https://github.com/iotaledger/iota-sdk/releases/download/iota-sdk-nodejs-v1.0.11/sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install info downloading to @ C:\Users\danie\AppData\Local\npm-cache\_prebuilds\a263ce-sdk-v1.0.11-napi-v6-win32-x64.tar.gz.8488-c9dbfdc9f8a8d.tmp
prebuild-install info renaming to @ C:\Users\danie\AppData\Local\npm-cache\_prebuilds\a263ce-sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install info unpacking @ C:\Users\danie\AppData\Local\npm-cache\_prebuilds\a263ce-sdk-v1.0.11-napi-v6-win32-x64.tar.gz
prebuild-install info install Successfully installed prebuilt binary!
```
