### PR TITLE
CLI: Restrict file permissions on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "winapi",
+ "windows-acl",
  "zeroize",
 ]
 
@@ -1046,6 +1048,16 @@ name = "fiat-crypto"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset 0.9.0",
+ "rustc_version",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -3762,6 +3774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,6 +3821,18 @@ dependencies = [
  "windows_i686_msvc 0.36.1",
  "windows_x86_64_gnu 0.36.1",
  "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-acl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177b1723986bcb4c606058e77f6e8614b51c7f9ad2face6f6fd63dd5c8b3cec3"
+dependencies = [
+ "field-offset",
+ "libc",
+ "widestring",
+ "winapi",
 ]
 
 [[package]]

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `print_wallet_help` changed to `WalletCli::print_help`;
 - `print_account_help` changed to `AccountCli::print_help`;
 - `AccountCommand::Addresses` now prints an overview that includes NTs, NFTs, Aliases and Foundries;
+- Restrict permissions of mnemonic file on Windows;
 
 ## 1.0.1 - 2023-MM-DD
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -46,5 +46,5 @@ tokio = { version = "1.32.0", default-features = false, features = ["fs"] }
 zeroize = { version = "1.6.0", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-acl = { version = "0.3.0", default-features = false }
 winapi = { version = "0.3.9", default-features = false }
+windows-acl = { version = "0.3.0", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,3 +44,7 @@ serde_json = { version = "1.0.107", default-features = false }
 thiserror = { version = "1.0.48", default-features = false }
 tokio = { version = "1.32.0", default-features = false, features = ["fs"] }
 zeroize = { version = "1.6.0", default-features = false }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-acl = { version = "0.3.0", default-features = false }
+winapi = { version = "0.3.9", default-features = false }

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -211,6 +211,88 @@ async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error>
     let mut file = open_options.open(path).await?;
     file.write_all(format!("{mnemonic}\n").as_bytes()).await?;
 
+    #[cfg(windows)]
+    restrict_file_permissions(path)?;
+
+    Ok(())
+}
+
+// Slightly modified from https://github.com/sile/sloggers/blob/master/src/permissions.rs
+#[cfg(windows)]
+pub fn restrict_file_permissions<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
+    use winapi::um::winnt::{FILE_GENERIC_READ, FILE_GENERIC_WRITE, STANDARD_RIGHTS_ALL};
+
+    /// This is the security identifier in Windows for the owner of a file. See:
+    /// - https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows#well-known-sids-all-versions-of-windows
+    #[cfg(windows)]
+    const OWNER_SID_STR: &str = "S-1-3-4";
+    /// We don't need any of the `AceFlags` listed here:
+    /// - https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-ace_header
+    #[cfg(windows)]
+    const OWNER_ACL_ENTRY_FLAGS: u8 = 0;
+    /// Generic Rights:
+    ///  - https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights
+    /// Individual Read/Write/Execute Permissions (referenced in generic rights link):
+    ///  - https://docs.microsoft.com/en-us/windows/win32/wmisdk/file-and-directory-access-rights-constants
+    /// STANDARD_RIGHTS_ALL
+    ///  - https://docs.microsoft.com/en-us/windows/win32/secauthz/access-mask
+    #[cfg(windows)]
+    const OWNER_ACL_ENTRY_MASK: u32 = FILE_GENERIC_READ | FILE_GENERIC_WRITE | STANDARD_RIGHTS_ALL;
+
+    use std::io;
+
+    use winapi::um::winnt::PSID;
+    use windows_acl::{
+        acl::{AceType, ACL},
+        helper::sid_to_string,
+    };
+
+    let path_str = path
+        .as_ref()
+        .to_str()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Unable to open file path.".to_string()))?;
+
+    let mut acl = ACL::from_file_path(path_str, false)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Unable to retrieve ACL: {:?}", e)))?;
+
+    let owner_sid = windows_acl::helper::string_to_sid(OWNER_SID_STR)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Unable to convert SID: {:?}", e)))?;
+
+    let entries = acl.all().map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("Unable to enumerate ACL entries: {:?}", e),
+        )
+    })?;
+
+    // Add single entry for file owner.
+    acl.add_entry(
+        owner_sid.as_ptr() as PSID,
+        AceType::AccessAllow,
+        OWNER_ACL_ENTRY_FLAGS,
+        OWNER_ACL_ENTRY_MASK,
+    )
+    .map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("Failed to add ACL entry for SID {} error={}", OWNER_SID_STR, e),
+        )
+    })?;
+    // Remove all AccessAllow entries from the file that aren't the owner_sid.
+    for entry in &entries {
+        if let Some(ref entry_sid) = entry.sid {
+            let entry_sid_str = sid_to_string(entry_sid.as_ptr() as PSID).unwrap_or_else(|_| "BadFormat".to_string());
+            if entry_sid_str != OWNER_SID_STR {
+                acl.remove(entry_sid.as_ptr() as PSID, Some(AceType::AccessAllow), None)
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Failed to remove ACL entry for SID {}", entry_sid_str),
+                        )
+                    })?;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -220,15 +220,19 @@ async fn write_mnemonic_to_file(path: &str, mnemonic: &str) -> Result<(), Error>
 // Slightly modified from https://github.com/sile/sloggers/blob/master/src/permissions.rs
 #[cfg(windows)]
 pub fn restrict_file_permissions<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
-    use winapi::um::winnt::{FILE_GENERIC_READ, FILE_GENERIC_WRITE, STANDARD_RIGHTS_ALL};
+    use std::io;
+
+    use winapi::um::winnt::{FILE_GENERIC_READ, FILE_GENERIC_WRITE, PSID, STANDARD_RIGHTS_ALL};
+    use windows_acl::{
+        acl::{AceType, ACL},
+        helper::sid_to_string,
+    };
 
     /// This is the security identifier in Windows for the owner of a file. See:
     /// - https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows#well-known-sids-all-versions-of-windows
-    #[cfg(windows)]
     const OWNER_SID_STR: &str = "S-1-3-4";
     /// We don't need any of the `AceFlags` listed here:
     /// - https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-ace_header
-    #[cfg(windows)]
     const OWNER_ACL_ENTRY_FLAGS: u8 = 0;
     /// Generic Rights:
     ///  - https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights
@@ -236,16 +240,7 @@ pub fn restrict_file_permissions<P: AsRef<Path>>(path: P) -> std::io::Result<()>
     ///  - https://docs.microsoft.com/en-us/windows/win32/wmisdk/file-and-directory-access-rights-constants
     /// STANDARD_RIGHTS_ALL
     ///  - https://docs.microsoft.com/en-us/windows/win32/secauthz/access-mask
-    #[cfg(windows)]
     const OWNER_ACL_ENTRY_MASK: u32 = FILE_GENERIC_READ | FILE_GENERIC_WRITE | STANDARD_RIGHTS_ALL;
-
-    use std::io;
-
-    use winapi::um::winnt::PSID;
-    use windows_acl::{
-        acl::{AceType, ACL},
-        helper::sid_to_string,
-    };
 
     let path_str = path
         .as_ref()


### PR DESCRIPTION
# Description of change

CLI: Restrict file permissions on Windows

## Links to any relevant issues

Closes #624 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running the cli wallet
The rights look now like this
![image](https://github.com/iotaledger/iota-sdk/assets/46689931/cbe53291-b39f-4f37-a4ac-5ab5b35ef81e)
Without it would look like this
![image](https://github.com/iotaledger/iota-sdk/assets/46689931/80159b56-a603-47e6-bf8c-0f1577fe6a12)

