### PR TITLE
Node: Cyclic dep. in transaction payload

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.12 - 2023-09-14
+
+### Changed
+
+- `RegularTransactionEssence.payload` field type to an optional `TaggedDataPayload`;
+
 ## 1.0.11 - 2023-09-14
 
 ### Fixed

--- a/bindings/nodejs/examples/client/07-get-block-data.ts
+++ b/bindings/nodejs/examples/client/07-get-block-data.ts
@@ -7,6 +7,9 @@ require('dotenv').config({ path: '.env' });
 // Run with command:
 // yarn run-example ./client/07-get-block-data.ts
 
+// Set a specific block id or leave undefined for getting a tip.
+let ID: string | undefined = '0x1234';
+
 // In this example we will send a block and get the data and metadata for it.
 async function run() {
     initLogger();
@@ -22,15 +25,17 @@ async function run() {
     try {
         // Fetch a block ID from the node.
         const blockIds = await client.getTips();
-        console.log('Block IDs:', blockIds, '\n');
+
+        const blockId = ID || blockIds[0];
+        console.log('Block ID:', blockId, '\n');
 
         // Get the metadata for the block.
-        const blockMetadata = await client.getBlockMetadata(blockIds[0]);
-        console.log('Block metadata: ', blockMetadata, '\n');
+        const blockMetadata = await client.getBlockMetadata(blockId);
+        console.log('Block metadata:', blockMetadata, '\n');
 
         // Request the block by its id.
-        const blockData = await client.getBlock(blockIds[0]);
-        console.log('Block data: ', blockData, '\n');
+        const blockData = await client.getBlock(blockId);
+        console.log('Block data:', blockData, '\n');
     } catch (error) {
         console.error('Error: ', error);
     }

--- a/bindings/nodejs/examples/client/07-get-block-data.ts
+++ b/bindings/nodejs/examples/client/07-get-block-data.ts
@@ -8,7 +8,7 @@ require('dotenv').config({ path: '.env' });
 // yarn run-example ./client/07-get-block-data.ts
 
 // Set a specific block id or leave undefined for getting a tip.
-let ID: string | undefined = '0x1234';
+const ID: string | undefined = '0x1234';
 
 // In this example we will send a block and get the data and metadata for it.
 async function run() {

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from 'class-transformer';
-import { PayloadDiscriminator } from '..';
 import { HexEncodedString } from '../../../utils';
 import { Input, InputDiscriminator } from '../../input';
 import { Output, OutputDiscriminator } from '../../output';
-import { Payload } from '../payload';
+import { TaggedDataPayload } from '../tagged';
 
 /**
  * All of the essence types.
@@ -57,10 +56,8 @@ class RegularTransactionEssence extends TransactionEssence {
     })
     outputs: Output[];
 
-    @Type(() => Payload, {
-        discriminator: PayloadDiscriminator,
-    })
-    payload: Payload | undefined;
+    @Type(() => TaggedDataPayload)
+    payload?: TaggedDataPayload;
 
     /**
      * @param networkId The ID of the network the transaction was issued to.
@@ -75,7 +72,7 @@ class RegularTransactionEssence extends TransactionEssence {
         inputsCommitment: HexEncodedString,
         inputs: Input[],
         outputs: Output[],
-        payload: Payload | undefined,
+        payload: TaggedDataPayload | undefined,
     ) {
         super(TransactionEssenceType.Regular);
         this.networkId = networkId;


### PR DESCRIPTION
# Description of change

Transaction payload wasnt parsed due to cyclic dependency in class-transformer.
Setting it to Always being TaggedDataPayload solves this as the discriminator is no longer needed.

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/1249
