### PR TITLE
Fix set_client_options()

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.1.1 - 2023-MM-DD
+
+### Fixed
+
+- Update protocol params and addresses with correct bech32 HRP in `Wallet::set_client_options()`;
+
 ## 1.1.0 - 2023-09-29
 
 Stable release.

--- a/sdk/src/client/stronghold/mod.rs
+++ b/sdk/src/client/stronghold/mod.rs
@@ -582,6 +582,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clear_key() {
+        iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
         let timeout = Duration::from_millis(100);
 
         let stronghold_path = "test_clear_key.stronghold";
@@ -627,6 +628,7 @@ mod tests {
 
     #[tokio::test]
     async fn stronghold_password_already_set() {
+        iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
         let stronghold_path = "stronghold_password_already_set.stronghold";
         let adapter = StrongholdAdapter::builder()
             .password("drowssap".to_owned())

--- a/sdk/src/wallet/core/operations/client.rs
+++ b/sdk/src/wallet/core/operations/client.rs
@@ -62,8 +62,10 @@ where
         }
 
         // Update the protocol of the network_info to not have the default data, which can be wrong
-        let info = self.client.get_info().await?.node_info;
-        network_info.protocol_parameters = info.protocol.clone();
+        // Ignore errors, because there might be no node at all and then it should still not error
+        if let Ok(info) = self.client.get_info().await {
+            network_info.protocol_parameters = info.node_info.protocol;
+        }
         *self.client.network_info.write().await = network_info;
 
         for account in self.accounts.write().await.iter_mut() {

--- a/sdk/src/wallet/core/operations/stronghold_backup/mod.rs
+++ b/sdk/src/wallet/core/operations/stronghold_backup/mod.rs
@@ -84,9 +84,8 @@ impl Wallet {
             return Err(crate::wallet::Error::Backup("backup path doesn't exist"));
         }
 
-        let mut accounts = self.accounts.write().await;
         // We don't want to overwrite possible existing accounts
-        if !accounts.is_empty() {
+        if !self.accounts.read().await.is_empty() {
             return Err(crate::wallet::Error::Backup(
                 "can't restore backup when there are already accounts",
             ));
@@ -160,6 +159,8 @@ impl Wallet {
                 self.set_client_options(read_client_options).await?;
             }
         }
+
+        let mut accounts = self.accounts.write().await;
 
         if !ignore_backup_values {
             if let Some(read_accounts) = read_accounts {


### PR DESCRIPTION
# Description of change

Fix set_client_options() by getting the nodeinfo and updating the protocol params and then the accounts with a potential new bech32 hrp

## Links to any relevant issues

Fixes #1257 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running

```Rust
use iota_sdk::{
    client::{
        constants::SHIMMER_COIN_TYPE,
        secret::{stronghold::StrongholdSecretManager, SecretManager},
    },
    wallet::{ClientOptions, Result, Wallet},
};

#[tokio::main]
async fn main() -> Result<()> {
    // Setup Stronghold secret manager.
    // WARNING: Never hardcode passwords in production code.
    let secret_manager = StrongholdSecretManager::builder()
        .password("password".to_owned()) // A password to encrypt the stored data.
        .build("getting-started-db/vault.stronghold")?; // The path to store the account snapshot.

    let client_options = ClientOptions::new().with_node("https://api.shimmer.network")?;

    // Set up and store the wallet.
    let wallet = Wallet::builder()
        .with_secret_manager(SecretManager::Stronghold(secret_manager))
        .with_client_options(client_options)
        .with_coin_type(SHIMMER_COIN_TYPE)
        .with_storage_path("getting-started-db")
        .finish()
        .await?;

    // Generate a mnemonic and store its seed in the Stronghold vault.
    // INFO: It is best practice to back up the mnemonic somewhere secure.
    let mnemonic = wallet.generate_mnemonic()?;
    println!("Mnemonic: {}", mnemonic.as_ref());
    wallet.store_mnemonic(mnemonic).await?;

    // Create an account.
    let account = wallet
        .create_account()
        .with_alias("Alice") // A name to associate with the created account.
        .finish()
        .await?;

    let first_address = &account.addresses().await?[0];
    println!("{}", first_address.address());

    let client_options = ClientOptions::new().with_node("https://api.testnet.shimmer.network")?;
    wallet.set_client_options(client_options).await?;

    let first_address = &account.addresses().await?[0];
    println!("{}", first_address.address());

    Ok(())
}
```
Got 
```
smr1qzkpx0wyhnepnaccagz5sdg8rxxktc6hy3ujqrarfu6shesxqp2fchhqcsh
rms1qzkpx0wyhnepnaccagz5sdg8rxxktc6hy3ujqrarfu6shesxqp2fcrstztw
````
where it without this change would print twice the same bech32 address