### PR TITLE
Node: Fix cyclic dep. in transaction payload

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.0.12 - 2023-mm-dd
+## 1.0.12 - 2023-09-25
 
 ### Fixed
 

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.0.12 - 2023-mm-dd
+
+### Added
+
+- `RegularTransactionEssence.getParsedPayload()` method;
+
+### Changed
+
+- `RegularTransactionEssence.payload` type to `unknown`;
+
 ## 1.0.11 - 2023-09-14
 
 ### Fixed

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -21,13 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.12 - 2023-mm-dd
 
-### Added
+### Fixed
 
-- `RegularTransactionEssence.getParsedPayload()` method;
-
-### Changed
-
-- `RegularTransactionEssence.payload` type to `unknown`;
+- Parsing of `RegularTransactionEssence.payload`;
 
 ## 1.0.11 - 2023-09-14
 

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -76,7 +76,7 @@ class RegularTransactionEssence extends TransactionEssence {
         inputsCommitment: HexEncodedString,
         inputs: Input[],
         outputs: Output[],
-        payload: Payload | undefined,
+        payload: unknown | undefined,
     ) {
         super(TransactionEssenceType.Regular);
         this.networkId = networkId;

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -86,8 +86,13 @@ class RegularTransactionEssence extends TransactionEssence {
         this.payload = payload;
     }
 
-    getParsedPayload(): TransactionPayload | MilestonePayload | TaggedDataPayload | TreasuryTransactionPayload | undefined {
-        return this.payload ? parsePayload(this.payload) as any : undefined
+    getParsedPayload():
+        | TransactionPayload
+        | MilestonePayload
+        | TaggedDataPayload
+        | TreasuryTransactionPayload
+        | undefined {
+        return this.payload ? (parsePayload(this.payload) as any) : undefined;
     }
 }
 

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -89,7 +89,7 @@ class RegularTransactionEssence extends TransactionEssence {
         inputsCommitment: HexEncodedString,
         inputs: Input[],
         outputs: Output[],
-        payload: MilestonePayload | TaggedDataPayload | undefined,
+        payload: Payload | undefined,
     ) {
         super(TransactionEssenceType.Regular);
         this.networkId = networkId;

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -5,10 +5,8 @@ import { Type } from 'class-transformer';
 import { HexEncodedString } from '../../../utils';
 import { Input, InputDiscriminator } from '../../input';
 import { Output, OutputDiscriminator } from '../../output';
-import { MilestonePayload } from '../milestone/milestone';
 import { Payload, PayloadType } from '../payload';
 import { TaggedDataPayload } from '../tagged/tagged';
-import { TreasuryTransactionPayload } from '../treasury';
 
 /**
  * All of the essence types.
@@ -41,15 +39,13 @@ abstract class TransactionEssence {
     }
 }
 
+/**
+ * PayloadDiscriminator for payloads inside of a TransactionEssence.
+ */
 const PayloadDiscriminator = {
     property: 'type',
     subTypes: [
-        { value: MilestonePayload, name: PayloadType.Milestone as any },
         { value: TaggedDataPayload, name: PayloadType.TaggedData as any },
-        {
-            value: TreasuryTransactionPayload,
-            name: PayloadType.TreasuryTransaction as any,
-        },
     ],
 };
 

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -7,7 +7,6 @@ import { HexEncodedString } from '../../../utils';
 import { Input, InputDiscriminator } from '../../input';
 import { Output, OutputDiscriminator } from '../../output';
 import { MilestonePayload } from '../milestone/milestone';
-import { Payload } from '../payload';
 import { TaggedDataPayload } from '../tagged/tagged';
 import { TreasuryTransactionPayload } from '../treasury';
 import { TransactionPayload } from './transaction';

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from 'class-transformer';
-import { PayloadDiscriminator } from '..';
+import { parsePayload } from '../../../..';
 import { HexEncodedString } from '../../../utils';
 import { Input, InputDiscriminator } from '../../input';
 import { Output, OutputDiscriminator } from '../../output';
+import { MilestonePayload } from '../milestone/milestone';
 import { Payload } from '../payload';
+import { TaggedDataPayload } from '../tagged/tagged';
+import { TreasuryTransactionPayload } from '../treasury';
+import { TransactionPayload } from './transaction';
 
 /**
  * All of the essence types.
@@ -57,10 +61,7 @@ class RegularTransactionEssence extends TransactionEssence {
     })
     outputs: Output[];
 
-    @Type(() => Payload, {
-        discriminator: PayloadDiscriminator,
-    })
-    payload: Payload | undefined;
+    payload?: unknown;
 
     /**
      * @param networkId The ID of the network the transaction was issued to.
@@ -83,6 +84,10 @@ class RegularTransactionEssence extends TransactionEssence {
         this.inputs = inputs;
         this.outputs = outputs;
         this.payload = payload;
+    }
+
+    getParsedPayload(): TransactionPayload | MilestonePayload | TaggedDataPayload | TreasuryTransactionPayload | undefined {
+        return this.payload ? parsePayload(this.payload) as any : undefined
     }
 }
 

--- a/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
+++ b/bindings/nodejs/lib/types/block/payload/transaction/essence.ts
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from 'class-transformer';
-import { parsePayload } from '../../../..';
 import { HexEncodedString } from '../../../utils';
 import { Input, InputDiscriminator } from '../../input';
 import { Output, OutputDiscriminator } from '../../output';
 import { MilestonePayload } from '../milestone/milestone';
+import { Payload, PayloadType } from '../payload';
 import { TaggedDataPayload } from '../tagged/tagged';
 import { TreasuryTransactionPayload } from '../treasury';
-import { TransactionPayload } from './transaction';
 
 /**
  * All of the essence types.
@@ -42,6 +41,18 @@ abstract class TransactionEssence {
     }
 }
 
+const PayloadDiscriminator = {
+    property: 'type',
+    subTypes: [
+        { value: MilestonePayload, name: PayloadType.Milestone as any },
+        { value: TaggedDataPayload, name: PayloadType.TaggedData as any },
+        {
+            value: TreasuryTransactionPayload,
+            name: PayloadType.TreasuryTransaction as any,
+        },
+    ],
+};
+
 /**
  * RegularTransactionEssence transaction essence.
  */
@@ -60,7 +71,10 @@ class RegularTransactionEssence extends TransactionEssence {
     })
     outputs: Output[];
 
-    payload?: unknown;
+    @Type(() => Payload, {
+        discriminator: PayloadDiscriminator,
+    })
+    payload: Payload | undefined;
 
     /**
      * @param networkId The ID of the network the transaction was issued to.
@@ -75,7 +89,7 @@ class RegularTransactionEssence extends TransactionEssence {
         inputsCommitment: HexEncodedString,
         inputs: Input[],
         outputs: Output[],
-        payload: unknown | undefined,
+        payload: MilestonePayload | TaggedDataPayload | undefined,
     ) {
         super(TransactionEssenceType.Regular);
         this.networkId = networkId;
@@ -83,15 +97,6 @@ class RegularTransactionEssence extends TransactionEssence {
         this.inputs = inputs;
         this.outputs = outputs;
         this.payload = payload;
-    }
-
-    getParsedPayload():
-        | TransactionPayload
-        | MilestonePayload
-        | TaggedDataPayload
-        | TreasuryTransactionPayload
-        | undefined {
-        return this.payload ? (parsePayload(this.payload) as any) : undefined;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-sdk/issues/1249
replaces https://github.com/iotaledger/iota-sdk/pull/1253

The issue actually is not a cyclic dependency in class transformer, it's cyclic dependency in our code. Since `PayloadDiscriminator` depends on → `TransactionPayload` → `RegularTransactionEssence` → `PayloadDiscrminator` so the last would be replaced with 
`undefined`  by JavaScript.

