### PR TITLE
Don't return error with custom remainder address and ledger nano

### DIFF
--- a/bindings/nodejs-old/examples/ledger_nano.js
+++ b/bindings/nodejs-old/examples/ledger_nano.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 const { AccountManager, CoinType } = require('@iota/wallet');
 
 // In this example we will create addresses with a ledger nano hardware wallet
-// To use the ledger nano simulator clone https://github.com/iotaledger/ledger-shimmer-app, run `git submodule init && git submodule update --recursive`,
+// To use the ledger nano simulator clone https://github.com/iotaledger/ledger-iota-app, run `git submodule init && git submodule update --recursive`,
 // then `./build.sh -m nanos|nanox|nanosplus -s` and use `true` for `LedgerNano`.
 
 async function run() {

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -21,9 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.12 - 2023-09-25
 
+### Changed
+
+- Made `TransactionOptions.allowMicroAmount` optional;
+
 ### Fixed
 
 - Parsing of `RegularTransactionEssence.payload`;
+- Don't error if custom remainder address is provided with ledger nano;
 
 ## 1.0.11 - 2023-09-14
 

--- a/bindings/nodejs/examples/secret_manager/ledger-nano.ts
+++ b/bindings/nodejs/examples/secret_manager/ledger-nano.ts
@@ -8,7 +8,7 @@ require('dotenv').config({ path: '.env' });
 // yarn run-example ./secret_manager/ledger-nano.ts
 
 // In this example we will get the ledger status and generate an address
-// To use the ledger nano simulator clone https://github.com/iotaledger/ledger-shimmer-app, run `git submodule init && git submodule update --recursive`,
+// To use the ledger nano simulator clone https://github.com/iotaledger/ledger-iota-app, run `git submodule init && git submodule update --recursive`,
 // then `./build.sh -m nanos|nanox|nanosplus -s` and use `true` in `LedgerSecretManager::new(true)`.
 async function run() {
     initLogger();

--- a/bindings/nodejs/lib/types/wallet/transaction-options.ts
+++ b/bindings/nodejs/lib/types/wallet/transaction-options.ts
@@ -26,7 +26,7 @@ export interface TransactionOptions {
     /** Optional note, that is only stored locally. */
     note?: string;
     /** Whether to allow sending a micro amount. */
-    allowMicroAmount: boolean;
+    allowMicroAmount?: boolean;
 }
 
 /** The possible remainder value strategies. */

--- a/bindings/python/examples/secret_manager/ledger_nano.py
+++ b/bindings/python/examples/secret_manager/ledger_nano.py
@@ -5,7 +5,7 @@ import os
 load_dotenv()
 
 # In this example we will get the ledger status and generate an address
-# To use the ledger nano simulator clone https://github.com/iotaledger/ledger-shimmer-app, run `git submodule init && git submodule update --recursive`,
+# To use the ledger nano simulator clone https://github.com/iotaledger/ledger-iota-app, run `git submodule init && git submodule update --recursive`,
 # then `./build.sh -m nanos|nanox|nanosplus -s` and use `True` in
 # `LedgerNanoSecretManager(True)`.
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `migrate_db_chrysalis_to_stardust()` returns an error if no chrysalis data was found;
 
+### Fixed
+
+- Don't error if custom remainder address is provided with ledger nano;
+
 ## 1.0.3 - 2023-09-07
 
 ### Added

--- a/sdk/examples/client/ledger_nano.rs
+++ b/sdk/examples/client/ledger_nano.rs
@@ -4,7 +4,7 @@
 //! In this example we will create testnet addresses with a simulated ledger nano hardware wallet.
 //!
 //! To use the ledger nano simulator, run the following commands:
-//! 1. `clone https://github.com/iotaledger/ledger-shimmer-app`
+//! 1. `clone https://github.com/iotaledger/ledger-iota-app`
 //! 2. `cd ledger-shimmer-app`
 //! 3. `git submodule init && git submodule update --recursive`
 //! 4. `./build.sh -m nanos|nanox|nanosplus -s`

--- a/sdk/examples/client/ledger_nano_transaction.rs
+++ b/sdk/examples/client/ledger_nano_transaction.rs
@@ -4,7 +4,7 @@
 //! In this example we will create a testnet transaction with a simulated ledger nano hardware wallet.
 //!
 //! To use the ledger nano simulator, run the following commands:
-//! 1. `clone https://github.com/iotaledger/ledger-shimmer-app`
+//! 1. `clone https://github.com/iotaledger/ledger-iota-app`
 //! 2. `cd ledger-shimmer-app`
 //! 3. `git submodule init && git submodule update --recursive`
 //! 4. `./build.sh -m nanos|nanox|nanosplus -s`

--- a/sdk/examples/wallet/ledger_nano.rs
+++ b/sdk/examples/wallet/ledger_nano.rs
@@ -4,7 +4,7 @@
 //! In this example we will create addresses with a ledger nano hardware wallet.
 //!
 //! To use the ledger nano simulator
-//! * clone https://github.com/iotaledger/ledger-shimmer-app,
+//! * clone https://github.com/iotaledger/ledger-iota-app,
 //! * run `git submodule init && git submodule update --recursive`,
 //! * run `./build.sh -m nanos|nanox|nanosplus -s`, and
 //! * use `true` in `LedgerSecretManager::new(true)`.

--- a/sdk/src/client/api/block_builder/input_selection/core/remainder.rs
+++ b/sdk/src/client/api/block_builder/input_selection/core/remainder.rs
@@ -24,7 +24,6 @@ impl InputSelection {
     fn get_remainder_address(&self) -> Option<(Address, Option<Bip44>)> {
         if let Some(remainder_address) = self.remainder_address {
             // Search in inputs for the Bip44 chain for the remainder address, so the ledger can regenerate it
-            #[cfg(feature = "ledger_nano")]
             for input in self.available_inputs.iter().chain(self.selected_inputs.iter()) {
                 let alias_transition = is_alias_transition(
                     &input.output,

--- a/sdk/src/client/api/block_builder/input_selection/core/remainder.rs
+++ b/sdk/src/client/api/block_builder/input_selection/core/remainder.rs
@@ -32,13 +32,12 @@ impl InputSelection {
                     self.outputs.as_slice(),
                     self.burn.as_ref(),
                 );
-                // PANIC: safe to unwrap as treasury outputs can't be used as input.
-                let required_address = input
-                    .output
-                    .required_and_unlocked_address(self.timestamp, input.output_id(), alias_transition)
-                    .unwrap()
-                    .0;
-                if remainder_address == required_address {
+                let required_address =
+                    input
+                        .output
+                        .required_and_unlocked_address(self.timestamp, input.output_id(), alias_transition);
+
+                if matches!(required_address, Ok(a) if a.0 == remainder_address) {
                     return Some((remainder_address, input.chain));
                 }
             }

--- a/sdk/src/client/api/block_builder/input_selection/core/remainder.rs
+++ b/sdk/src/client/api/block_builder/input_selection/core/remainder.rs
@@ -21,7 +21,7 @@ use crate::{
 
 impl InputSelection {
     // Gets the remainder address from configuration of finds one from the inputs.
-    fn get_remainder_address(&self) -> Option<(Address, Option<Bip44>)> {
+    fn get_remainder_address(&self) -> Result<Option<(Address, Option<Bip44>)>, Error> {
         if let Some(remainder_address) = self.remainder_address {
             // Search in inputs for the Bip44 chain for the remainder address, so the ledger can regenerate it
             for input in self.available_inputs.iter().chain(self.selected_inputs.iter()) {
@@ -31,16 +31,16 @@ impl InputSelection {
                     self.outputs.as_slice(),
                     self.burn.as_ref(),
                 );
-                let required_address =
+                let (required_address, _) =
                     input
                         .output
-                        .required_and_unlocked_address(self.timestamp, input.output_id(), alias_transition);
+                        .required_and_unlocked_address(self.timestamp, input.output_id(), alias_transition)?;
 
-                if matches!(required_address, Ok(a) if a.0 == remainder_address) {
-                    return Some((remainder_address, input.chain));
+                if required_address == remainder_address {
+                    return Ok(Some((remainder_address, input.chain)));
                 }
             }
-            return Some((remainder_address, None));
+            return Ok(Some((remainder_address, None)));
         }
 
         for input in &self.selected_inputs {
@@ -50,19 +50,17 @@ impl InputSelection {
                 self.outputs.as_slice(),
                 self.burn.as_ref(),
             );
-            // PANIC: safe to unwrap as outputs with no address have been filtered out already.
             let required_address = input
                 .output
-                .required_and_unlocked_address(self.timestamp, input.output_id(), alias_transition)
-                .unwrap()
+                .required_and_unlocked_address(self.timestamp, input.output_id(), alias_transition)?
                 .0;
 
             if required_address.is_ed25519() {
-                return Some((required_address, input.chain));
+                return Ok(Some((required_address, input.chain)));
             }
         }
 
-        None
+        Ok(None)
     }
 
     pub(crate) fn remainder_amount(&self) -> Result<(u64, bool), Error> {
@@ -142,7 +140,7 @@ impl InputSelection {
             return Ok((None, storage_deposit_returns));
         }
 
-        let Some((remainder_address, chain)) = self.get_remainder_address() else {
+        let Some((remainder_address, chain)) = self.get_remainder_address()? else {
             return Err(Error::MissingInputWithEd25519Address);
         };
 

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -295,24 +295,24 @@ impl SecretManage for LedgerSecretManager {
                 .map_err(Error::from)?;
         } else {
             // figure out the remainder address and bip32 index (if there is one)
+            #[allow(clippy::option_if_let_else)]
             let (remainder_address, remainder_bip32): (Option<&Address>, LedgerBIP32Index) =
-                prepared_transaction.remainder.as_ref().map_or_else(
-                    || (None, LedgerBIP32Index::default()),
-                    |a| {
-                        a.chain.map_or_else(
-                            || (None, LedgerBIP32Index::default()),
-                            |chain| {
-                                (
-                                    Some(&a.address),
-                                    LedgerBIP32Index {
-                                        bip32_change: chain.change.harden().into(),
-                                        bip32_index: chain.address_index.harden().into(),
-                                    },
-                                )
-                            },
-                        )
-                    },
-                );
+                match &prepared_transaction.remainder {
+                    Some(a) => {
+                        if let Some(chain) = a.chain {
+                            (
+                                Some(&a.address),
+                                LedgerBIP32Index {
+                                    bip32_change: chain.change.harden().into(),
+                                    bip32_index: chain.address_index.harden().into(),
+                                },
+                            )
+                        } else {
+                            (None, LedgerBIP32Index::default())
+                        }
+                    }
+                    None => (None, LedgerBIP32Index::default()),
+                };
 
             let mut remainder_index = 0u16;
             if let Some(remainder_address) = remainder_address {

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -296,19 +296,23 @@ impl SecretManage for LedgerSecretManager {
         } else {
             // figure out the remainder address and bip32 index (if there is one)
             let (remainder_address, remainder_bip32): (Option<&Address>, LedgerBIP32Index) =
-                match &prepared_transaction.remainder {
-                    Some(a) => {
-                        let chain = a.chain.ok_or(Error::MissingBip32Chain)?;
-                        (
-                            Some(&a.address),
-                            LedgerBIP32Index {
-                                bip32_change: chain.change.harden().into(),
-                                bip32_index: chain.address_index.harden().into(),
+                prepared_transaction.remainder.as_ref().map_or_else(
+                    || (None, LedgerBIP32Index::default()),
+                    |a| {
+                        a.chain.map_or_else(
+                            || (None, LedgerBIP32Index::default()),
+                            |chain| {
+                                (
+                                    Some(&a.address),
+                                    LedgerBIP32Index {
+                                        bip32_change: chain.change.harden().into(),
+                                        bip32_index: chain.address_index.harden().into(),
+                                    },
+                                )
                             },
                         )
-                    }
-                    None => (None, LedgerBIP32Index::default()),
-                };
+                    },
+                );
 
             let mut remainder_index = 0u16;
             if let Some(remainder_address) = remainder_address {


### PR DESCRIPTION
# Description of change

Don't return error with custom remainder address and ledger nano

## Links to any relevant issues

Fixes #1099 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the simple transaction example modified with ledger nano
```
        const response = await account.send(amount, address, {
            remainderValueStrategy: {
                strategy: 'CustomAddress',
                value: {
                    address: 'rms1qqdnv60ryxynaeyu8paq3lp9rkll7d7d92vpumz88fdj4l0pn5mruskth6z', 
                    keyIndex: 0, 
                    internal: false, 
                    used: false
                }
            }
        });
```
