### PR TITLE
Adjust claim_outputs() for very small inputs

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.1.2 - 2023-MM-DD
+### Fixed
+
+- `Account::claim_outputs()` if an input have less amount than min storage deposit;
+
 ## 1.1.1 - 2023-10-11
 
 ### Added

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Account::claim_outputs()` if an input have less amount than min storage deposit;
+- `Account::claim_outputs()` if an input has less amount than min storage deposit;
 
 ## 1.1.1 - 2023-10-11
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security -->
 
 ## 1.1.2 - 2023-MM-DD
-### Fixed
 
+### Fixed
 
 - `Account::claim_outputs()` if an input have less amount than min storage deposit;
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.1.2 - 2023-MM-DD
 ### Fixed
 
+
 - `Account::claim_outputs()` if an input have less amount than min storage deposit;
 
 ## 1.1.1 - 2023-10-11

--- a/sdk/src/wallet/account/operations/output_claiming.rs
+++ b/sdk/src/wallet/account/operations/output_claiming.rs
@@ -242,6 +242,15 @@ where
         let mut available_amount = 0;
         let mut required_amount_for_nfts = 0;
         let mut new_native_tokens = NativeTokensBuilder::new();
+
+        // There can be outputs with less amount than min required storage deposit, so we have to check that we
+        // have enough amount to create a new basic output
+        let enough_amount_for_basic_output = possible_additional_inputs
+            .iter()
+            .map(|i| i.output.amount())
+            .sum::<u64>()
+            >= MinimumStorageDepositBasicOutput::new(rent_structure, token_supply).finish()?;
+
         // check native tokens
         for output_data in &outputs_to_claim {
             if let Some(native_tokens) = output_data.output.native_tokens() {
@@ -266,7 +275,7 @@ where
                 // build new output with same amount, nft_id, immutable/feature blocks and native tokens, just
                 // updated address unlock conditions
 
-                let nft_output = if possible_additional_inputs.is_empty() {
+                let nft_output = if !enough_amount_for_basic_output {
                     // Only update address and nft id if we have no additional inputs which can provide the storage
                     // deposit for the remaining amount and possible NTs
                     NftOutputBuilder::from(nft_output)
@@ -296,7 +305,7 @@ where
         };
 
         // Check if the new amount is enough for the storage deposit, otherwise increase it to this
-        let mut required_amount = if possible_additional_inputs.is_empty() {
+        let mut required_amount = if !enough_amount_for_basic_output {
             required_amount_for_nfts
         } else {
             required_amount_for_nfts


### PR DESCRIPTION
# Description of change

Adjust claim_outputs() to work even if an input has less amount than min storage deposit, because before the code assumed that if there is an input, that it can be used to create a new output which might not be the case anymore

## Links to any relevant issues

https://github.com/iotaledger/iota-sdk/issues/1373

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Didn't test, there isn't really a way without custom snapshot creation
