### PR TITLE
feat/Node: id() on wrapper

### DIFF
--- a/bindings/nodejs/lib/types/block/core/wrapper.ts
+++ b/bindings/nodejs/lib/types/block/core/wrapper.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { IssuerId } from '../id';
+import { BlockId, IssuerId } from '../id';
 import { Signature, SignatureDiscriminator } from '../signature';
 import { SlotCommitmentId, SlotIndex } from '../slot';
 import { u64 } from '../../utils/type-aliases';
@@ -10,6 +10,8 @@ import { Block, BlockType } from './block';
 import { BasicBlock } from './basic';
 import { ValidationBlock } from './validation';
 import { BlockDiscriminator } from './';
+import { Utils } from '../../../utils';
+import { ProtocolParameters } from '../../models';
 
 /**
  * Represent the object that nodes gossip around the network.
@@ -71,6 +73,16 @@ class BlockWrapper {
         this.issuerId = issuerId;
         this.signature = signature;
         this.block = block;
+    }
+
+    /**
+     * Compute the block ID (Blake2b256 hash of the block bytes).
+     * 
+     * @param params The network protocol parameters.
+     * @returns The corresponding block ID.
+     */
+    id(params: ProtocolParameters): BlockId {
+        return Utils.blockId(this, params)
     }
 
     /**

--- a/bindings/nodejs/lib/types/block/core/wrapper.ts
+++ b/bindings/nodejs/lib/types/block/core/wrapper.ts
@@ -77,12 +77,12 @@ class BlockWrapper {
 
     /**
      * Compute the block ID (Blake2b256 hash of the block bytes).
-     * 
+     *
      * @param params The network protocol parameters.
      * @returns The corresponding block ID.
      */
     id(params: ProtocolParameters): BlockId {
-        return Utils.blockId(this, params)
+        return Utils.blockId(this, params);
     }
 
     /**

--- a/bindings/nodejs/lib/types/utils/bridge/utils.ts
+++ b/bindings/nodejs/lib/types/utils/bridge/utils.ts
@@ -8,6 +8,8 @@ import {
     TokenSchemeType,
     Output,
     RentStructure,
+    BlockWrapper,
+    ProtocolParameters,
 } from '../../';
 import { AccountId } from '../../block/id';
 import { SlotCommitment } from '../../block/slot';
@@ -88,7 +90,8 @@ export interface __ParseBech32AddressMethod__ {
 export interface __BlockIdMethod__ {
     name: 'blockId';
     data: {
-        block: Block;
+        wrapper: BlockWrapper;
+        params: ProtocolParameters;
     };
 }
 

--- a/bindings/nodejs/lib/utils/utils.ts
+++ b/bindings/nodejs/lib/utils/utils.ts
@@ -15,6 +15,8 @@ import {
     RentStructure,
     OutputId,
     u64,
+    BlockWrapper,
+    ProtocolParameters,
 } from '../types';
 import {
     AccountId,
@@ -193,16 +195,18 @@ export class Utils {
     }
 
     /**
-     * Compute the block ID (Blake2b256 hash of the block bytes) of a block.
+     * Compute the block ID (Blake2b256 hash of the block bytes) of a blockwrapper.
      *
-     * @param block A block.
+     * @param wrapper A blockwrapper.
+     * @param params The network protocol parameters.
      * @returns The corresponding block ID.
      */
-    static blockId(block: Block): BlockId {
+    static blockId(wrapper: BlockWrapper, params: ProtocolParameters): BlockId {
         return callUtilsMethod({
             name: 'blockId',
             data: {
-                block,
+                wrapper,
+                params,
             },
         });
     }


### PR DESCRIPTION
# Description of change

the method `.id(protocolparams)` was missing on the blockwrapper type, which we have in rust
