### PR TITLE
Add WalletCommand::SetPow command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `outputs`, `unspent-outputs` print a list that includes number and type of the output;
 - `Account::switch` command to allow changing accounts quickly;
 - UX improvements (Ctrl+l, TAB completion/suggestions and more) during interactive account management;
+- `WalletCommand::SetPow` command;
 
 ### Changed
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -9,7 +9,8 @@ use crate::{
     command::wallet::{
         accounts_command, add_account, backup_command, change_password_command, init_command,
         migrate_stronghold_snapshot_v2_to_v3_command, mnemonic_command, new_account_command, node_info_command,
-        restore_command, set_node_url_command, sync_command, unlock_wallet, InitParameters, WalletCli, WalletCommand,
+        restore_command, set_node_url_command, set_pow_command, sync_command, unlock_wallet, InitParameters, WalletCli,
+        WalletCommand,
     },
     error::Error,
     helper::{get_account_alias, get_decision, get_password, pick_account},
@@ -52,6 +53,13 @@ pub async fn new_wallet(cli: WalletCli) -> Result<(Option<Wallet>, Option<Accoun
             }
             WalletCommand::SetNodeUrl { url } => {
                 let wallet = set_node_url_command(storage_path, snapshot_path, url).await?;
+                (Some(wallet), None)
+            }
+            WalletCommand::SetPow {
+                local_pow,
+                worker_count,
+            } => {
+                let wallet = set_pow_command(storage_path, snapshot_path, local_pow, worker_count).await?;
                 (Some(wallet), None)
             }
             WalletCommand::Sync => {

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -124,6 +124,7 @@ impl ClientInner {
                 if !self.get_fallback_to_local_pow().await {
                     return Err(Error::Node(crate::client::node_api::error::Error::UnavailablePow));
                 }
+                log::debug!("[post_block] falling back to local PoW");
 
                 self.network_info.write().await.local_pow = true;
 

--- a/sdk/src/wallet/account/operations/output_consolidation.rs
+++ b/sdk/src/wallet/account/operations/output_consolidation.rs
@@ -149,6 +149,7 @@ where
 
         drop(account_details);
 
+        #[allow(clippy::option_if_let_else)]
         let output_threshold = match params.output_threshold {
             Some(t) => t,
             None => {


### PR DESCRIPTION
# Description of change

Add WalletCommand::SetPow command

## Links to any relevant issues

Closes #1267 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the command like this for example
`cargo run --release set-pow --local-pow true --worker-count 10`
and then sending transactions and looking at the CPU utilization and debug logs to see if local pow was set or not
