### PR TITLE
Use `json` instead of `serde_json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "iota-sdk",
  "iota_stronghold",
  "iterator-sorted",
+ "json",
  "lazy_static",
  "log",
  "num_cpus",
@@ -1760,6 +1761,12 @@ checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "k256"

--- a/bindings/core/src/method/account.rs
+++ b/bindings/core/src/method/account.rs
@@ -5,6 +5,7 @@
 use iota_sdk::{
     client::node_manager::node::Node,
     types::api::plugins::participation::types::{ParticipationEventId, ParticipationEventType},
+    utils::json::{FromJson, JsonExt, ToJson, Value},
     wallet::account::types::participation::ParticipationEventRegistrationOptions,
 };
 use iota_sdk::{

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -65,6 +65,7 @@ futures = { version = "0.3.28", default-features = false, features = [
 instant = { version = "0.1.12", default-features = false, optional = true }
 iota-ledger-nano = { version = "1.0.0-alpha.5", default-features = false, optional = true }
 iota_stronghold = { version = "2.0.0", default-features = false, optional = true }
+json = { version = "0.12.4", default-features = false, optional = true }
 log = { version = "0.4.20", default-features = false, optional = true }
 once_cell = { version = "1.18.0", default-features = false, optional = true }
 rand = { version = "0.8.5", default-features = false, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -152,6 +152,7 @@ serde = [
     "zeroize?/serde",
     "dep:serde_repr",
 ]
+serde_types = ["serde"]
 std = [
     "packable/std",
     "prefix-hex/std",

--- a/sdk/src/client/api/types.rs
+++ b/sdk/src/client/api/types.rs
@@ -57,11 +57,13 @@ impl From<&PreparedTransactionData> for PreparedTransactionDataDto {
     }
 }
 
-impl TryFromDto for PreparedTransactionData {
-    type Dto = PreparedTransactionDataDto;
+impl TryFromDto<PreparedTransactionDataDto> for PreparedTransactionData {
     type Error = Error;
 
-    fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+    fn try_from_dto_with_params_inner(
+        dto: PreparedTransactionDataDto,
+        params: ValidationParams<'_>,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             essence: TransactionEssence::try_from_dto_with_params(dto.essence, &params)
                 .map_err(|_| Error::InvalidField("essence"))?,
@@ -110,11 +112,13 @@ impl From<&SignedTransactionData> for SignedTransactionDataDto {
     }
 }
 
-impl TryFromDto for SignedTransactionData {
-    type Dto = SignedTransactionDataDto;
+impl TryFromDto<SignedTransactionDataDto> for SignedTransactionData {
     type Error = Error;
 
-    fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+    fn try_from_dto_with_params_inner(
+        dto: SignedTransactionDataDto,
+        params: ValidationParams<'_>,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             transaction_payload: TransactionPayload::try_from_dto_with_params(dto.transaction_payload, &params)
                 .map_err(|_| Error::InvalidField("transaction_payload"))?,
@@ -151,11 +155,13 @@ pub struct RemainderDataDto {
     pub address: Address,
 }
 
-impl TryFromDto for RemainderData {
-    type Dto = RemainderDataDto;
+impl TryFromDto<RemainderDataDto> for RemainderData {
     type Error = Error;
 
-    fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+    fn try_from_dto_with_params_inner(
+        dto: RemainderDataDto,
+        params: ValidationParams<'_>,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             output: Output::try_from_dto_with_params_inner(dto.output, params)?,
             chain: dto.chain,

--- a/sdk/src/client/secret/types.rs
+++ b/sdk/src/client/secret/types.rs
@@ -167,11 +167,13 @@ pub struct InputSigningDataDto {
     pub chain: Option<Bip44>,
 }
 
-impl TryFromDto for InputSigningData {
-    type Dto = InputSigningDataDto;
+impl TryFromDto<InputSigningDataDto> for InputSigningData {
     type Error = crate::client::Error;
 
-    fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+    fn try_from_dto_with_params_inner(
+        dto: InputSigningDataDto,
+        params: ValidationParams<'_>,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             output: Output::try_from_dto_with_params_inner(dto.output, params)?,
             output_metadata: dto.output_metadata,

--- a/sdk/src/types/api/core/response.rs
+++ b/sdk/src/types/api/core/response.rs
@@ -492,3 +492,32 @@ pub struct UtxoChangesResponse {
     pub created_outputs: Vec<OutputId>,
     pub consumed_outputs: Vec<OutputId>,
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
+
+    impl ToJson for OutputWithMetadataResponse {
+        fn to_json(&self) -> Value {
+            crate::json!({
+                "metadata": self.metadata,
+                "output": self.output,
+            })
+        }
+    }
+
+    impl FromJson for OutputWithMetadataResponse {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self {
+                metadata: value["metadata"].take_value()?,
+                output: value["output"].take_value()?,
+            })
+        }
+    }
+}

--- a/sdk/src/types/api/plugins/indexer.rs
+++ b/sdk/src/types/api/plugins/indexer.rs
@@ -12,7 +12,7 @@ use crate::types::block::output::OutputId;
 /// Returns the output_ids for the provided query parameters.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/sdk/src/types/api/plugins/participation/responses.rs
+++ b/sdk/src/types/api/plugins/participation/responses.rs
@@ -16,7 +16,7 @@ use crate::types::{
 /// EventsResponse defines the response of a GET RouteParticipationEvents REST API call.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -28,7 +28,7 @@ pub struct EventsResponse {
 /// TrackedParticipation holds the information for each tracked participation.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -47,7 +47,7 @@ pub struct TrackedParticipation {
 
 /// OutputStatusResponse defines the response of a GET RouteOutputStatus REST API call.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputStatusResponse {
     /// Participations holds the participations that were created in the output.
     pub participations: HashMap<ParticipationEventId, TrackedParticipation>,
@@ -55,7 +55,7 @@ pub struct OutputStatusResponse {
 
 /// AddressOutputsResponse defines the response of a GET RouteAddressBech32Outputs REST API call.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddressOutputsResponse {
     /// Outputs is a map of output status per output_id.
     pub outputs: HashMap<OutputId, OutputStatusResponse>,

--- a/sdk/src/types/api/plugins/participation/types.rs
+++ b/sdk/src/types/api/plugins/participation/types.rs
@@ -12,6 +12,8 @@ use getset::Getters;
 use hashbrown::HashMap;
 use packable::PackableExt;
 
+#[cfg(feature = "json")]
+use crate::types::block::string_json_impl;
 #[cfg(feature = "serde")]
 use crate::types::block::string_serde_impl;
 use crate::types::{api::plugins::participation::error::Error, block::impl_id};
@@ -56,6 +58,8 @@ pub struct ParticipationEvent {
 impl_id!(pub ParticipationEventId, 32, "A participation event id.");
 #[cfg(feature = "serde")]
 string_serde_impl!(ParticipationEventId);
+#[cfg(feature = "json")]
+string_json_impl!(ParticipationEventId);
 
 /// Information about a voting or staking event.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]

--- a/sdk/src/types/api/plugins/participation/types.rs
+++ b/sdk/src/types/api/plugins/participation/types.rs
@@ -14,7 +14,7 @@ use packable::PackableExt;
 
 #[cfg(feature = "json")]
 use crate::types::block::string_json_impl;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 use crate::types::block::string_serde_impl;
 use crate::types::{api::plugins::participation::error::Error, block::impl_id};
 
@@ -27,7 +27,7 @@ mod participation_event_type {
     /// Possible participation event types.
     #[derive(Debug, Clone, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr),
         serde(untagged)
     )]
@@ -44,7 +44,7 @@ pub use participation_event_type::*;
 /// Wrapper interface containing a participation event ID and the corresponding event data.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -56,7 +56,7 @@ pub struct ParticipationEvent {
 }
 
 impl_id!(pub ParticipationEventId, 32, "A participation event id.");
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(ParticipationEventId);
 #[cfg(feature = "json")]
 string_json_impl!(ParticipationEventId);
@@ -64,7 +64,7 @@ string_json_impl!(ParticipationEventId);
 /// Information about a voting or staking event.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -80,7 +80,11 @@ pub struct ParticipationEventData {
 
 /// Event payload types.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum ParticipationEventPayload {
     /// Voting payload.
     VotingEventPayload(VotingEventPayload),
@@ -91,7 +95,7 @@ pub enum ParticipationEventPayload {
 /// Payload for a voting event.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -105,7 +109,7 @@ pub struct VotingEventPayload {
 /// Question for a voting event.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -119,7 +123,7 @@ pub struct Question {
 /// Answer in a voting event.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -133,7 +137,7 @@ pub struct Answer {
 /// Payload for a staking event.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -152,7 +156,7 @@ pub struct StakingEventPayload {
 /// Event status.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -166,7 +170,7 @@ pub struct ParticipationEventStatus {
 
 /// Question status.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 #[getset(get = "pub")]
 pub struct QuestionStatus {
     answers: Vec<AnswerStatus>,
@@ -174,7 +178,7 @@ pub struct QuestionStatus {
 
 /// Answer status.
 #[derive(Debug, Clone, Eq, PartialEq, Getters)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 #[getset(get = "pub")]
 pub struct AnswerStatus {
     value: u8,
@@ -185,7 +189,7 @@ pub struct AnswerStatus {
 /// Staking rewards for an address.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -199,7 +203,7 @@ pub struct AddressStakingStatus {
 /// Staking rewards for an address.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -215,7 +219,7 @@ pub struct StakingStatus {
 /// Participation information.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -229,7 +233,7 @@ pub struct Participation {
 /// Participations information.
 /// <https://github.com/iota-community/treasury/blob/main/specifications/hornet-participation-plugin.md#structure-of-the-participation>
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub struct Participations {
     /// Multiple participations that happen at the same time.
     pub participations: Vec<Participation>,

--- a/sdk/src/types/block/address/account.rs
+++ b/sdk/src/types/block/address/account.rs
@@ -57,7 +57,7 @@ impl core::fmt::Debug for AccountAddress {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/address/account.rs
+++ b/sdk/src/types/block/address/account.rs
@@ -89,3 +89,37 @@ mod dto {
 
     impl_serde_typed_dto!(AccountAddress, AccountAddressDto, "account address");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson};
+
+    impl ToJson for AccountAddress {
+        fn to_json(&self) -> ::json::JsonValue {
+            crate::json! ({
+                "type": AccountAddress::KIND,
+                "accountId": self.0
+            })
+        }
+    }
+
+    impl FromJson for AccountAddress {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(::json::Error::WrongType(alloc::format!(
+                    "invalid account address type: expected {}, found {}",
+                    Self::KIND,
+                    value["type"]
+                ))
+                .into());
+            }
+            Ok(Self::new(AccountId::from_json(value["accountId"].take())?))
+        }
+    }
+}

--- a/sdk/src/types/block/address/account.rs
+++ b/sdk/src/types/block/address/account.rs
@@ -98,7 +98,7 @@ mod json {
     impl ToJson for AccountAddress {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": AccountAddress::KIND,
+                "type": Self::KIND,
                 "accountId": self.0
             })
         }

--- a/sdk/src/types/block/address/account.rs
+++ b/sdk/src/types/block/address/account.rs
@@ -93,7 +93,7 @@ mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
 
     impl ToJson for AccountAddress {
         fn to_json(&self) -> Value {

--- a/sdk/src/types/block/address/account.rs
+++ b/sdk/src/types/block/address/account.rs
@@ -93,10 +93,10 @@ mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, ToJson};
+    use crate::utils::json::{FromJson, ToJson, Value};
 
     impl ToJson for AccountAddress {
-        fn to_json(&self) -> ::json::JsonValue {
+        fn to_json(&self) -> Value {
             crate::json! ({
                 "type": AccountAddress::KIND,
                 "accountId": self.0
@@ -107,17 +107,12 @@ mod json {
     impl FromJson for AccountAddress {
         type Error = Error;
 
-        fn from_non_null_json(mut value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
         where
             Self: Sized,
         {
             if value["type"] != Self::KIND {
-                return Err(::json::Error::WrongType(alloc::format!(
-                    "invalid account address type: expected {}, found {}",
-                    Self::KIND,
-                    value["type"]
-                ))
-                .into());
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
             Ok(Self::new(AccountId::from_json(value["accountId"].take())?))
         }

--- a/sdk/src/types/block/address/account.rs
+++ b/sdk/src/types/block/address/account.rs
@@ -93,7 +93,7 @@ mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, ToJson, Value};
+    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
 
     impl ToJson for AccountAddress {
         fn to_json(&self) -> Value {
@@ -114,7 +114,7 @@ mod json {
             if value["type"] != Self::KIND {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
-            Ok(Self::new(AccountId::from_json(value["accountId"].take())?))
+            Ok(Self::new(value["accountId"].take_value()?))
         }
     }
 }

--- a/sdk/src/types/block/address/bech32.rs
+++ b/sdk/src/types/block/address/bech32.rs
@@ -133,7 +133,7 @@ impl PartialEq<str> for Hrp {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(Hrp);
 #[cfg(feature = "json")]
 string_json_impl!(Hrp);
@@ -257,7 +257,7 @@ impl<T: core::borrow::Borrow<Bech32Address>> From<T> for Address {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(Bech32Address);
 #[cfg(feature = "json")]
 string_json_impl!(Bech32Address);

--- a/sdk/src/types/block/address/bech32.rs
+++ b/sdk/src/types/block/address/bech32.rs
@@ -135,6 +135,8 @@ impl PartialEq<str> for Hrp {
 
 #[cfg(feature = "serde")]
 string_serde_impl!(Hrp);
+#[cfg(feature = "json")]
+string_json_impl!(Hrp);
 
 impl<T: AsRef<str> + Send> ConvertTo<Hrp> for T {
     fn convert(self) -> Result<Hrp, Error> {
@@ -257,6 +259,8 @@ impl<T: core::borrow::Borrow<Bech32Address>> From<T> for Address {
 
 #[cfg(feature = "serde")]
 string_serde_impl!(Bech32Address);
+#[cfg(feature = "json")]
+string_json_impl!(Bech32Address);
 
 impl<T: AsRef<str> + Send> ConvertTo<Bech32Address> for T {
     fn convert(self) -> Result<Bech32Address, Error> {

--- a/sdk/src/types/block/address/ed25519.rs
+++ b/sdk/src/types/block/address/ed25519.rs
@@ -89,7 +89,7 @@ mod json {
     impl ToJson for Ed25519Address {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": Ed25519Address::KIND,
+                "type": Self::KIND,
                 "pubKeyHash": self.to_string()
             })
         }

--- a/sdk/src/types/block/address/ed25519.rs
+++ b/sdk/src/types/block/address/ed25519.rs
@@ -46,7 +46,7 @@ impl core::fmt::Debug for Ed25519Address {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -26,7 +26,11 @@ use crate::types::block::{
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, From, packable::Packable)]
 #[packable(tag_type = u8, with_error = Error::InvalidAddressKind)]
 #[packable(unpack_error = Error)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum Address {
     /// An Ed25519 address.
     #[packable(tag = Ed25519Address::KIND)]

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -93,10 +93,10 @@ pub(crate) mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, ToJson};
+    use crate::utils::json::{FromJson, ToJson, Value};
 
     impl ToJson for NftAddress {
-        fn to_json(&self) -> ::json::JsonValue {
+        fn to_json(&self) -> Value {
             crate::json! ({
                 "type": NftAddress::KIND,
                 "nftId": self.0
@@ -107,17 +107,12 @@ mod json {
     impl FromJson for NftAddress {
         type Error = Error;
 
-        fn from_non_null_json(mut value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
         where
             Self: Sized,
         {
             if value["type"] != Self::KIND {
-                return Err(::json::Error::WrongType(alloc::format!(
-                    "invalid nft address type: expected {}, found {}",
-                    Self::KIND,
-                    value["type"]
-                ))
-                .into());
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
             Ok(Self::new(NftId::from_json(value["nftId"].take())?))
         }

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -93,7 +93,7 @@ pub(crate) mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, ToJson, Value};
+    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
 
     impl ToJson for NftAddress {
         fn to_json(&self) -> Value {
@@ -114,7 +114,7 @@ mod json {
             if value["type"] != Self::KIND {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
-            Ok(Self::new(NftId::from_json(value["nftId"].take())?))
+            Ok(Self::new(value["nftId"].take_value()?))
         }
     }
 }

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -57,7 +57,7 @@ impl core::fmt::Debug for NftAddress {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -89,3 +89,37 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(NftAddress, NftAddressDto, "nft address");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson};
+
+    impl ToJson for NftAddress {
+        fn to_json(&self) -> ::json::JsonValue {
+            crate::json! ({
+                "type": NftAddress::KIND,
+                "nftId": self.0
+            })
+        }
+    }
+
+    impl FromJson for NftAddress {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(::json::Error::WrongType(alloc::format!(
+                    "invalid nft address type: expected {}, found {}",
+                    Self::KIND,
+                    value["type"]
+                ))
+                .into());
+            }
+            Ok(Self::new(NftId::from_json(value["nftId"].take())?))
+        }
+    }
+}

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -93,7 +93,7 @@ pub(crate) mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
 
     impl ToJson for NftAddress {
         fn to_json(&self) -> Value {

--- a/sdk/src/types/block/address/nft.rs
+++ b/sdk/src/types/block/address/nft.rs
@@ -98,7 +98,7 @@ mod json {
     impl ToJson for NftAddress {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": NftAddress::KIND,
+                "type": Self::KIND,
                 "nftId": self.0
             })
         }

--- a/sdk/src/types/block/block_id.rs
+++ b/sdk/src/types/block/block_id.rs
@@ -113,7 +113,7 @@ impl core::ops::Deref for BlockId {
         unsafe { core::mem::transmute::<_, &[u8; Self::LENGTH]>(self) }
     }
 }
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(BlockId);
 
 #[cfg(feature = "json")]

--- a/sdk/src/types/block/block_id.rs
+++ b/sdk/src/types/block/block_id.rs
@@ -115,3 +115,6 @@ impl core::ops::Deref for BlockId {
 }
 #[cfg(feature = "serde")]
 string_serde_impl!(BlockId);
+
+#[cfg(feature = "json")]
+string_json_impl!(BlockId);

--- a/sdk/src/types/block/context_input/block_issuance_credit.rs
+++ b/sdk/src/types/block/context_input/block_issuance_credit.rs
@@ -68,7 +68,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, ToJson, Value},
+        utils::json::{FromJson, TakeValue, ToJson, Value},
     };
 
     impl ToJson for BlockIssuanceCreditContextInput {
@@ -90,7 +90,7 @@ mod json {
             if value["type"] != Self::KIND {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
-            Ok(Self::new(AccountId::from_json(value["accountId"].take())?))
+            Ok(Self::new(value["accountId"].take_value()?))
         }
     }
 }

--- a/sdk/src/types/block/context_input/block_issuance_credit.rs
+++ b/sdk/src/types/block/context_input/block_issuance_credit.rs
@@ -68,7 +68,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, TakeValue, ToJson, Value},
+        utils::json::{FromJson, JsonExt, ToJson, Value},
     };
 
     impl ToJson for BlockIssuanceCreditContextInput {

--- a/sdk/src/types/block/context_input/block_issuance_credit.rs
+++ b/sdk/src/types/block/context_input/block_issuance_credit.rs
@@ -74,7 +74,7 @@ mod json {
     impl ToJson for BlockIssuanceCreditContextInput {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": BlockIssuanceCreditContextInput::KIND,
+                "type": Self::KIND,
                 "accountId": self.0
             })
         }

--- a/sdk/src/types/block/context_input/block_issuance_credit.rs
+++ b/sdk/src/types/block/context_input/block_issuance_credit.rs
@@ -62,3 +62,35 @@ mod dto {
         "block issuance credit context input"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, ToJson, Value},
+    };
+
+    impl ToJson for BlockIssuanceCreditContextInput {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": BlockIssuanceCreditContextInput::KIND,
+                "accountId": self.0
+            })
+        }
+    }
+
+    impl FromJson for BlockIssuanceCreditContextInput {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(AccountId::from_json(value["accountId"].take())?))
+        }
+    }
+}

--- a/sdk/src/types/block/context_input/block_issuance_credit.rs
+++ b/sdk/src/types/block/context_input/block_issuance_credit.rs
@@ -25,7 +25,7 @@ impl BlockIssuanceCreditContextInput {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/context_input/commitment.rs
+++ b/sdk/src/types/block/context_input/commitment.rs
@@ -71,7 +71,7 @@ mod json {
     impl ToJson for CommitmentContextInput {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": CommitmentContextInput::KIND,
+                "type": Self::KIND,
                 "commitmentId": self.0
             })
         }

--- a/sdk/src/types/block/context_input/commitment.rs
+++ b/sdk/src/types/block/context_input/commitment.rs
@@ -24,7 +24,7 @@ impl CommitmentContextInput {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/context_input/commitment.rs
+++ b/sdk/src/types/block/context_input/commitment.rs
@@ -65,7 +65,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, TakeValue, ToJson, Value},
+        utils::json::{FromJson, JsonExt, ToJson, Value},
     };
 
     impl ToJson for CommitmentContextInput {

--- a/sdk/src/types/block/context_input/commitment.rs
+++ b/sdk/src/types/block/context_input/commitment.rs
@@ -65,7 +65,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, ToJson, Value},
+        utils::json::{FromJson, TakeValue, ToJson, Value},
     };
 
     impl ToJson for CommitmentContextInput {
@@ -87,7 +87,7 @@ mod json {
             if value["type"] != Self::KIND {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
-            Ok(Self::new(SlotCommitmentId::from_json(value["commitmentId"].take())?))
+            Ok(Self::new(value["commitmentId"].take_value()?))
         }
     }
 }

--- a/sdk/src/types/block/context_input/commitment.rs
+++ b/sdk/src/types/block/context_input/commitment.rs
@@ -59,3 +59,35 @@ mod dto {
         "commitment context input"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, ToJson, Value},
+    };
+
+    impl ToJson for CommitmentContextInput {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": CommitmentContextInput::KIND,
+                "commitmentId": self.0
+            })
+        }
+    }
+
+    impl FromJson for CommitmentContextInput {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(SlotCommitmentId::from_json(value["commitmentId"].take())?))
+        }
+    }
+}

--- a/sdk/src/types/block/context_input/mod.rs
+++ b/sdk/src/types/block/context_input/mod.rs
@@ -26,7 +26,11 @@ pub const CONTEXT_INPUT_COUNT_RANGE: RangeInclusive<u16> = 0..=CONTEXT_INPUT_COU
 #[derive(Clone, Eq, Display, PartialEq, Hash, Ord, PartialOrd, From, packable::Packable)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidContextInputKind)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum ContextInput {
     /// A [`CommitmentContextInput`].
     #[packable(tag = CommitmentContextInput::KIND)]

--- a/sdk/src/types/block/context_input/reward.rs
+++ b/sdk/src/types/block/context_input/reward.rs
@@ -74,7 +74,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, ToJson, Value},
+        utils::json::{FromJson, TakeValue, ToJson, Value},
     };
 
     impl ToJson for RewardContextInput {
@@ -96,7 +96,7 @@ mod json {
             if value["type"] != Self::KIND {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
-            Ok(Self::new(u16::from_json(value["commitmentId"].take())?)?)
+            Ok(Self::new(value["commitmentId"].take_value()?)?)
         }
     }
 }

--- a/sdk/src/types/block/context_input/reward.rs
+++ b/sdk/src/types/block/context_input/reward.rs
@@ -74,7 +74,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, TakeValue, ToJson, Value},
+        utils::json::{FromJson, JsonExt, ToJson, Value},
     };
 
     impl ToJson for RewardContextInput {

--- a/sdk/src/types/block/context_input/reward.rs
+++ b/sdk/src/types/block/context_input/reward.rs
@@ -80,7 +80,7 @@ mod json {
     impl ToJson for RewardContextInput {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": RewardContextInput::KIND,
+                "type": Self::KIND,
                 "index": self.index()
             })
         }

--- a/sdk/src/types/block/context_input/reward.rs
+++ b/sdk/src/types/block/context_input/reward.rs
@@ -35,7 +35,7 @@ impl core::fmt::Display for RewardContextInput {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/context_input/reward.rs
+++ b/sdk/src/types/block/context_input/reward.rs
@@ -68,3 +68,35 @@ mod dto {
 
     impl_serde_typed_dto!(RewardContextInput, RewardContextInputDto, "reward context input");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, ToJson, Value},
+    };
+
+    impl ToJson for RewardContextInput {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": RewardContextInput::KIND,
+                "index": self.index()
+            })
+        }
+    }
+
+    impl FromJson for RewardContextInput {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(u16::from_json(value["commitmentId"].take())?)?)
+        }
+    }
+}

--- a/sdk/src/types/block/core/basic.rs
+++ b/sdk/src/types/block/core/basic.rs
@@ -224,11 +224,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for BasicBlock {
-        type Dto = BasicBlockDto;
+    impl TryFromDto<BasicBlockDto> for BasicBlock {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: BasicBlockDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             BasicBlockBuilder::new(StrongParents::from_set(dto.strong_parents)?, dto.max_burned_mana)
                 .with_weak_parents(WeakParents::from_set(dto.weak_parents)?)
                 .with_shallow_like_parents(ShallowLikeParents::from_set(dto.shallow_like_parents)?)

--- a/sdk/src/types/block/core/basic.rs
+++ b/sdk/src/types/block/core/basic.rs
@@ -196,19 +196,19 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct BasicBlockDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
         pub strong_parents: BTreeSet<BlockId>,
         pub weak_parents: BTreeSet<BlockId>,
         pub shallow_like_parents: BTreeSet<BlockId>,
-        #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+        #[cfg_attr(feature = "serde_types", serde(default, skip_serializing_if = "Option::is_none"))]
         pub payload: Option<PayloadDto>,
-        #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
         pub max_burned_mana: u64,
     }
 

--- a/sdk/src/types/block/core/mod.rs
+++ b/sdk/src/types/block/core/mod.rs
@@ -230,14 +230,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for Block {
-        type Dto = BlockDto;
+    impl TryFromDto<BlockDto> for Block {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(dto: BlockDto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
             match dto {
-                Self::Dto::Basic(basic) => Ok(BasicBlock::try_from_dto_with_params_inner(basic, params)?.into()),
-                Self::Dto::Validation(validation) => {
+                BlockDto::Basic(basic) => Ok(BasicBlock::try_from_dto_with_params_inner(basic, params)?.into()),
+                BlockDto::Validation(validation) => {
                     Ok(ValidationBlock::try_from_dto_with_params_inner(validation, params)?.into())
                 }
             }

--- a/sdk/src/types/block/core/mod.rs
+++ b/sdk/src/types/block/core/mod.rs
@@ -167,7 +167,7 @@ pub(crate) mod dto {
         }
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_types")]
     impl<'de> serde::Deserialize<'de> for BlockDto {
         fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
             let value = Value::deserialize(d)?;
@@ -192,7 +192,7 @@ pub(crate) mod dto {
         }
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_types")]
     impl serde::Serialize for BlockDto {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where

--- a/sdk/src/types/block/core/parent.rs
+++ b/sdk/src/types/block/core/parent.rs
@@ -54,6 +54,11 @@ impl<const MIN: u8, const MAX: u8> Parents<MIN, MAX> {
         ))
     }
 
+    /// Returns the underlying list
+    pub fn as_list(&self) -> &[BlockId] {
+        self
+    }
+
     /// Returns the unique, ordered set of parents.
     pub fn to_set(&self) -> BTreeSet<BlockId> {
         self.0.iter().copied().collect()

--- a/sdk/src/types/block/core/parent.rs
+++ b/sdk/src/types/block/core/parent.rs
@@ -19,7 +19,7 @@ use crate::types::block::{BlockId, Error};
 /// * lexicographically sorted;
 /// * unique;
 #[derive(Clone, Debug, Eq, PartialEq, Deref, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 #[deref(forward)]
 #[packable(unpack_error = Error, with = |_| Error::InvalidParentCount)]
 pub struct Parents<const MIN: u8, const MAX: u8>(

--- a/sdk/src/types/block/core/validation.rs
+++ b/sdk/src/types/block/core/validation.rs
@@ -244,11 +244,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for ValidationBlock {
-        type Dto = ValidationBlockDto;
+    impl TryFromDto<ValidationBlockDto> for ValidationBlock {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: ValidationBlockDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             if let Some(protocol_params) = params.protocol_parameters() {
                 validate_protocol_params_hash(&dto.protocol_parameters_hash, protocol_params)?;
             }

--- a/sdk/src/types/block/core/validation.rs
+++ b/sdk/src/types/block/core/validation.rs
@@ -218,12 +218,12 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct ValidationBlockDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
         pub strong_parents: BTreeSet<BlockId>,
         pub weak_parents: BTreeSet<BlockId>,

--- a/sdk/src/types/block/core/wrapper.rs
+++ b/sdk/src/types/block/core/wrapper.rs
@@ -331,11 +331,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for BlockWrapper {
-        type Dto = BlockWrapperDto;
+    impl TryFromDto<BlockWrapperDto> for BlockWrapper {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: BlockWrapperDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             if let Some(protocol_params) = params.protocol_parameters() {
                 if dto.protocol_version != protocol_params.version() {
                     return Err(Error::ProtocolVersionMismatch {

--- a/sdk/src/types/block/core/wrapper.rs
+++ b/sdk/src/types/block/core/wrapper.rs
@@ -290,7 +290,7 @@ impl Packable for BlockWrapper {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/error.rs
+++ b/sdk/src/types/block/error.rs
@@ -172,6 +172,8 @@ pub enum Error {
     DuplicateOutputChain(ChainId),
     InvalidField(&'static str),
     NullDelegationValidatorId,
+    // #[cfg(feature = "json")]
+    // JsonError(json::Error),
 }
 
 #[cfg(feature = "std")]
@@ -373,6 +375,8 @@ impl fmt::Display for Error {
             Self::DuplicateOutputChain(chain_id) => write!(f, "duplicate output chain {chain_id}"),
             Self::InvalidField(field) => write!(f, "invalid field: {field}"),
             Self::NullDelegationValidatorId => write!(f, "null delegation validator ID"),
+            // #[cfg(feature = "json")]
+            // Self::JsonError(e) => e.fmt(f),
         }
     }
 }

--- a/sdk/src/types/block/input/mod.rs
+++ b/sdk/src/types/block/input/mod.rs
@@ -23,7 +23,11 @@ pub const INPUT_INDEX_RANGE: RangeInclusive<u16> = 0..=INPUT_INDEX_MAX; // [0..1
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd, From, packable::Packable)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidInputKind)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum Input {
     /// A UTXO input.
     #[packable(tag = UtxoInput::KIND)]

--- a/sdk/src/types/block/input/mod.rs
+++ b/sdk/src/types/block/input/mod.rs
@@ -58,3 +58,36 @@ impl Input {
         input
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson, Value};
+
+    impl ToJson for Input {
+        fn to_json(&self) -> Value {
+            match self {
+                Self::Utxo(i) => i.to_json(),
+            }
+        }
+    }
+
+    impl FromJson for Input {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(match value["type"].as_u8() {
+                Some(UtxoInput::KIND) => UtxoInput::from_json(value)?.into(),
+                _ => {
+                    return Err(Error::invalid_type::<Self>(
+                        format!("one of {:?}", [UtxoInput::KIND]),
+                        &value["type"],
+                    ));
+                }
+            })
+        }
+    }
+}

--- a/sdk/src/types/block/input/utxo.rs
+++ b/sdk/src/types/block/input/utxo.rs
@@ -83,3 +83,39 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(UtxoInput, UtxoInputDto, "UTXO input");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, TakeValue, ToJson, Value},
+    };
+
+    impl ToJson for UtxoInput {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "transactionId": self.output_id().transaction_id(),
+                "transactionOutputIndex": self.output_id().index()
+            })
+        }
+    }
+
+    impl FromJson for UtxoInput {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(
+                value["transactionId"].take_value()?,
+                value["transactionOutputIndex"].take_value()?,
+            )
+        }
+    }
+}

--- a/sdk/src/types/block/input/utxo.rs
+++ b/sdk/src/types/block/input/utxo.rs
@@ -89,7 +89,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, TakeValue, ToJson, Value},
+        utils::json::{FromJson, JsonExt, ToJson, Value},
     };
 
     impl ToJson for UtxoInput {

--- a/sdk/src/types/block/input/utxo.rs
+++ b/sdk/src/types/block/input/utxo.rs
@@ -46,7 +46,7 @@ impl core::fmt::Debug for UtxoInput {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/issuer_id.rs
+++ b/sdk/src/types/block/issuer_id.rs
@@ -9,3 +9,5 @@ impl_id!(
 
 #[cfg(feature = "serde")]
 string_serde_impl!(IssuerId);
+#[cfg(feature = "json")]
+string_json_impl!(IssuerId);

--- a/sdk/src/types/block/issuer_id.rs
+++ b/sdk/src/types/block/issuer_id.rs
@@ -7,7 +7,7 @@ impl_id!(
     "Identifier of a block issuer."
 );
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(IssuerId);
 #[cfg(feature = "json")]
 string_json_impl!(IssuerId);

--- a/sdk/src/types/block/macro.rs
+++ b/sdk/src/types/block/macro.rs
@@ -159,13 +159,12 @@ macro_rules! string_json_impl {
         impl $crate::utils::json::FromJson for $type {
             type Error = $crate::types::block::Error;
 
-            fn from_non_null_json(value: json::JsonValue) -> Result<Self, $crate::utils::json::JsonError<Self::Error>> {
+            fn from_non_null_json(value: json::JsonValue) -> Result<Self, Self::Error> {
                 core::str::FromStr::from_str(
                     value
                         .as_str()
-                        .ok_or_else(|| json::Error::WrongType(value.to_string()))?,
+                        .ok_or_else(|| $crate::utils::json::Error::wrong_type::<$type>(&value))?,
                 )
-                .map_err($crate::utils::json::JsonError::Conversion)
             }
         }
     };

--- a/sdk/src/types/block/macro.rs
+++ b/sdk/src/types/block/macro.rs
@@ -160,11 +160,7 @@ macro_rules! string_json_impl {
             type Error = $crate::types::block::Error;
 
             fn from_non_null_json(value: json::JsonValue) -> Result<Self, Self::Error> {
-                core::str::FromStr::from_str(
-                    value
-                        .as_str()
-                        .ok_or_else(|| $crate::utils::json::Error::wrong_type::<$type>(&value))?,
-                )
+                core::str::FromStr::from_str($crate::utils::json::JsonExt::to_str(&value)?)
             }
         }
     };

--- a/sdk/src/types/block/macro.rs
+++ b/sdk/src/types/block/macro.rs
@@ -146,6 +146,33 @@ macro_rules! string_serde_impl {
 #[cfg(feature = "serde")]
 pub(crate) use string_serde_impl;
 
+#[macro_export]
+#[cfg(feature = "json")]
+macro_rules! string_json_impl {
+    ($type:ty) => {
+        impl $crate::utils::json::ToJson for $type {
+            fn to_json(&self) -> json::JsonValue {
+                self.to_string().into()
+            }
+        }
+
+        impl $crate::utils::json::FromJson for $type {
+            type Error = $crate::types::block::Error;
+
+            fn from_non_null_json(value: json::JsonValue) -> Result<Self, $crate::utils::json::JsonError<Self::Error>> {
+                core::str::FromStr::from_str(
+                    value
+                        .as_str()
+                        .ok_or_else(|| json::Error::WrongType(value.to_string()))?,
+                )
+                .map_err($crate::utils::json::JsonError::Conversion)
+            }
+        }
+    };
+}
+#[cfg(feature = "json")]
+pub(crate) use string_json_impl;
+
 /// Convenience macro to work around the fact the `[bitflags]` crate does not yet support iterating over the
 /// individual flags. This macro essentially creates the `[bitflags]` and puts the individual flags into an associated
 /// constant `pub const ALL_FLAGS: &'static []`.

--- a/sdk/src/types/block/macro.rs
+++ b/sdk/src/types/block/macro.rs
@@ -99,12 +99,12 @@ macro_rules! impl_id {
         }
     };
 }
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) use impl_id;
 
 /// Convenience macro to serialize types to string via serde.
 #[macro_export]
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 macro_rules! string_serde_impl {
     ($type:ty) => {
         impl serde::Serialize for $type {
@@ -143,7 +143,7 @@ macro_rules! string_serde_impl {
         }
     };
 }
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) use string_serde_impl;
 
 #[macro_export]

--- a/sdk/src/types/block/macro.rs
+++ b/sdk/src/types/block/macro.rs
@@ -151,7 +151,7 @@ pub(crate) use string_serde_impl;
 macro_rules! string_json_impl {
     ($type:ty) => {
         impl $crate::utils::json::ToJson for $type {
-            fn to_json(&self) -> json::JsonValue {
+            fn to_json(&self) -> $crate::utils::json::Value {
                 self.to_string().into()
             }
         }
@@ -159,7 +159,7 @@ macro_rules! string_json_impl {
         impl $crate::utils::json::FromJson for $type {
             type Error = $crate::types::block::Error;
 
-            fn from_non_null_json(value: json::JsonValue) -> Result<Self, Self::Error> {
+            fn from_non_null_json(value: $crate::utils::json::Value) -> Result<Self, Self::Error> {
                 core::str::FromStr::from_str($crate::utils::json::JsonExt::to_str(&value)?)
             }
         }

--- a/sdk/src/types/block/mana/allotment.rs
+++ b/sdk/src/types/block/mana/allotment.rs
@@ -75,13 +75,13 @@ pub(super) mod dto {
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct ManaAllotmentDto {
         pub account_id: AccountId,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub mana: u64,
     }
 

--- a/sdk/src/types/block/mana/allotment.rs
+++ b/sdk/src/types/block/mana/allotment.rs
@@ -93,12 +93,11 @@ pub(super) mod dto {
         }
     }
 
-    impl TryFromDto for ManaAllotment {
-        type Dto = ManaAllotmentDto;
+    impl TryFromDto<ManaAllotmentDto> for ManaAllotment {
         type Error = Error;
 
         fn try_from_dto_with_params_inner(
-            dto: Self::Dto,
+            dto: ManaAllotmentDto,
             params: crate::types::ValidationParams<'_>,
         ) -> Result<Self, Self::Error> {
             Ok(if let Some(params) = params.protocol_parameters() {

--- a/sdk/src/types/block/mana/mod.rs
+++ b/sdk/src/types/block/mana/mod.rs
@@ -12,7 +12,7 @@ use derive_more::Deref;
 use iterator_sorted::is_unique_sorted;
 use packable::{bounded::BoundedU16, prefix::BoxedSlicePrefix, Packable};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub use self::allotment::dto::ManaAllotmentDto;
 pub use self::{allotment::ManaAllotment, rewards::RewardsParameters, structure::ManaStructure};
 use super::{output::AccountId, protocol::ProtocolParameters, Error};

--- a/sdk/src/types/block/mana/rewards.rs
+++ b/sdk/src/types/block/mana/rewards.rs
@@ -8,7 +8,7 @@ use crate::types::block::{slot::EpochIndex, Error};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable, CopyGetters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -22,12 +22,12 @@ pub struct RewardsParameters {
     /// The length of the bootstrapping phase in epochs.
     bootstrapping_duration: EpochIndex,
     /// The coefficient used for calculation of initial rewards.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     mana_share_coefficient: u64,
     /// The exponent used for calculation of the initial reward.
     decay_balancing_constant_exponent: u8,
     /// An integer approximation which is calculated using the `decay_balancing_constant_exponent`.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     decay_balancing_constant: u64,
     /// The exponent used for shifting operation during the pool rewards calculations.
     pool_coefficient_exponent: u8,

--- a/sdk/src/types/block/mana/structure.rs
+++ b/sdk/src/types/block/mana/structure.rs
@@ -8,7 +8,7 @@ use crate::types::block::{slot::EpochIndex, Error};
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable, CopyGetters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -23,7 +23,7 @@ pub struct ManaStructure {
     pub(crate) generation_rate_exponent: u8,
     /// A lookup table of epoch index diff to mana decay factor.
     #[packable(unpack_error_with = |_| Error::InvalidManaDecayFactors)]
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::boxed_slice_prefix"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::boxed_slice_prefix"))]
     #[getset(skip)]
     pub(crate) decay_factors: BoxedSlicePrefix<u32, u16>,
     /// The scaling of `decay_factors` expressed as an exponent of 2.

--- a/sdk/src/types/block/mod.rs
+++ b/sdk/src/types/block/mod.rs
@@ -41,6 +41,8 @@ pub mod slot;
 pub mod unlock;
 
 pub(crate) use r#macro::create_bitflags;
+#[cfg(feature = "json")]
+pub(crate) use r#macro::string_json_impl;
 #[cfg(feature = "serde")]
 pub(crate) use r#macro::{impl_id, string_serde_impl};
 

--- a/sdk/src/types/block/mod.rs
+++ b/sdk/src/types/block/mod.rs
@@ -43,10 +43,10 @@ pub mod unlock;
 pub(crate) use r#macro::create_bitflags;
 #[cfg(feature = "json")]
 pub(crate) use r#macro::string_json_impl;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) use r#macro::{impl_id, string_serde_impl};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub use self::core::dto::{BlockDto, BlockWrapperDto};
 pub use self::{
     block_id::{BlockHash, BlockId},

--- a/sdk/src/types/block/output/account.rs
+++ b/sdk/src/types/block/output/account.rs
@@ -35,7 +35,7 @@ use crate::types::{
 
 impl_id!(pub AccountId, 32, "Unique identifier of an account, which is the BLAKE2b-256 hash of the Output ID that created it.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(AccountId);
 #[cfg(feature = "json")]
 string_json_impl!(AccountId);
@@ -61,7 +61,7 @@ impl From<AccountId> for Address {
 
 /// Types of account transition.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub enum AccountTransition {
     /// State transition.
     State,
@@ -776,31 +776,31 @@ pub(crate) mod dto {
     /// Describes an account in the ledger that can be controlled by the state and governance controllers.
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct AccountOutputDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub amount: u64,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub mana: u64,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub native_tokens: Vec<NativeToken>,
         pub account_id: AccountId,
         pub state_index: u32,
         #[cfg_attr(
-            feature = "serde",
+            feature = "serde_types",
             serde(skip_serializing_if = "<[_]>::is_empty", default, with = "prefix_hex_bytes")
         )]
         pub state_metadata: Box<[u8]>,
         pub foundry_counter: u32,
         pub unlock_conditions: Vec<UnlockConditionDto>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub features: Vec<Feature>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub immutable_features: Vec<Feature>,
     }
 
@@ -935,6 +935,33 @@ mod json {
             }
             if !self.immutable_features().is_empty() {
                 res["immutableFeatures"] = self.immutable_features().to_json();
+            }
+            res
+        }
+    }
+
+    impl ToJson for dto::AccountOutputDto {
+        fn to_json(&self) -> Value {
+            let mut res = crate::json! ({
+                "type": AccountOutput::KIND,
+                "amount": self.amount,
+                "mana": self.mana,
+                "accountId": *self.account_id,
+                "stateIndex": self.state_index,
+                "foundryCounter": self.foundry_counter,
+                "unlockConditions": self.unlock_conditions,
+            });
+            if !self.native_tokens.is_empty() {
+                res["nativeTokens"] = self.native_tokens.to_json();
+            }
+            if !self.state_metadata.is_empty() {
+                res["stateMetadata"] = self.state_metadata.to_json();
+            }
+            if !self.features.is_empty() {
+                res["features"] = self.features.to_json();
+            }
+            if !self.immutable_features.is_empty() {
+                res["immutableFeatures"] = self.immutable_features.to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/account.rs
+++ b/sdk/src/types/block/output/account.rs
@@ -922,7 +922,7 @@ mod json {
                 "accountId": *self.account_id(),
                 "stateIndex": self.state_index(),
                 "foundryCounter": self.foundry_counter(),
-                "unlockConditions": ***self.unlock_conditions(),
+                "unlockConditions": self.unlock_conditions().as_list(),
             });
             if !self.native_tokens().is_empty() {
                 res["nativeTokens"] = self.native_tokens().to_json();

--- a/sdk/src/types/block/output/account.rs
+++ b/sdk/src/types/block/output/account.rs
@@ -37,6 +37,8 @@ impl_id!(pub AccountId, 32, "Unique identifier of an account, which is the BLAKE
 
 #[cfg(feature = "serde")]
 string_serde_impl!(AccountId);
+#[cfg(feature = "json")]
+string_json_impl!(AccountId);
 
 impl From<&OutputId> for AccountId {
     fn from(output_id: &OutputId) -> Self {

--- a/sdk/src/types/block/output/account.rs
+++ b/sdk/src/types/block/output/account.rs
@@ -917,8 +917,8 @@ mod json {
         fn to_json(&self) -> Value {
             let mut res = crate::json! ({
                 "type": Self::KIND,
-                "amount": self.amount().to_string(),
-                "mana": self.mana().to_string(),
+                "amount": self.amount(),
+                "mana": self.mana(),
                 "accountId": *self.account_id(),
                 "stateIndex": self.state_index(),
                 "foundryCounter": self.foundry_counter(),
@@ -955,14 +955,8 @@ mod json {
             }
             Ok(Self {
                 kind: AccountOutput::KIND,
-                amount: value["amount"]
-                    .to_str()?
-                    .parse()
-                    .map_err(|_| Error::InvalidField("amount"))?,
-                mana: value["mana"]
-                    .to_str()?
-                    .parse()
-                    .map_err(|_| Error::InvalidField("mana"))?,
+                amount: value["amount"].to_u64()?,
+                mana: value["mana"].to_u64()?,
                 native_tokens: value["nativeTokens"].take_opt_or_default()?,
                 account_id: value["accountId"].take_value()?,
                 state_index: value["stateIndex"].to_u32()?,

--- a/sdk/src/types/block/output/account.rs
+++ b/sdk/src/types/block/output/account.rs
@@ -922,19 +922,19 @@ mod json {
                 "accountId": *self.account_id(),
                 "stateIndex": self.state_index(),
                 "foundryCounter": self.foundry_counter(),
-                "unlockConditions": self.unlock_conditions().to_vec(),
+                "unlockConditions": ***self.unlock_conditions(),
             });
             if !self.native_tokens().is_empty() {
-                res["nativeTokens"] = self.native_tokens().to_vec().to_json();
+                res["nativeTokens"] = self.native_tokens().to_json();
             }
             if !self.state_metadata().is_empty() {
-                res["stateMetadata"] = self.state_metadata().to_vec().to_json();
+                res["stateMetadata"] = self.state_metadata().to_json();
             }
             if !self.features().is_empty() {
-                res["features"] = self.features().to_vec().to_json();
+                res["features"] = self.features().to_json();
             }
             if !self.immutable_features().is_empty() {
-                res["immutableFeatures"] = self.immutable_features().to_vec().to_json();
+                res["immutableFeatures"] = self.immutable_features().to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -470,13 +470,13 @@ mod json {
                 "type": Self::KIND,
                 "amount": self.amount(),
                 "mana": self.mana(),
-                "unlockConditions": self.unlock_conditions().to_vec(),
+                "unlockConditions": ***self.unlock_conditions(),
             });
             if !self.native_tokens().is_empty() {
-                res["nativeTokens"] = self.native_tokens().to_vec().to_json();
+                res["nativeTokens"] = self.native_tokens().to_json();
             }
             if !self.features().is_empty() {
-                res["features"] = self.features().to_vec().to_json();
+                res["features"] = self.features().to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -368,21 +368,21 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct BasicOutputDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub amount: u64,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub mana: u64,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub native_tokens: Vec<NativeToken>,
         pub unlock_conditions: Vec<UnlockConditionDto>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub features: Vec<Feature>,
     }
 
@@ -477,6 +477,24 @@ mod json {
             }
             if !self.features().is_empty() {
                 res["features"] = self.features().to_json();
+            }
+            res
+        }
+    }
+
+    impl ToJson for dto::BasicOutputDto {
+        fn to_json(&self) -> Value {
+            let mut res = crate::json! ({
+                "type": BasicOutput::KIND,
+                "amount": self.amount,
+                "mana": self.mana,
+                "unlockConditions": self.unlock_conditions,
+            });
+            if !self.native_tokens.is_empty() {
+                res["nativeTokens"] = self.native_tokens.to_json();
+            }
+            if !self.features.is_empty() {
+                res["features"] = self.features.to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -398,11 +398,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for BasicOutput {
-        type Dto = BasicOutputDto;
+    impl TryFromDto<BasicOutputDto> for BasicOutput {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: BasicOutputDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             let mut builder = BasicOutputBuilder::new_with_amount(dto.amount)
                 .with_native_tokens(dto.native_tokens)
                 .with_mana(dto.mana)

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -470,7 +470,7 @@ mod json {
                 "type": Self::KIND,
                 "amount": self.amount(),
                 "mana": self.mana(),
-                "unlockConditions": ***self.unlock_conditions(),
+                "unlockConditions": self.unlock_conditions().as_list(),
             });
             if !self.native_tokens().is_empty() {
                 res["nativeTokens"] = self.native_tokens().to_json();

--- a/sdk/src/types/block/output/chain_id.rs
+++ b/sdk/src/types/block/output/chain_id.rs
@@ -7,7 +7,7 @@ use crate::types::block::output::{AccountId, DelegationId, FoundryId, NftId, Out
 
 ///
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd, From)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChainId {
     ///
     Account(AccountId),

--- a/sdk/src/types/block/output/delegation.rs
+++ b/sdk/src/types/block/output/delegation.rs
@@ -34,6 +34,8 @@ impl_id!(pub DelegationId, 32, "Unique identifier of the Delegation Output, whic
 
 #[cfg(feature = "serde")]
 string_serde_impl!(DelegationId);
+#[cfg(feature = "json")]
+string_json_impl!(DelegationId);
 
 impl From<&OutputId> for DelegationId {
     fn from(output_id: &OutputId) -> Self {

--- a/sdk/src/types/block/output/delegation.rs
+++ b/sdk/src/types/block/output/delegation.rs
@@ -518,12 +518,11 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for DelegationOutput {
-        type Dto = DelegationOutputDto;
+    impl TryFromDto<DelegationOutputDto> for DelegationOutput {
         type Error = Error;
 
         fn try_from_dto_with_params_inner(
-            dto: Self::Dto,
+            dto: DelegationOutputDto,
             params: crate::types::ValidationParams<'_>,
         ) -> Result<Self, Self::Error> {
             let mut builder = DelegationOutputBuilder::new_with_amount(

--- a/sdk/src/types/block/output/delegation.rs
+++ b/sdk/src/types/block/output/delegation.rs
@@ -32,7 +32,7 @@ use crate::types::{
 
 impl_id!(pub DelegationId, 32, "Unique identifier of the Delegation Output, which is the BLAKE2b-256 hash of the Output ID that created it.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(DelegationId);
 #[cfg(feature = "json")]
 string_json_impl!(DelegationId);
@@ -486,16 +486,16 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct DelegationOutputDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub amount: u64,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub delegated_amount: u64,
         pub delegation_id: DelegationId,
         pub validator_address: AccountAddress,
@@ -604,7 +604,22 @@ mod json {
                 "validatorAddress": self.validator_address(),
                 "startEpoch": self.start_epoch(),
                 "endEpoch": self.end_epoch(),
-                "unlockConditions": self.unlock_conditions().to_json(),
+                "unlockConditions": self.unlock_conditions().as_list(),
+            })
+        }
+    }
+
+    impl ToJson for dto::DelegationOutputDto {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": DelegationOutput::KIND,
+                "amount": self.amount,
+                "delegatedAmount": self.delegated_amount,
+                "delegationId": self.delegation_id,
+                "validatorAddress": self.validator_address,
+                "startEpoch": self.start_epoch,
+                "endEpoch": self.end_epoch,
+                "unlockConditions": self.unlock_conditions,
             })
         }
     }

--- a/sdk/src/types/block/output/delegation.rs
+++ b/sdk/src/types/block/output/delegation.rs
@@ -604,7 +604,7 @@ mod json {
                 "validatorAddress": self.validator_address(),
                 "startEpoch": self.start_epoch(),
                 "endEpoch": self.end_epoch(),
-                "unlockConditions": self.unlock_conditions().to_vec(),
+                "unlockConditions": self.unlock_conditions().to_json(),
             })
         }
     }

--- a/sdk/src/types/block/output/feature/block_issuer.rs
+++ b/sdk/src/types/block/output/feature/block_issuer.rs
@@ -19,7 +19,11 @@ use packable::{
 use crate::types::block::{slot::SlotIndex, Error};
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From, packable::Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidBlockIssuerKeyKind)]
 pub enum BlockIssuerKey {
@@ -60,7 +64,7 @@ impl BlockIssuerKey {
 /// An Ed25519 block issuer key.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, AsRef, From)]
 #[as_ref(forward)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ed25519BlockIssuerKey(ed25519::PublicKey);
 
 impl Ed25519BlockIssuerKey {
@@ -221,7 +225,7 @@ impl BlockIssuerFeature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use alloc::{string::String, vec::Vec};
 

--- a/sdk/src/types/block/output/feature/issuer.rs
+++ b/sdk/src/types/block/output/feature/issuer.rs
@@ -56,3 +56,35 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(IssuerFeature, IssuerFeatureDto, "issuer feature");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for IssuerFeature {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "address": self.0,
+            })
+        }
+    }
+
+    impl FromJson for IssuerFeature {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["address"].take_value::<Address>()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/feature/issuer.rs
+++ b/sdk/src/types/block/output/feature/issuer.rs
@@ -26,7 +26,7 @@ impl IssuerFeature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -459,3 +459,35 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(MetadataFeature, MetadataFeatureDto<'_>, "metadata feature");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for MetadataFeature {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "data": self.to_string(),
+            })
+        }
+    }
+
+    impl FromJson for MetadataFeature {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::from_str(value["data"].to_str()?)
+        }
+    }
+}

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -425,7 +425,7 @@ pub(crate) mod irc_30 {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use alloc::borrow::Cow;
 

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -34,7 +34,11 @@ use crate::types::block::{create_bitflags, Error};
 #[derive(Clone, Eq, PartialEq, Hash, From, Packable)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidFeatureKind)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum Feature {
     /// A sender feature.
     #[packable(tag = SenderFeature::KIND)]

--- a/sdk/src/types/block/output/feature/sender.rs
+++ b/sdk/src/types/block/output/feature/sender.rs
@@ -26,7 +26,7 @@ impl SenderFeature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/feature/sender.rs
+++ b/sdk/src/types/block/output/feature/sender.rs
@@ -56,3 +56,35 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(SenderFeature, SenderFeatureDto, "sender feature");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for SenderFeature {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "address": self.0,
+            })
+        }
+    }
+
+    impl FromJson for SenderFeature {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["address"].take_value::<Address>()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/feature/staking.rs
+++ b/sdk/src/types/block/output/feature/staking.rs
@@ -56,7 +56,7 @@ impl StakingFeature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/feature/tag.rs
+++ b/sdk/src/types/block/output/feature/tag.rs
@@ -74,7 +74,7 @@ impl core::fmt::Debug for TagFeature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use alloc::borrow::Cow;
 

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -715,11 +715,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for FoundryOutput {
-        type Dto = FoundryOutputDto;
+    impl TryFromDto<FoundryOutputDto> for FoundryOutput {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: FoundryOutputDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             let mut builder = FoundryOutputBuilder::new_with_amount(dto.amount, dto.serial_number, dto.token_scheme);
 
             for t in dto.native_tokens {

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -806,7 +806,7 @@ mod json {
                 "amount": self.amount(),
                 "serialNumber": self.serial_number(),
                 "tokenScheme": self.token_scheme(),
-                "unlockConditions": ***self.unlock_conditions(),
+                "unlockConditions": self.unlock_conditions().as_list(),
             });
             if !self.native_tokens().is_empty() {
                 res["nativeTokens"] = self.native_tokens().to_json();

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -37,6 +37,8 @@ impl_id!(pub FoundryId, 38, "Defines the unique identifier of a foundry.");
 
 #[cfg(feature = "serde")]
 string_serde_impl!(FoundryId);
+#[cfg(feature = "json")]
+string_json_impl!(FoundryId);
 
 impl From<TokenId> for FoundryId {
     fn from(token_id: TokenId) -> Self {

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -35,7 +35,7 @@ use crate::types::{
 
 impl_id!(pub FoundryId, 38, "Defines the unique identifier of a foundry.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(FoundryId);
 #[cfg(feature = "json")]
 string_json_impl!(FoundryId);
@@ -681,23 +681,23 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct FoundryOutputDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub amount: u64,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub native_tokens: Vec<NativeToken>,
         pub serial_number: u32,
         pub token_scheme: TokenScheme,
         pub unlock_conditions: Vec<UnlockConditionDto>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub features: Vec<Feature>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub immutable_features: Vec<Feature>,
     }
 
@@ -816,6 +816,28 @@ mod json {
             }
             if !self.immutable_features().is_empty() {
                 res["immutableFeatures"] = self.immutable_features().to_json();
+            }
+            res
+        }
+    }
+
+    impl ToJson for dto::FoundryOutputDto {
+        fn to_json(&self) -> Value {
+            let mut res = crate::json! ({
+                "type": FoundryOutput::KIND,
+                "amount": self.amount,
+                "serialNumber": self.serial_number,
+                "tokenScheme": self.token_scheme,
+                "unlockConditions": self.unlock_conditions,
+            });
+            if !self.native_tokens.is_empty() {
+                res["nativeTokens"] = self.native_tokens.to_json();
+            }
+            if !self.features.is_empty() {
+                res["features"] = self.features.to_json();
+            }
+            if !self.immutable_features.is_empty() {
+                res["immutableFeatures"] = self.immutable_features.to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -806,16 +806,16 @@ mod json {
                 "amount": self.amount(),
                 "serialNumber": self.serial_number(),
                 "tokenScheme": self.token_scheme(),
-                "unlockConditions": self.unlock_conditions().to_vec(),
+                "unlockConditions": ***self.unlock_conditions(),
             });
             if !self.native_tokens().is_empty() {
-                res["nativeTokens"] = self.native_tokens().to_vec().to_json();
+                res["nativeTokens"] = self.native_tokens().to_json();
             }
             if !self.features().is_empty() {
-                res["features"] = self.features().to_vec().to_json();
+                res["features"] = self.features().to_json();
             }
             if !self.immutable_features().is_empty() {
-                res["immutableFeatures"] = self.immutable_features().to_vec().to_json();
+                res["immutableFeatures"] = self.immutable_features().to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/inputs_commitment.rs
+++ b/sdk/src/types/block/output/inputs_commitment.rs
@@ -9,7 +9,7 @@ use crate::types::block::output::Output;
 
 /// Represents a commitment to transaction inputs.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, From, Deref, packable::Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputsCommitment([u8; Self::LENGTH]);
 
 impl InputsCommitment {

--- a/sdk/src/types/block/output/inputs_commitment.rs
+++ b/sdk/src/types/block/output/inputs_commitment.rs
@@ -47,3 +47,29 @@ impl core::fmt::Debug for InputsCommitment {
         write!(f, "InputsCommitment({self})")
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for InputsCommitment {
+        fn to_json(&self) -> Value {
+            self.0.to_json()
+        }
+    }
+
+    impl FromJson for InputsCommitment {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self(value.take_array()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/inputs_commitment.rs
+++ b/sdk/src/types/block/output/inputs_commitment.rs
@@ -49,27 +49,4 @@ impl core::fmt::Debug for InputsCommitment {
 }
 
 #[cfg(feature = "json")]
-mod json {
-    use super::*;
-    use crate::{
-        types::block::Error,
-        utils::json::{FromJson, JsonExt, ToJson, Value},
-    };
-
-    impl ToJson for InputsCommitment {
-        fn to_json(&self) -> Value {
-            self.0.to_json()
-        }
-    }
-
-    impl FromJson for InputsCommitment {
-        type Error = Error;
-
-        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
-        where
-            Self: Sized,
-        {
-            Ok(Self(value.take_array()?))
-        }
-    }
-}
+string_json_impl!(InputsCommitment);

--- a/sdk/src/types/block/output/metadata.rs
+++ b/sdk/src/types/block/output/metadata.rs
@@ -96,7 +96,7 @@ impl OutputMetadata {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -553,11 +553,10 @@ pub mod dto {
         }
     }
 
-    impl TryFromDto for Output {
-        type Dto = OutputDto;
+    impl TryFromDto<OutputDto> for Output {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(dto: OutputDto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
             Ok(match dto {
                 OutputDto::Basic(o) => Self::Basic(BasicOutput::try_from_dto_with_params_inner(o, params)?),
                 OutputDto::Account(o) => Self::Account(AccountOutput::try_from_dto_with_params_inner(o, params)?),

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -567,7 +567,7 @@ pub mod dto {
         }
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_types")]
     impl<'de> serde::Deserialize<'de> for OutputDto {
         fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
             let value = Value::deserialize(d)?;
@@ -604,7 +604,7 @@ pub mod dto {
         }
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_types")]
     impl serde::Serialize for OutputDto {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -652,6 +652,18 @@ mod json {
     use crate::utils::json::{FromJson, ToJson, Value};
 
     impl ToJson for Output {
+        fn to_json(&self) -> Value {
+            match self {
+                Self::Basic(o) => o.to_json(),
+                Self::Account(o) => o.to_json(),
+                Self::Foundry(o) => o.to_json(),
+                Self::Nft(o) => o.to_json(),
+                Self::Delegation(o) => o.to_json(),
+            }
+        }
+    }
+
+    impl ToJson for dto::OutputDto {
         fn to_json(&self) -> Value {
             match self {
                 Self::Basic(o) => o.to_json(),

--- a/sdk/src/types/block/output/native_token.rs
+++ b/sdk/src/types/block/output/native_token.rs
@@ -257,3 +257,32 @@ fn verify_unique_sorted<const VERIFY: bool>(native_tokens: &[NativeToken], _: &(
         Ok(())
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for NativeToken {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "id": self.token_id,
+                "amount": self.amount
+            })
+        }
+    }
+
+    impl FromJson for NativeToken {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Self::new(value["id"].take_value()?, value["amount"].take_value::<U256>()?)
+        }
+    }
+}

--- a/sdk/src/types/block/output/native_token.rs
+++ b/sdk/src/types/block/output/native_token.rs
@@ -16,7 +16,7 @@ use crate::types::block::{output::foundry::FoundryId, Error};
 
 impl_id!(pub TokenId, 38, "Unique identifiers of native tokens. The TokenId of native tokens minted by a specific foundry is the same as the FoundryId.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(TokenId);
 #[cfg(feature = "json")]
 string_json_impl!(TokenId);
@@ -29,11 +29,11 @@ impl From<FoundryId> for TokenId {
 
 ///
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_error = Error)]
 pub struct NativeToken {
     // Identifier of the native token.
-    #[cfg_attr(feature = "serde", serde(rename = "id"))]
+    #[cfg_attr(feature = "serde_types", serde(rename = "id"))]
     token_id: TokenId,
     // Amount of native tokens.
     #[packable(verify_with = verify_amount)]
@@ -165,7 +165,7 @@ pub(crate) type NativeTokenCount = BoundedU8<0, { NativeTokens::COUNT_MAX }>;
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, Packable)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
 #[packable(unpack_error = Error, with = |e| e.unwrap_item_err_or_else(|p| Error::InvalidNativeTokenCount(p.into())))]
 pub struct NativeTokens(
     #[packable(verify_with = verify_unique_sorted)] BoxedSlicePrefix<NativeToken, NativeTokenCount>,

--- a/sdk/src/types/block/output/native_token.rs
+++ b/sdk/src/types/block/output/native_token.rs
@@ -18,6 +18,8 @@ impl_id!(pub TokenId, 38, "Unique identifiers of native tokens. The TokenId of n
 
 #[cfg(feature = "serde")]
 string_serde_impl!(TokenId);
+#[cfg(feature = "json")]
+string_json_impl!(TokenId);
 
 impl From<FoundryId> for TokenId {
     fn from(foundry_id: FoundryId) -> Self {

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -34,6 +34,8 @@ impl_id!(pub NftId, 32, "Unique identifier of an NFT, which is the BLAKE2b-256 h
 
 #[cfg(feature = "serde")]
 string_serde_impl!(NftId);
+#[cfg(feature = "json")]
+string_json_impl!(NftId);
 
 impl From<&OutputId> for NftId {
     fn from(output_id: &OutputId) -> Self {

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -666,16 +666,16 @@ mod json {
                 "amount": self.amount(),
                 "mana": self.mana(),
                 "nftId": self.nft_id(),
-                "unlockConditions": self.unlock_conditions().to_vec(),
+                "unlockConditions": ***self.unlock_conditions(),
             });
             if !self.native_tokens().is_empty() {
-                res["nativeTokens"] = self.native_tokens().to_vec().to_json();
+                res["nativeTokens"] = self.native_tokens().to_json();
             }
             if !self.features().is_empty() {
-                res["features"] = self.features().to_vec().to_json();
+                res["features"] = self.features().to_json();
             }
             if !self.immutable_features().is_empty() {
-                res["immutableFeatures"] = self.immutable_features().to_vec().to_json();
+                res["immutableFeatures"] = self.immutable_features().to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -666,7 +666,7 @@ mod json {
                 "amount": self.amount(),
                 "mana": self.mana(),
                 "nftId": self.nft_id(),
-                "unlockConditions": ***self.unlock_conditions(),
+                "unlockConditions": self.unlock_conditions().as_list(),
             });
             if !self.native_tokens().is_empty() {
                 res["nativeTokens"] = self.native_tokens().to_json();

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -32,7 +32,7 @@ use crate::types::{
 
 impl_id!(pub NftId, 32, "Unique identifier of an NFT, which is the BLAKE2b-256 hash of the Output ID that created it.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(NftId);
 #[cfg(feature = "json")]
 string_json_impl!(NftId);
@@ -550,24 +550,24 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct NftOutputDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub amount: u64,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub mana: u64,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub native_tokens: Vec<NativeToken>,
         pub nft_id: NftId,
         pub unlock_conditions: Vec<UnlockConditionDto>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub features: Vec<Feature>,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+        #[cfg_attr(feature = "serde_types", serde(skip_serializing_if = "Vec::is_empty", default))]
         pub immutable_features: Vec<Feature>,
     }
 
@@ -676,6 +676,28 @@ mod json {
             }
             if !self.immutable_features().is_empty() {
                 res["immutableFeatures"] = self.immutable_features().to_json();
+            }
+            res
+        }
+    }
+
+    impl ToJson for dto::NftOutputDto {
+        fn to_json(&self) -> Value {
+            let mut res = crate::json! ({
+                "type": NftOutput::KIND,
+                "amount": self.amount,
+                "mana": self.mana,
+                "nftId": self.nft_id,
+                "unlockConditions": self.unlock_conditions,
+            });
+            if !self.native_tokens.is_empty() {
+                res["nativeTokens"] = self.native_tokens.to_json();
+            }
+            if !self.features.is_empty() {
+                res["features"] = self.features.to_json();
+            }
+            if !self.immutable_features.is_empty() {
+                res["immutableFeatures"] = self.immutable_features.to_json();
             }
             res
         }

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -585,11 +585,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for NftOutput {
-        type Dto = NftOutputDto;
+    impl TryFromDto<NftOutputDto> for NftOutput {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: NftOutputDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             let mut builder = NftOutputBuilder::new_with_amount(dto.amount, dto.nft_id)
                 .with_mana(dto.mana)
                 .with_native_tokens(dto.native_tokens)

--- a/sdk/src/types/block/output/output_id.rs
+++ b/sdk/src/types/block/output/output_id.rs
@@ -67,6 +67,8 @@ impl OutputId {
 
 #[cfg(feature = "serde")]
 string_serde_impl!(OutputId);
+#[cfg(feature = "json")]
+string_json_impl!(OutputId);
 
 impl TryFrom<[u8; Self::LENGTH]> for OutputId {
     type Error = Error;

--- a/sdk/src/types/block/output/output_id.rs
+++ b/sdk/src/types/block/output/output_id.rs
@@ -65,7 +65,7 @@ impl OutputId {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(OutputId);
 #[cfg(feature = "json")]
 string_json_impl!(OutputId);

--- a/sdk/src/types/block/output/rent.rs
+++ b/sdk/src/types/block/output/rent.rs
@@ -26,7 +26,7 @@ const DEFAULT_BYTE_COST_FACTOR_BLOCK_ISSUER_KEY: u8 = 1;
 /// Specifies the current parameters for the byte cost computation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]

--- a/sdk/src/types/block/output/token_scheme/mod.rs
+++ b/sdk/src/types/block/output/token_scheme/mod.rs
@@ -10,7 +10,11 @@ use crate::types::block::Error;
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, derive_more::From, packable::Packable)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidTokenSchemeKind)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum TokenScheme {
     ///
     #[packable(tag = SimpleTokenScheme::KIND)]

--- a/sdk/src/types/block/output/token_scheme/mod.rs
+++ b/sdk/src/types/block/output/token_scheme/mod.rs
@@ -45,3 +45,36 @@ impl TokenScheme {
         scheme
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson, Value};
+
+    impl ToJson for TokenScheme {
+        fn to_json(&self) -> Value {
+            match self {
+                Self::Simple(f) => f.to_json(),
+            }
+        }
+    }
+
+    impl FromJson for TokenScheme {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(match value["type"].as_u8() {
+                Some(SimpleTokenScheme::KIND) => SimpleTokenScheme::from_json(value)?.into(),
+                _ => {
+                    return Err(Error::invalid_type::<Self>(
+                        format!("one of {:?}", [SimpleTokenScheme::KIND]),
+                        &value["type"],
+                    ));
+                }
+            })
+        }
+    }
+}

--- a/sdk/src/types/block/output/token_scheme/simple.rs
+++ b/sdk/src/types/block/output/token_scheme/simple.rs
@@ -116,7 +116,7 @@ fn verify_supply(minted_tokens: &U256, melted_tokens: &U256, maximum_supply: &U2
     Ok(())
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/token_scheme/simple.rs
+++ b/sdk/src/types/block/output/token_scheme/simple.rs
@@ -158,3 +158,41 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(SimpleTokenScheme, SimpleTokenSchemeDto, "simple token scheme");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for SimpleTokenScheme {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "mintedTokens": self.minted_tokens,
+                "meltedTokens": self.melted_tokens,
+                "maximumSupply": self.maximum_supply,
+            })
+        }
+    }
+
+    impl FromJson for SimpleTokenScheme {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(
+                value["mintedTokens"].take_value::<U256>()?,
+                value["meltedTokens"].take_value::<U256>()?,
+                value["maximumSupply"].take_value::<U256>()?,
+            )
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/address.rs
+++ b/sdk/src/types/block/output/unlock_condition/address.rs
@@ -60,3 +60,35 @@ pub(crate) mod dto {
         "address unlock condition"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for AddressUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "address": self.0,
+            })
+        }
+    }
+
+    impl FromJson for AddressUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["address"].take_value::<Address>()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/address.rs
+++ b/sdk/src/types/block/output/unlock_condition/address.rs
@@ -26,7 +26,7 @@ impl AddressUnlockCondition {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/expiration.rs
+++ b/sdk/src/types/block/output/unlock_condition/expiration.rs
@@ -64,7 +64,7 @@ fn verify_slot_index<const VERIFY: bool>(slot_index: &SlotIndex, _: &()) -> Resu
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/expiration.rs
+++ b/sdk/src/types/block/output/unlock_condition/expiration.rs
@@ -105,3 +105,39 @@ pub(crate) mod dto {
         "expiration unlock condition"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for ExpirationUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "returnAddress": self.return_address(),
+                "slotIndex": self.slot_index,
+            })
+        }
+    }
+
+    impl FromJson for ExpirationUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(
+                value["returnAddress"].take_value::<Address>()?,
+                value["slotIndex"].take_value::<SlotIndex>()?,
+            )
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/governor_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/governor_address.rs
@@ -62,3 +62,35 @@ pub(crate) mod dto {
         "governor address unlock condition"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for GovernorAddressUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "address": self.0,
+            })
+        }
+    }
+
+    impl FromJson for GovernorAddressUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["address"].take_value::<Address>()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/governor_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/governor_address.rs
@@ -28,7 +28,7 @@ impl GovernorAddressUnlockCondition {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/immutable_account_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/immutable_account_address.rs
@@ -60,3 +60,35 @@ mod dto {
         "immutable account adress unlock condition"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for ImmutableAccountAddressUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "address": self.0,
+            })
+        }
+    }
+
+    impl FromJson for ImmutableAccountAddressUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["address"].take_value::<AccountAddress>()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/immutable_account_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/immutable_account_address.rs
@@ -26,7 +26,7 @@ impl ImmutableAccountAddressUnlockCondition {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -496,7 +496,7 @@ mod json {
         }
     }
 
-    impl FromJson for UnlockCondition {
+    impl FromJson for dto::UnlockConditionDto {
         type Error = Error;
 
         fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
@@ -506,7 +506,7 @@ mod json {
             Ok(match value["type"].as_u8() {
                 Some(AddressUnlockCondition::KIND) => AddressUnlockCondition::from_json(value)?.into(),
                 Some(StorageDepositReturnUnlockCondition::KIND) => {
-                    StorageDepositReturnUnlockCondition::from_json(value)?.into()
+                    dto::StorageDepositReturnUnlockConditionDto::from_json(value)?.into()
                 }
                 Some(TimelockUnlockCondition::KIND) => TimelockUnlockCondition::from_json(value)?.into(),
                 Some(ExpirationUnlockCondition::KIND) => ExpirationUnlockCondition::from_json(value)?.into(),
@@ -560,16 +560,13 @@ mod test {
     }
 }
 
-#[cfg(feature = "serde")]
 pub mod dto {
-    use serde::{Deserialize, Serialize};
-
     pub use self::storage_deposit_return::dto::StorageDepositReturnUnlockConditionDto;
     use super::*;
     use crate::types::{block::Error, TryFromDto, ValidationParams};
 
-    #[derive(Clone, Debug, Eq, PartialEq, From, Serialize, Deserialize)]
-    #[serde(untagged)]
+    #[derive(Clone, Debug, Eq, PartialEq, From)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
     pub enum UnlockConditionDto {
         /// An address unlock condition.
         Address(AddressUnlockCondition),
@@ -601,11 +598,13 @@ pub mod dto {
         }
     }
 
-    impl TryFromDto for UnlockCondition {
-        type Dto = UnlockConditionDto;
+    impl TryFromDto<UnlockConditionDto> for UnlockCondition {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: UnlockConditionDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             Ok(match dto {
                 UnlockConditionDto::Address(v) => Self::Address(v),
                 UnlockConditionDto::StorageDepositReturn(v) => Self::StorageDepositReturn(

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -501,6 +501,20 @@ mod json {
         }
     }
 
+    impl ToJson for dto::UnlockConditionDto {
+        fn to_json(&self) -> Value {
+            match self {
+                Self::Address(u) => u.to_json(),
+                Self::StorageDepositReturn(u) => u.to_json(),
+                Self::Timelock(u) => u.to_json(),
+                Self::Expiration(u) => u.to_json(),
+                Self::StateControllerAddress(u) => u.to_json(),
+                Self::GovernorAddress(u) => u.to_json(),
+                Self::ImmutableAccountAddress(u) => u.to_json(),
+            }
+        }
+    }
+
     impl FromJson for dto::UnlockConditionDto {
         type Error = Error;
 
@@ -571,7 +585,11 @@ pub mod dto {
     use crate::types::{block::Error, TryFromDto, ValidationParams};
 
     #[derive(Clone, Debug, Eq, PartialEq, From)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+    #[cfg_attr(
+        feature = "serde_types",
+        derive(serde::Serialize, serde::Deserialize),
+        serde(untagged)
+    )]
     pub enum UnlockConditionDto {
         /// An address unlock condition.
         Address(AddressUnlockCondition),

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -477,6 +477,68 @@ pub(crate) fn verify_allowed_unlock_conditions(
     Ok(())
 }
 
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson, Value};
+
+    impl ToJson for UnlockCondition {
+        fn to_json(&self) -> Value {
+            match self {
+                Self::Address(u) => u.to_json(),
+                Self::StorageDepositReturn(u) => u.to_json(),
+                Self::Timelock(u) => u.to_json(),
+                Self::Expiration(u) => u.to_json(),
+                Self::StateControllerAddress(u) => u.to_json(),
+                Self::GovernorAddress(u) => u.to_json(),
+                Self::ImmutableAccountAddress(u) => u.to_json(),
+            }
+        }
+    }
+
+    impl FromJson for UnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(match value["type"].as_u8() {
+                Some(AddressUnlockCondition::KIND) => AddressUnlockCondition::from_json(value)?.into(),
+                Some(StorageDepositReturnUnlockCondition::KIND) => {
+                    StorageDepositReturnUnlockCondition::from_json(value)?.into()
+                }
+                Some(TimelockUnlockCondition::KIND) => TimelockUnlockCondition::from_json(value)?.into(),
+                Some(ExpirationUnlockCondition::KIND) => ExpirationUnlockCondition::from_json(value)?.into(),
+                Some(StateControllerAddressUnlockCondition::KIND) => {
+                    StateControllerAddressUnlockCondition::from_json(value)?.into()
+                }
+                Some(GovernorAddressUnlockCondition::KIND) => GovernorAddressUnlockCondition::from_json(value)?.into(),
+                Some(ImmutableAccountAddressUnlockCondition::KIND) => {
+                    ImmutableAccountAddressUnlockCondition::from_json(value)?.into()
+                }
+                _ => {
+                    return Err(Error::invalid_type::<Self>(
+                        format!(
+                            "one of {:?}",
+                            [
+                                AddressUnlockCondition::KIND,
+                                StorageDepositReturnUnlockCondition::KIND,
+                                TimelockUnlockCondition::KIND,
+                                ExpirationUnlockCondition::KIND,
+                                StateControllerAddressUnlockCondition::KIND,
+                                GovernorAddressUnlockCondition::KIND,
+                                ImmutableAccountAddressUnlockCondition::KIND,
+                            ]
+                        ),
+                        &value["type"],
+                    ));
+                }
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -442,6 +442,11 @@ impl UnlockConditions {
         self.expiration()
             .map_or(false, |expiration| slot_index >= expiration.slot_index())
     }
+
+    /// Returns the underlying list
+    pub fn as_list(&self) -> &[UnlockCondition] {
+        self
+    }
 }
 
 #[inline]

--- a/sdk/src/types/block/output/unlock_condition/state_controller_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/state_controller_address.rs
@@ -62,3 +62,35 @@ pub(crate) mod dto {
         "state controller address unlock condition"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for StateControllerAddressUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "address": self.0,
+            })
+        }
+    }
+
+    impl FromJson for StateControllerAddressUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["address"].take_value::<Address>()?))
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/state_controller_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/state_controller_address.rs
@@ -28,7 +28,7 @@ impl StateControllerAddressUnlockCondition {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
+++ b/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
@@ -69,19 +69,22 @@ pub(crate) mod dto {
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct StorageDepositReturnUnlockConditionDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type", deserialize_with = "deserialize_kind"))]
+        #[cfg_attr(
+            feature = "serde_types",
+            serde(rename = "type", deserialize_with = "deserialize_kind")
+        )]
         pub kind: u8,
         pub return_address: Address,
-        #[cfg_attr(feature = "serde", serde(with = "string"))]
+        #[cfg_attr(feature = "serde_types", serde(with = "string"))]
         pub amount: u64,
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_types")]
     fn deserialize_kind<'de, D>(d: D) -> Result<u8, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -126,7 +129,7 @@ pub(crate) mod dto {
         }
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serde_types")]
     impl serde::Serialize for StorageDepositReturnUnlockCondition {
         fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where
@@ -150,7 +153,17 @@ mod json {
             crate::json! ({
                 "type": Self::KIND,
                 "returnAddress": self.return_address(),
-                "amount": self.amount.to_string(),
+                "amount": self.amount,
+            })
+        }
+    }
+
+    impl ToJson for dto::StorageDepositReturnUnlockConditionDto {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": StorageDepositReturnUnlockCondition::KIND,
+                "returnAddress": self.return_address,
+                "amount": self.amount,
             })
         }
     }

--- a/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
+++ b/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
@@ -130,3 +130,42 @@ pub(crate) mod dto {
         }
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for StorageDepositReturnUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "returnAddress": self.return_address(),
+                "amount": self.amount.to_string(),
+            })
+        }
+    }
+
+    impl FromJson for StorageDepositReturnUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self {
+                return_address: value["returnAddress"].take_value()?,
+                amount: value["amount"]
+                    .to_str()?
+                    .parse()
+                    .map_err(|_| Error::InvalidField("amount"))?,
+            })
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/timelock.rs
+++ b/sdk/src/types/block/output/unlock_condition/timelock.rs
@@ -77,3 +77,35 @@ pub(crate) mod dto {
         "timelock unlock condition"
     );
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, JsonExt, ToJson, Value},
+    };
+
+    impl ToJson for TimelockUnlockCondition {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": Self::KIND,
+                "slotIndex": self.0,
+            })
+        }
+    }
+
+    impl FromJson for TimelockUnlockCondition {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(value["slotIndex"].take_value::<SlotIndex>()?)
+        }
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/timelock.rs
+++ b/sdk/src/types/block/output/unlock_condition/timelock.rs
@@ -40,7 +40,7 @@ fn verify_slot_index<const VERIFY: bool>(slot_index: &SlotIndex, _: &()) -> Resu
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/payload/mod.rs
+++ b/sdk/src/types/block/payload/mod.rs
@@ -179,7 +179,11 @@ pub mod dto {
 
     /// Describes all the different payload types.
     #[derive(Clone, Debug, Eq, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+    #[cfg_attr(
+        feature = "serde_types",
+        derive(serde::Serialize, serde::Deserialize),
+        serde(untagged)
+    )]
     pub enum PayloadDto {
         Transaction(Box<TransactionPayloadDto>),
         TaggedData(Box<TaggedDataPayload>),

--- a/sdk/src/types/block/payload/mod.rs
+++ b/sdk/src/types/block/payload/mod.rs
@@ -209,11 +209,10 @@ pub mod dto {
         }
     }
 
-    impl TryFromDto for Payload {
-        type Dto = PayloadDto;
+    impl TryFromDto<PayloadDto> for Payload {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(dto: PayloadDto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
             Ok(match dto {
                 PayloadDto::Transaction(p) => {
                     Self::from(TransactionPayload::try_from_dto_with_params_inner(*p, params)?)

--- a/sdk/src/types/block/payload/tagged_data/mod.rs
+++ b/sdk/src/types/block/payload/tagged_data/mod.rs
@@ -77,17 +77,17 @@ pub mod dto {
 
     /// The payload type to define a tagged data payload.
     #[derive(Clone, Debug, Eq, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
     struct TaggedDataPayloadDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         kind: u32,
         #[cfg_attr(
-            feature = "serde",
+            feature = "serde_types",
             serde(skip_serializing_if = "<[_]>::is_empty", default, with = "prefix_hex_bytes")
         )]
         tag: Box<[u8]>,
         #[cfg_attr(
-            feature = "serde",
+            feature = "serde_types",
             serde(skip_serializing_if = "<[_]>::is_empty", default, with = "prefix_hex_bytes")
         )]
         data: Box<[u8]>,

--- a/sdk/src/types/block/payload/transaction/essence/mod.rs
+++ b/sdk/src/types/block/payload/transaction/essence/mod.rs
@@ -54,7 +54,11 @@ pub(crate) mod dto {
 
     /// Describes all the different essence types.
     #[derive(Clone, Debug, Eq, PartialEq, From)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+    #[cfg_attr(
+        feature = "serde_types",
+        derive(serde::Serialize, serde::Deserialize),
+        serde(untagged)
+    )]
     pub enum TransactionEssenceDto {
         Regular(RegularTransactionEssenceDto),
     }

--- a/sdk/src/types/block/payload/transaction/essence/mod.rs
+++ b/sdk/src/types/block/payload/transaction/essence/mod.rs
@@ -70,11 +70,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for TransactionEssence {
-        type Dto = TransactionEssenceDto;
+    impl TryFromDto<TransactionEssenceDto> for TransactionEssence {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: TransactionEssenceDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             match dto {
                 TransactionEssenceDto::Regular(r) => Ok(Self::Regular(
                     RegularTransactionEssence::try_from_dto_with_params_inner(r, params)?,

--- a/sdk/src/types/block/payload/transaction/essence/regular.rs
+++ b/sdk/src/types/block/payload/transaction/essence/regular.rs
@@ -469,11 +469,13 @@ pub(crate) mod dto {
         }
     }
 
-    impl TryFromDto for RegularTransactionEssence {
-        type Dto = RegularTransactionEssenceDto;
+    impl TryFromDto<RegularTransactionEssenceDto> for RegularTransactionEssence {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: RegularTransactionEssenceDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             let network_id = dto
                 .network_id
                 .parse::<u64>()

--- a/sdk/src/types/block/payload/transaction/essence/regular.rs
+++ b/sdk/src/types/block/payload/transaction/essence/regular.rs
@@ -432,12 +432,12 @@ pub(crate) mod dto {
     /// Describes the essence data making up a transaction by defining its inputs and outputs and an optional payload.
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(
-        feature = "serde",
+        feature = "serde_types",
         derive(serde::Serialize, serde::Deserialize),
         serde(rename_all = "camelCase")
     )]
     pub struct RegularTransactionEssenceDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u8,
         pub network_id: String,
         pub creation_slot: SlotIndex,
@@ -446,7 +446,7 @@ pub(crate) mod dto {
         pub inputs_commitment: String,
         pub outputs: Vec<OutputDto>,
         pub allotments: Vec<ManaAllotmentDto>,
-        #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+        #[cfg_attr(feature = "serde_types", serde(default, skip_serializing_if = "Option::is_none"))]
         pub payload: Option<PayloadDto>,
     }
 

--- a/sdk/src/types/block/payload/transaction/mod.rs
+++ b/sdk/src/types/block/payload/transaction/mod.rs
@@ -150,7 +150,7 @@ mod json {
             crate::json! ({
                 "type": Self::KIND,
                 "essence": self.essence(),
-                "unlocks": ***self.unlocks(),
+                "unlocks": self.unlocks().as_list(),
             })
         }
     }

--- a/sdk/src/types/block/payload/transaction/mod.rs
+++ b/sdk/src/types/block/payload/transaction/mod.rs
@@ -105,9 +105,9 @@ pub mod dto {
 
     /// The payload type to define a value transaction.
     #[derive(Clone, Debug, Eq, PartialEq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde_types", derive(serde::Serialize, serde::Deserialize))]
     pub struct TransactionPayloadDto {
-        #[cfg_attr(feature = "serde", serde(rename = "type"))]
+        #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
         pub kind: u32,
         pub essence: TransactionEssenceDto,
         pub unlocks: Vec<Unlock>,

--- a/sdk/src/types/block/payload/transaction/mod.rs
+++ b/sdk/src/types/block/payload/transaction/mod.rs
@@ -125,11 +125,13 @@ pub mod dto {
         }
     }
 
-    impl TryFromDto for TransactionPayload {
-        type Dto = TransactionPayloadDto;
+    impl TryFromDto<TransactionPayloadDto> for TransactionPayload {
         type Error = Error;
 
-        fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
+        fn try_from_dto_with_params_inner(
+            dto: TransactionPayloadDto,
+            params: ValidationParams<'_>,
+        ) -> Result<Self, Self::Error> {
             let TransactionEssence::Regular(essence) =
                 TransactionEssence::try_from_dto_with_params_inner(dto.essence, params)?;
             Self::new(essence, Unlocks::new(dto.unlocks)?)

--- a/sdk/src/types/block/payload/transaction/transaction_id.rs
+++ b/sdk/src/types/block/payload/transaction/transaction_id.rs
@@ -9,3 +9,5 @@ impl_id!(
 
 #[cfg(feature = "serde")]
 string_serde_impl!(TransactionId);
+#[cfg(feature = "json")]
+string_json_impl!(TransactionId);

--- a/sdk/src/types/block/payload/transaction/transaction_id.rs
+++ b/sdk/src/types/block/payload/transaction/transaction_id.rs
@@ -7,7 +7,7 @@ impl_id!(
     "A transaction identifier, the BLAKE2b-256 hash of the transaction bytes. See <https://www.blake2.net/> for more information."
 );
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(TransactionId);
 #[cfg(feature = "json")]
 string_json_impl!(TransactionId);

--- a/sdk/src/types/block/protocol.rs
+++ b/sdk/src/types/block/protocol.rs
@@ -335,3 +335,5 @@ impl_id!(
 
 #[cfg(feature = "serde")]
 string_serde_impl!(ProtocolParametersHash);
+#[cfg(feature = "json")]
+string_json_impl!(ProtocolParametersHash);

--- a/sdk/src/types/block/protocol.rs
+++ b/sdk/src/types/block/protocol.rs
@@ -19,20 +19,20 @@ use crate::types::block::{helper::network_name_to_id, output::RentStructure, Con
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable, Getters, CopyGetters)]
 #[packable(unpack_error = Error)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
 #[getset(get_copy = "pub")]
 pub struct ProtocolParameters {
     /// The layout type.
-    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    #[cfg_attr(feature = "serde_types", serde(rename = "type"))]
     pub(crate) kind: u8,
     /// The version of the protocol running.
     pub(crate) version: u8,
     /// The human friendly name of the network.
     #[packable(unpack_error_with = |err| Error::InvalidNetworkName(err.into_item_err()))]
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string_prefix"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string_prefix"))]
     #[getset(skip)]
     pub(crate) network_name: StringPrefix<u8>,
     /// The HRP prefix used for Bech32 addresses in the network.
@@ -42,10 +42,10 @@ pub struct ProtocolParameters {
     /// The work score structure used by the node/network.
     pub(crate) work_score_structure: WorkScoreStructure,
     /// TokenSupply defines the current token supply on the network.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) token_supply: u64,
     /// Genesis timestamp at which the slots start to count.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) genesis_unix_timestamp: u64,
     /// Duration of each slot in seconds.
     pub(crate) slot_duration_in_seconds: u8,
@@ -55,27 +55,27 @@ pub struct ProtocolParameters {
     #[getset(skip)]
     pub(crate) mana_structure: ManaStructure,
     /// The unbonding period in epochs before an account can stop staking.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) staking_unbonding_period: u64,
     /// The number of validation blocks that each validator should issue each slot.
     pub(crate) validation_blocks_per_slot: u16,
     /// The number of epochs worth of Mana that a node is punished with for each additional validation block it issues.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) punishment_epochs: u64,
     /// Liveness Threshold is used by tip-selection to determine if a block is eligible by evaluating issuingTimes and
     /// commitments in its past-cone to Accepted Tangle Time and lastCommittedSlot respectively.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) liveness_threshold: u64,
     /// Minimum age relative to the accepted tangle time slot index that a slot can be committed.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) min_committable_age: u64,
     /// Maximum age for a slot commitment to be included in a block relative to the slot index of the block issuing
     /// time.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) max_committable_age: u64,
     /// Epoch Nearing Threshold is used by the epoch orchestrator to detect the slot that should trigger a new
     /// committee selection for the next and upcoming epoch.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     pub(crate) epoch_nearing_threshold: u64,
     /// Parameters used to calculate the Reference Mana Cost (RMC).
     pub(crate) congestion_control_parameters: CongestionControlParameters,
@@ -184,7 +184,7 @@ impl ProtocolParameters {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable, CopyGetters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -239,7 +239,7 @@ impl Default for WorkScoreStructure {
 /// Defines the parameters used to calculate the Reference Mana Cost (RMC).
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable, CopyGetters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -247,13 +247,13 @@ impl Default for WorkScoreStructure {
 #[getset(get_copy = "pub")]
 pub struct CongestionControlParameters {
     /// Minimum value of the reference Mana cost.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     min_reference_mana_cost: u64,
     /// Increase step size of the RMC.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     increase: u64,
     /// Decrease step size of the RMC.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     decrease: u64,
     /// Threshold for increasing the RMC.
     increase_threshold: u32,
@@ -285,7 +285,7 @@ impl Default for CongestionControlParameters {
 /// Defines the parameters used to signal a protocol parameters upgrade.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Packable, CopyGetters)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -333,7 +333,7 @@ impl_id!(
     "The hash of the protocol parameters."
 );
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(ProtocolParametersHash);
 #[cfg(feature = "json")]
 string_json_impl!(ProtocolParametersHash);

--- a/sdk/src/types/block/semantic.rs
+++ b/sdk/src/types/block/semantic.rs
@@ -18,7 +18,10 @@ use crate::types::block::{
 /// Describes the reason of a transaction failure.
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, packable::Packable)]
-#[cfg_attr(feature = "serde", derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)
+)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidTransactionFailureReason)]
 #[non_exhaustive]

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -197,12 +197,12 @@ mod json {
             if value["type"] != Self::KIND {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
-            Ok(Self::try_from_bytes(
+            Self::try_from_bytes(
                 prefix_hex::decode(&String::from_json(value["publicKey"].take())?)
                     .map_err(|_| Error::InvalidField("publicKey"))?,
                 prefix_hex::decode(&String::from_json(value["signature"].take())?)
                     .map_err(|_| Error::InvalidField("publicKey"))?,
-            )?)
+            )
         }
     }
 }

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -174,7 +174,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, ToJson, Value},
+        utils::json::{FromJson, JsonExt, ToJson, Value},
     };
 
     impl ToJson for Ed25519Signature {
@@ -198,10 +198,8 @@ mod json {
                 return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
             }
             Self::try_from_bytes(
-                prefix_hex::decode(&String::from_json(value["publicKey"].take())?)
-                    .map_err(|_| Error::InvalidField("publicKey"))?,
-                prefix_hex::decode(&String::from_json(value["signature"].take())?)
-                    .map_err(|_| Error::InvalidField("publicKey"))?,
+                prefix_hex::decode(value["publicKey"].to_str()?).map_err(|_| Error::InvalidField("publicKey"))?,
+                prefix_hex::decode(value["signature"].to_str()?).map_err(|_| Error::InvalidField("publicKey"))?,
             )
         }
     }

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -190,7 +190,7 @@ mod json {
     impl FromJson for Ed25519Signature {
         type Error = Error;
 
-        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
         where
             Self: Sized,
         {

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -126,7 +126,7 @@ impl Packable for Ed25519Signature {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use alloc::string::String;
 

--- a/sdk/src/types/block/signature/mod.rs
+++ b/sdk/src/types/block/signature/mod.rs
@@ -51,3 +51,36 @@ impl Signature {
         sig
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson, Value};
+
+    impl ToJson for Signature {
+        fn to_json(&self) -> Value {
+            match self {
+                Self::Ed25519(i) => i.to_json(),
+            }
+        }
+    }
+
+    impl FromJson for Signature {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(match value["type"].as_u8() {
+                Some(Ed25519Signature::KIND) => Ed25519Signature::from_json(value)?.into(),
+                _ => {
+                    return Err(Error::invalid_type::<Self>(
+                        format!("one of {:?}", [Ed25519Signature::KIND]),
+                        &value["type"],
+                    ));
+                }
+            })
+        }
+    }
+}

--- a/sdk/src/types/block/signature/mod.rs
+++ b/sdk/src/types/block/signature/mod.rs
@@ -16,7 +16,11 @@ use crate::types::block::Error;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, packable::Packable, From)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidSignatureKind)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum Signature {
     /// An Ed25519 signature.
     #[packable(tag = Ed25519Signature::KIND)]

--- a/sdk/src/types/block/slot/commitment.rs
+++ b/sdk/src/types/block/slot/commitment.rs
@@ -10,7 +10,7 @@ use crate::types::block::slot::{RootsId, SlotCommitmentId, SlotIndex};
 /// It is linked to the commitment of the previous slot, which forms a commitment chain.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, derive_more::From, Packable)]
 #[cfg_attr(
-    feature = "serde",
+    feature = "serde_types",
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
@@ -21,17 +21,17 @@ pub struct SlotCommitment {
     /// It is calculated based on genesis timestamp and the duration of a slot.
     index: SlotIndex,
     /// The commitment ID of the previous slot.
-    #[cfg_attr(feature = "serde", serde(rename = "previousCommitmentId"))]
+    #[cfg_attr(feature = "serde_types", serde(rename = "previousCommitmentId"))]
     previous_slot_commitment_id: SlotCommitmentId,
     /// The digest of multiple sparse merkle tree roots of this slot.
     roots_id: RootsId,
     /// The sum of previous slot commitment cumulative weight and weight of issuers of accepted blocks within this
     /// slot. It is just an indication of "committed into" this slot, and can not strictly be used for evaluating
     /// the switching of a chain.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     cumulative_weight: u64,
     /// Reference Mana Cost (RMC) to be used in the slot with index at `index + Max Committable Age`.
-    #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::string"))]
+    #[cfg_attr(feature = "serde_types", serde(with = "crate::utils::serde::string"))]
     reference_mana_cost: u64,
 }
 

--- a/sdk/src/types/block/slot/commitment.rs
+++ b/sdk/src/types/block/slot/commitment.rs
@@ -99,3 +99,40 @@ impl SlotCommitment {
         SlotCommitmentId::from(bytes)
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+
+    impl ToJson for SlotCommitment {
+        fn to_json(&self) -> Value {
+            crate::json!({
+                "protocolVersion": self.protocol_version,
+                "index": self.index,
+                "previousSlotCommitmentId": self.previous_slot_commitment_id,
+                "rootsId": self.roots_id,
+                "cumulativeWeight": self.cumulative_weight,
+                "referenceManaCost": self.reference_mana_cost,
+            })
+        }
+    }
+
+    impl FromJson for SlotCommitment {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self::new(
+                value["protocolVersion"].take_value()?,
+                value["index"].take_value()?,
+                value["previousSlotCommitmentId"].take_value()?,
+                value["rootsId"].take_value()?,
+                value["cumulativeWeight"].take_value()?,
+                value["referenceManaCost"].take_value()?,
+            ))
+        }
+    }
+}

--- a/sdk/src/types/block/slot/commitment.rs
+++ b/sdk/src/types/block/slot/commitment.rs
@@ -103,7 +103,7 @@ impl SlotCommitment {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
 
     impl ToJson for SlotCommitment {
         fn to_json(&self) -> Value {

--- a/sdk/src/types/block/slot/commitment_id.rs
+++ b/sdk/src/types/block/slot/commitment_id.rs
@@ -5,3 +5,5 @@ impl_id!(pub SlotCommitmentId, 40, "Identifier of a slot commitment.");
 
 #[cfg(feature = "serde")]
 string_serde_impl!(SlotCommitmentId);
+#[cfg(feature = "json")]
+string_json_impl!(SlotCommitmentId);

--- a/sdk/src/types/block/slot/commitment_id.rs
+++ b/sdk/src/types/block/slot/commitment_id.rs
@@ -3,7 +3,7 @@
 
 impl_id!(pub SlotCommitmentId, 40, "Identifier of a slot commitment.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(SlotCommitmentId);
 #[cfg(feature = "json")]
 string_json_impl!(SlotCommitmentId);

--- a/sdk/src/types/block/slot/epoch.rs
+++ b/sdk/src/types/block/slot/epoch.rs
@@ -99,10 +99,10 @@ string_serde_impl!(EpochIndex);
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, ToJson};
+    use crate::utils::json::{FromJson, ToJson, Value};
 
     impl ToJson for EpochIndex {
-        fn to_json(&self) -> ::json::JsonValue {
+        fn to_json(&self) -> Value {
             self.0.to_json()
         }
     }
@@ -110,7 +110,7 @@ mod json {
     impl FromJson for EpochIndex {
         type Error = <u64 as FromJson>::Error;
 
-        fn from_non_null_json(value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
         where
             Self: Sized,
         {

--- a/sdk/src/types/block/slot/epoch.rs
+++ b/sdk/src/types/block/slot/epoch.rs
@@ -96,6 +96,29 @@ impl PartialEq<u64> for EpochIndex {
 #[cfg(feature = "serde")]
 string_serde_impl!(EpochIndex);
 
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson};
+
+    impl ToJson for EpochIndex {
+        fn to_json(&self) -> ::json::JsonValue {
+            self.0.to_json()
+        }
+    }
+
+    impl FromJson for EpochIndex {
+        type Error = <u64 as FromJson>::Error;
+
+        fn from_non_null_json(value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        where
+            Self: Sized,
+        {
+            Ok(Self::new(u64::from_json(value)?))
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/sdk/src/types/block/slot/epoch.rs
+++ b/sdk/src/types/block/slot/epoch.rs
@@ -93,7 +93,7 @@ impl PartialEq<u64> for EpochIndex {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(EpochIndex);
 
 #[cfg(feature = "json")]

--- a/sdk/src/types/block/slot/index.rs
+++ b/sdk/src/types/block/slot/index.rs
@@ -121,6 +121,29 @@ impl From<SlotIndex> for u64 {
 #[cfg(feature = "serde")]
 string_serde_impl!(SlotIndex);
 
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, ToJson};
+
+    impl ToJson for SlotIndex {
+        fn to_json(&self) -> ::json::JsonValue {
+            self.0.to_json()
+        }
+    }
+
+    impl FromJson for SlotIndex {
+        type Error = <u64 as FromJson>::Error;
+
+        fn from_non_null_json(value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        where
+            Self: Sized,
+        {
+            Ok(Self::new(u64::from_json(value)?))
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::types::block::protocol::ProtocolParameters;

--- a/sdk/src/types/block/slot/index.rs
+++ b/sdk/src/types/block/slot/index.rs
@@ -124,10 +124,10 @@ string_serde_impl!(SlotIndex);
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, ToJson};
+    use crate::utils::json::{FromJson, ToJson, Value};
 
     impl ToJson for SlotIndex {
-        fn to_json(&self) -> ::json::JsonValue {
+        fn to_json(&self) -> Value {
             self.0.to_json()
         }
     }
@@ -135,7 +135,7 @@ mod json {
     impl FromJson for SlotIndex {
         type Error = <u64 as FromJson>::Error;
 
-        fn from_non_null_json(value: ::json::JsonValue) -> Result<Self, crate::utils::json::JsonError<Self::Error>>
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
         where
             Self: Sized,
         {

--- a/sdk/src/types/block/slot/index.rs
+++ b/sdk/src/types/block/slot/index.rs
@@ -118,7 +118,7 @@ impl From<SlotIndex> for u64 {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(SlotIndex);
 
 #[cfg(feature = "json")]

--- a/sdk/src/types/block/slot/roots_id.rs
+++ b/sdk/src/types/block/slot/roots_id.rs
@@ -3,7 +3,7 @@
 
 impl_id!(pub RootsId, 32, "The digest of multiple sparse merkle tree roots of a slot.");
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 string_serde_impl!(RootsId);
 #[cfg(feature = "json")]
 string_json_impl!(RootsId);

--- a/sdk/src/types/block/slot/roots_id.rs
+++ b/sdk/src/types/block/slot/roots_id.rs
@@ -5,3 +5,5 @@ impl_id!(pub RootsId, 32, "The digest of multiple sparse merkle tree roots of a 
 
 #[cfg(feature = "serde")]
 string_serde_impl!(RootsId);
+#[cfg(feature = "json")]
+string_json_impl!(RootsId);

--- a/sdk/src/types/block/unlock/account.rs
+++ b/sdk/src/types/block/unlock/account.rs
@@ -77,7 +77,7 @@ mod json {
     impl ToJson for AccountUnlock {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": AccountUnlock::KIND,
+                "type": Self::KIND,
                 "reference": self.index()
             })
         }

--- a/sdk/src/types/block/unlock/account.rs
+++ b/sdk/src/types/block/unlock/account.rs
@@ -68,3 +68,32 @@ mod dto {
 
     impl_serde_typed_dto!(AccountUnlock, AccountUnlockDto, "account unlock");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+
+    impl ToJson for AccountUnlock {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": AccountUnlock::KIND,
+                "reference": self.index()
+            })
+        }
+    }
+
+    impl FromJson for AccountUnlock {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(value["reference"].take_value()?)
+        }
+    }
+}

--- a/sdk/src/types/block/unlock/account.rs
+++ b/sdk/src/types/block/unlock/account.rs
@@ -72,7 +72,7 @@ mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
 
     impl ToJson for AccountUnlock {
         fn to_json(&self) -> Value {

--- a/sdk/src/types/block/unlock/mod.rs
+++ b/sdk/src/types/block/unlock/mod.rs
@@ -107,6 +107,11 @@ impl Unlocks {
             None => None,
         }
     }
+
+    /// Returns the underlying list
+    pub fn as_list(&self) -> &[Unlock] {
+        self
+    }
 }
 
 fn verify_unlocks<const VERIFY: bool>(unlocks: &[Unlock], _: &()) -> Result<(), Error> {

--- a/sdk/src/types/block/unlock/mod.rs
+++ b/sdk/src/types/block/unlock/mod.rs
@@ -34,7 +34,11 @@ pub(crate) type UnlockIndex = BoundedU16<{ *UNLOCK_INDEX_RANGE.start() }, { *UNL
 #[derive(Clone, Eq, PartialEq, Hash, From, Packable)]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidUnlockKind)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(untagged))]
+#[cfg_attr(
+    feature = "serde_types",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
+)]
 pub enum Unlock {
     /// A signature unlock.
     #[packable(tag = SignatureUnlock::KIND)]

--- a/sdk/src/types/block/unlock/nft.rs
+++ b/sdk/src/types/block/unlock/nft.rs
@@ -69,3 +69,32 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(NftUnlock, NftUnlockDto, "nft unlock");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+
+    impl ToJson for NftUnlock {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": NftUnlock::KIND,
+                "reference": self.index()
+            })
+        }
+    }
+
+    impl FromJson for NftUnlock {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(value["reference"].take_value()?)
+        }
+    }
+}

--- a/sdk/src/types/block/unlock/nft.rs
+++ b/sdk/src/types/block/unlock/nft.rs
@@ -36,7 +36,7 @@ impl NftUnlock {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/unlock/nft.rs
+++ b/sdk/src/types/block/unlock/nft.rs
@@ -78,7 +78,7 @@ mod json {
     impl ToJson for NftUnlock {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": NftUnlock::KIND,
+                "type": Self::KIND,
                 "reference": self.index()
             })
         }

--- a/sdk/src/types/block/unlock/nft.rs
+++ b/sdk/src/types/block/unlock/nft.rs
@@ -73,7 +73,7 @@ pub(crate) mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
 
     impl ToJson for NftUnlock {
         fn to_json(&self) -> Value {

--- a/sdk/src/types/block/unlock/reference.rs
+++ b/sdk/src/types/block/unlock/reference.rs
@@ -66,3 +66,32 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(ReferenceUnlock, ReferenceUnlockDto, "reference unlock");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+
+    impl ToJson for ReferenceUnlock {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": ReferenceUnlock::KIND,
+                "reference": self.index()
+            })
+        }
+    }
+
+    impl FromJson for ReferenceUnlock {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Self::new(value["reference"].take_value()?)
+        }
+    }
+}

--- a/sdk/src/types/block/unlock/reference.rs
+++ b/sdk/src/types/block/unlock/reference.rs
@@ -33,7 +33,7 @@ impl ReferenceUnlock {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/unlock/reference.rs
+++ b/sdk/src/types/block/unlock/reference.rs
@@ -75,7 +75,7 @@ mod json {
     impl ToJson for ReferenceUnlock {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": ReferenceUnlock::KIND,
+                "type": Self::KIND,
                 "reference": self.index()
             })
         }

--- a/sdk/src/types/block/unlock/reference.rs
+++ b/sdk/src/types/block/unlock/reference.rs
@@ -70,7 +70,7 @@ pub(crate) mod dto {
 #[cfg(feature = "json")]
 mod json {
     use super::*;
-    use crate::utils::json::{FromJson, TakeValue, ToJson, Value};
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
 
     impl ToJson for ReferenceUnlock {
         fn to_json(&self) -> Value {

--- a/sdk/src/types/block/unlock/signature.rs
+++ b/sdk/src/types/block/unlock/signature.rs
@@ -69,7 +69,7 @@ mod json {
     impl ToJson for SignatureUnlock {
         fn to_json(&self) -> Value {
             crate::json! ({
-                "type": SignatureUnlock::KIND,
+                "type": Self::KIND,
                 "signature": self.0
             })
         }

--- a/sdk/src/types/block/unlock/signature.rs
+++ b/sdk/src/types/block/unlock/signature.rs
@@ -27,7 +27,7 @@ impl SignatureUnlock {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::{Deserialize, Serialize};
 

--- a/sdk/src/types/block/unlock/signature.rs
+++ b/sdk/src/types/block/unlock/signature.rs
@@ -57,3 +57,35 @@ pub(crate) mod dto {
 
     impl_serde_typed_dto!(SignatureUnlock, SignatureUnlockDto, "signature unlock");
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::{
+        types::block::Error,
+        utils::json::{FromJson, TakeValue, ToJson, Value},
+    };
+
+    impl ToJson for SignatureUnlock {
+        fn to_json(&self) -> Value {
+            crate::json! ({
+                "type": SignatureUnlock::KIND,
+                "signature": self.0
+            })
+        }
+    }
+
+    impl FromJson for SignatureUnlock {
+        type Error = Error;
+
+        fn from_non_null_json(mut value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if value["type"] != Self::KIND {
+                return Err(Error::invalid_type::<Self>(Self::KIND, &value["type"]));
+            }
+            Ok(Self::new(value["signature"].take_value()?))
+        }
+    }
+}

--- a/sdk/src/types/block/unlock/signature.rs
+++ b/sdk/src/types/block/unlock/signature.rs
@@ -63,7 +63,7 @@ mod json {
     use super::*;
     use crate::{
         types::block::Error,
-        utils::json::{FromJson, TakeValue, ToJson, Value},
+        utils::json::{FromJson, JsonExt, ToJson, Value},
     };
 
     impl ToJson for SignatureUnlock {

--- a/sdk/src/types/mod.rs
+++ b/sdk/src/types/mod.rs
@@ -127,20 +127,19 @@ impl<'a> From<&'a ValidationParams<'a>> for ValidationParams<'a> {
     }
 }
 
-pub trait TryFromDto: Sized {
-    type Dto;
+pub trait TryFromDto<D>: Sized {
     type Error;
 
-    fn try_from_dto(dto: Self::Dto) -> Result<Self, Self::Error> {
+    fn try_from_dto(dto: D) -> Result<Self, Self::Error> {
         Self::try_from_dto_with_params(dto, ValidationParams::default())
     }
 
     fn try_from_dto_with_params<'a>(
-        dto: Self::Dto,
+        dto: D,
         params: impl Into<ValidationParams<'a>> + Send,
     ) -> Result<Self, Self::Error> {
         Self::try_from_dto_with_params_inner(dto, params.into())
     }
 
-    fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error>;
+    fn try_from_dto_with_params_inner(dto: D, params: ValidationParams<'_>) -> Result<Self, Self::Error>;
 }

--- a/sdk/src/types/mod.rs
+++ b/sdk/src/types/mod.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub mod api;
 pub mod block;
 

--- a/sdk/src/utils/json.rs
+++ b/sdk/src/utils/json.rs
@@ -40,6 +40,12 @@ pub trait ToJson {
     fn to_json(&self) -> Value;
 }
 
+impl<T: ToJson> ToJson for &T {
+    fn to_json(&self) -> Value {
+        ToJson::to_json(*self)
+    }
+}
+
 impl ToJson for Value {
     fn to_json(&self) -> Value {
         self.clone()

--- a/sdk/src/utils/json.rs
+++ b/sdk/src/utils/json.rs
@@ -1,0 +1,430 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use json::JsonValue;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum JsonError<T> {
+    Conversion(T),
+    WrongArraySize { expected: usize, found: usize },
+    MissingValue,
+    Json(json::JsonError),
+}
+
+impl<T> JsonError<T> {
+    pub fn map<U, F: Fn(T) -> U>(self, f: F) -> JsonError<U> {
+        match self {
+            Self::Conversion(t) => JsonError::Conversion(f(t)),
+            Self::WrongArraySize { expected, found } => JsonError::WrongArraySize { expected, found },
+            Self::MissingValue => JsonError::MissingValue,
+            Self::Json(e) => JsonError::Json(e),
+        }
+    }
+}
+
+impl<T> From<json::JsonError> for JsonError<T> {
+    fn from(value: json::JsonError) -> Self {
+        Self::Json(value)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: core::fmt::Debug + core::fmt::Display> std::error::Error for JsonError<T> {}
+
+impl<T: core::fmt::Display> core::fmt::Display for JsonError<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Conversion(e) => write!(f, "conversion error: {e}"),
+            Self::WrongArraySize { expected, found } => {
+                write!(f, "wrong array size: expected {expected}, found {found}")
+            }
+            Self::MissingValue => write!(f, "missing value"),
+            Self::Json(e) => e.fmt(f),
+        }
+    }
+}
+
+pub trait ToJson {
+    fn to_json(&self) -> JsonValue;
+}
+
+impl ToJson for JsonValue {
+    fn to_json(&self) -> JsonValue {
+        self.clone()
+    }
+}
+
+pub trait FromJson {
+    type Error;
+
+    fn from_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        if value.is_null() {
+            return Err(JsonError::MissingValue);
+        }
+        Self::from_non_null_json(value)
+    }
+
+    fn from_non_null_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+    where
+        Self: Sized;
+}
+
+impl<T: FromJson> FromJson for Option<T> {
+    type Error = T::Error;
+
+    fn from_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        Ok(if value.is_null() {
+            None
+        } else {
+            Self::from_non_null_json(value)?
+        })
+    }
+
+    fn from_non_null_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        Ok(Some(T::from_non_null_json(value)?))
+    }
+}
+
+impl ToJson for String {
+    fn to_json(&self) -> JsonValue {
+        self.clone().into()
+    }
+}
+
+impl FromJson for String {
+    type Error = json::Error;
+
+    fn from_non_null_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        if let JsonValue::String(s) = value {
+            Ok(s)
+        } else {
+            Err(json::Error::WrongType(value.to_string()).into())
+        }
+    }
+}
+
+macro_rules! impl_json_via {
+    ($type:ty, $fn:ident) => {
+        impl ToJson for $type {
+            fn to_json(&self) -> JsonValue {
+                (*self).into()
+            }
+        }
+
+        impl FromJson for $type {
+            type Error = json::Error;
+
+            fn from_non_null_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+            where
+                Self: Sized,
+            {
+                Ok(value
+                    .$fn()
+                    .ok_or_else(|| json::Error::WrongType(value.to_string()))?)
+            }
+        }
+    };
+}
+impl_json_via!(u8, as_u8);
+impl_json_via!(u16, as_u16);
+impl_json_via!(u32, as_u32);
+impl_json_via!(u64, as_u64);
+impl_json_via!(bool, as_bool);
+
+macro_rules! impl_json_array {
+    ($type:ty) => {
+        impl<T: ToJson> ToJson for $type {
+            fn to_json(&self) -> JsonValue {
+                JsonValue::Array(self.iter().map(ToJson::to_json).collect())
+            }
+        }
+
+        impl<T: FromJson> FromJson for $type {
+            type Error = T::Error;
+
+            fn from_non_null_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+            where
+                Self: Sized,
+            {
+                if let JsonValue::Array(s) = value {
+                    Ok(s.into_iter().map(FromJson::from_json).collect::<Result<_, _>>()?)
+                } else {
+                    Err(json::Error::WrongType(value.to_string()).into())
+                }
+            }
+        }
+    };
+}
+impl_json_array!(alloc::vec::Vec<T>);
+impl_json_array!(alloc::boxed::Box<[T]>);
+
+impl<T: FromJson, const N: usize> FromJson for [T; N] {
+    type Error = T::Error;
+
+    fn from_non_null_json(value: JsonValue) -> Result<Self, JsonError<Self::Error>>
+    where
+        Self: Sized,
+    {
+        if let JsonValue::Array(s) = value {
+            Ok(s.into_iter()
+                .map(FromJson::from_non_null_json)
+                .collect::<Result<Vec<T>, _>>()?
+                .try_into()
+                .map_err(|e: Vec<T>| JsonError::WrongArraySize {
+                    expected: N,
+                    found: e.len(),
+                })?)
+        } else {
+            Err(json::Error::WrongType(value.to_string()).into())
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! json {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: json!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        $crate::json_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        $crate::json_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)* $crate::json!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)* $crate::json!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)* $crate::json!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)* $crate::json!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)* $crate::json!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)* $crate::json!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        $crate::json!(@array [$($elems,)* $crate::json!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        $crate::json!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        $crate::json_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: json!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        $crate::json!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        $crate::json_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        $crate::json!(@object $object [$($key)+] ($crate::json!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        $crate::json!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        $crate::json!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        $crate::json_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        $crate::json_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        $crate::json_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        $crate::json!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: json!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        ::json::JsonValue::Null
+    };
+
+    (true) => {
+        ::json::JsonValue::Bool(true)
+    };
+
+    (false) => {
+        ::json::JsonValue::Bool(false)
+    };
+
+    ([]) => {
+        ::json::JsonValue::Array(json_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        ::json::JsonValue::Array(json!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        ::json::JsonValue::Object(::json::object::Object::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        ::json::JsonValue::Object({
+            let mut object = ::json::object::Object::new();
+            $crate::json!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        $crate::utils::json::ToJson::to_json(&$other)
+    };
+}
+
+// The json_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to $crate::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/sdk/src/utils/json.rs
+++ b/sdk/src/utils/json.rs
@@ -67,6 +67,16 @@ where
         Self: Sized;
 }
 
+pub trait TakeValue {
+    fn take_value<T: FromJson>(&mut self) -> Result<T, T::Error>;
+}
+
+impl TakeValue for Value {
+    fn take_value<T: FromJson>(&mut self) -> Result<T, T::Error> {
+        T::from_json(self.take())
+    }
+}
+
 impl<T: FromJson> FromJson for Option<T> {
     type Error = T::Error;
 

--- a/sdk/src/utils/json.rs
+++ b/sdk/src/utils/json.rs
@@ -113,6 +113,18 @@ pub trait JsonExt {
     fn to_value<T: FromJson>(&self) -> Result<T, T::Error>;
 
     fn take_value<T: FromJson>(&mut self) -> Result<T, T::Error>;
+
+    fn to_opt<T: FromJson>(&self) -> Result<Option<T>, T::Error>;
+
+    fn to_opt_or_default<T: FromJson + Default>(&self) -> Result<T, T::Error> {
+        Ok(self.to_opt::<T>()?.unwrap_or_default())
+    }
+
+    fn take_opt<T: FromJson>(&mut self) -> Result<Option<T>, T::Error>;
+
+    fn take_opt_or_default<T: FromJson + Default>(&mut self) -> Result<T, T::Error> {
+        Ok(self.take_opt::<T>()?.unwrap_or_default())
+    }
 }
 
 impl JsonExt for Value {
@@ -151,6 +163,14 @@ impl JsonExt for Value {
 
     fn take_value<T: FromJson>(&mut self) -> Result<T, T::Error> {
         T::from_json(self.take())
+    }
+
+    fn to_opt<T: FromJson>(&self) -> Result<Option<T>, T::Error> {
+        self.clone().take_opt()
+    }
+
+    fn take_opt<T: FromJson>(&mut self) -> Result<Option<T>, T::Error> {
+        Option::from_json(self.take())
     }
 }
 

--- a/sdk/src/utils/json/array.rs
+++ b/sdk/src/utils/json/array.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Error, FromJson, ToJson, Value};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ArrayError {
+    WrongSize { expected: usize, found: usize },
+    Item(String),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ArrayError {}
+
+impl core::fmt::Display for ArrayError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::WrongSize { expected, found } => write!(f, "wrong array size: expected {expected}, found {found}"),
+            Self::Item(e) => write!(f, "set item error: {e}"),
+        }
+    }
+}
+
+macro_rules! impl_json_array {
+    ($type:ty) => {
+        impl<T: ToJson> ToJson for $type {
+            fn to_json(&self) -> Value {
+                Value::Array(self.iter().map(ToJson::to_json).collect())
+            }
+        }
+
+        impl<T: FromJson> FromJson for $type
+        where
+            T::Error: core::fmt::Display,
+        {
+            type Error = Error;
+
+            fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+            where
+                Self: Sized,
+            {
+                if let Value::Array(s) = value {
+                    Ok(s.into_iter()
+                        .map(FromJson::from_json)
+                        .collect::<Result<_, T::Error>>()
+                        .map_err(|e| ArrayError::Item(e.to_string()))?)
+                } else {
+                    Err(Error::wrong_type::<T>(value).into())
+                }
+            }
+        }
+    };
+}
+impl_json_array!(alloc::vec::Vec<T>);
+impl_json_array!(alloc::boxed::Box<[T]>);
+
+impl<T: ToJson> ToJson for [T] {
+    fn to_json(&self) -> Value {
+        Value::Array(self.iter().map(ToJson::to_json).collect())
+    }
+}
+
+impl<T: ToJson, const N: usize> ToJson for [T; N] {
+    fn to_json(&self) -> Value {
+        Value::Array(self.iter().map(ToJson::to_json).collect())
+    }
+}
+
+impl<T: FromJson, const N: usize> FromJson for [T; N]
+where
+    T::Error: core::fmt::Display,
+{
+    type Error = Error;
+
+    fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        if let Value::Array(s) = value {
+            Ok(s.into_iter()
+                .map(FromJson::from_json)
+                .collect::<Result<Vec<T>, _>>()
+                .map_err(|e| ArrayError::Item(e.to_string()))?
+                .try_into()
+                .map_err(|e: Vec<T>| ArrayError::WrongSize {
+                    expected: N,
+                    found: e.len(),
+                })?)
+        } else {
+            Err(Error::wrong_type::<[T; N]>(value).into())
+        }
+    }
+}

--- a/sdk/src/utils/json/error.rs
+++ b/sdk/src/utils/json/error.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(Debug, PartialEq, Eq, derive_more::From)]
+pub enum Error {
+    MissingValue(String),
+    WrongType {
+        expected: String,
+        found: String,
+    },
+    InvalidKey {
+        expected: String,
+        found: String,
+    },
+    #[from]
+    Array(super::array::ArrayError),
+    #[from]
+    Set(super::set::SetError),
+    #[from]
+    OrderedSet(super::set::OrderedSetError),
+    Custom(String),
+}
+
+impl Error {
+    pub fn wrong_type<E>(found: impl alloc::string::ToString) -> Self {
+        Self::WrongType {
+            expected: core::any::type_name::<E>().to_owned(),
+            found: found.to_string(),
+        }
+    }
+
+    pub fn invalid_key<K>(found: impl alloc::string::ToString) -> Self {
+        Self::InvalidKey {
+            expected: core::any::type_name::<K>().to_owned(),
+            found: found.to_string(),
+        }
+    }
+
+    pub fn missing_value<V>() -> Self {
+        Self::MissingValue(core::any::type_name::<V>().to_owned())
+    }
+
+    pub fn custom<E: core::fmt::Display>(err: E) -> Self {
+        Self::Custom(err.to_string())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingValue(v) => write!(f, "missing value: {v}"),
+            Self::WrongType { expected, found } => {
+                write!(f, "wrong type: expected {expected}, found {found}")
+            }
+            Self::InvalidKey { expected, found } => {
+                write!(f, "invalid key: expected {expected}, found {found}")
+            }
+            Self::Array(e) => write!(f, "array error: {e}"),
+            Self::Set(e) => write!(f, "set error: {e}"),
+            Self::OrderedSet(e) => write!(f, "ordered set error: {e}"),
+            Self::Custom(e) => e.fmt(f),
+        }
+    }
+}

--- a/sdk/src/utils/json/map.rs
+++ b/sdk/src/utils/json/map.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    set::{OrderedSetError, SetError},
+    Error, FromJson, JsonExt, ToJson, Value,
+};
+
+#[cfg(feature = "std")]
+mod std_hash {
+    use super::*;
+
+    impl<K: ToString, V: ToJson> ToJson for std::collections::HashMap<K, V> {
+        fn to_json(&self) -> Value {
+            let mut obj = json::object::Object::new();
+            for (k, v) in self {
+                obj.insert(&k.to_string(), v.to_json());
+            }
+            Value::Object(obj)
+        }
+    }
+
+    impl<K: core::str::FromStr + Eq + core::hash::Hash, V: FromJson> FromJson for std::collections::HashMap<K, V>
+    where
+        V::Error: core::fmt::Display,
+    {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if let Value::Object(mut obj) = value {
+                let mut map = Self::default();
+                for (k, v) in obj.iter_mut() {
+                    map.insert(
+                        K::from_str(k).map_err(|_| Error::invalid_key::<K>(k))?,
+                        v.take_value::<V>().map_err(|e| SetError::Item(e.to_string()))?,
+                    );
+                }
+                Ok(map)
+            } else {
+                Err(Error::wrong_type::<Self>(value).into())
+            }
+        }
+    }
+}
+
+impl<K: ToString, V: ToJson> ToJson for alloc::collections::BTreeMap<K, V> {
+    fn to_json(&self) -> Value {
+        let mut obj = json::object::Object::new();
+        for (k, v) in self {
+            obj.insert(&k.to_string(), v.to_json());
+        }
+        Value::Object(obj)
+    }
+}
+
+impl<K: core::str::FromStr + Eq + Ord + core::hash::Hash, V: FromJson> FromJson for alloc::collections::BTreeMap<K, V>
+where
+    V::Error: core::fmt::Display,
+{
+    type Error = Error;
+
+    fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        if let Value::Object(mut obj) = value {
+            let mut map = Self::default();
+            for (k_value, v) in obj.iter_mut() {
+                let k = K::from_str(k_value).map_err(|_| Error::invalid_key::<K>(k_value))?;
+                let v = v.take_value::<V>().map_err(|e| SetError::Item(e.to_string()))?;
+                if let Some((last, _)) = map.last_key_value() {
+                    if &k < last {
+                        return Err(Error::OrderedSet(OrderedSetError::Unordered(k_value.to_string())));
+                    }
+                }
+                map.insert(k, v);
+            }
+            Ok(map)
+        } else {
+            Err(Error::wrong_type::<Self>(value).into())
+        }
+    }
+}

--- a/sdk/src/utils/json/set.rs
+++ b/sdk/src/utils/json/set.rs
@@ -1,0 +1,112 @@
+// Copyright 2023 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Error, FromJson, JsonExt, ToJson, Value};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SetError {
+    Duplicate(String),
+    Item(String),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SetError {}
+
+impl core::fmt::Display for SetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Duplicate(i) => write!(f, "duplicate set item: {i}"),
+            Self::Item(e) => write!(f, "set item error: {e}"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, derive_more::From)]
+pub enum OrderedSetError {
+    Unordered(String),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for OrderedSetError {}
+
+impl core::fmt::Display for OrderedSetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unordered(i) => write!(f, "unordered set item: {i}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_hash {
+    use super::*;
+
+    impl<T: ToJson> ToJson for std::collections::HashSet<T> {
+        fn to_json(&self) -> Value {
+            Value::Array(self.iter().map(ToJson::to_json).collect())
+        }
+    }
+
+    impl<T: FromJson + Eq + core::hash::Hash> FromJson for std::collections::HashSet<T>
+    where
+        T::Error: core::fmt::Display,
+    {
+        type Error = Error;
+
+        fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            if let Value::Array(s) = value {
+                let mut set = Self::default();
+                for value in s.into_iter() {
+                    let v = value.to_value::<T>().map_err(|e| SetError::Item(e.to_string()))?;
+                    if !set.insert(v) {
+                        return Err(Error::Set(SetError::Duplicate(value.to_string())));
+                    }
+                }
+                Ok(set)
+            } else {
+                Err(Error::wrong_type::<T>(value).into())
+            }
+        }
+    }
+}
+
+impl<T: ToJson> ToJson for alloc::collections::BTreeSet<T> {
+    fn to_json(&self) -> Value {
+        Value::Array(self.iter().map(ToJson::to_json).collect())
+    }
+}
+
+impl<T: FromJson + Eq + Ord + core::hash::Hash> FromJson for alloc::collections::BTreeSet<T>
+where
+    T::Error: core::fmt::Display,
+{
+    type Error = Error;
+
+    fn from_non_null_json(value: Value) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        if let Value::Array(s) = value {
+            let mut set = Self::default();
+            for value in s.into_iter() {
+                let v = value.to_value::<T>().map_err(|e| SetError::Item(e.to_string()))?;
+                if let Some(last) = set.last() {
+                    match v.cmp(last) {
+                        core::cmp::Ordering::Less => {
+                            return Err(Error::OrderedSet(OrderedSetError::Unordered(value.to_string())));
+                        }
+                        core::cmp::Ordering::Equal => return Err(Error::Set(SetError::Duplicate(value.to_string()))),
+                        _ => (),
+                    }
+                }
+                set.insert(v);
+            }
+            Ok(set)
+        } else {
+            Err(Error::wrong_type::<T>(value).into())
+        }
+    }
+}

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -1,5 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "json")]
+pub mod json;
 #[cfg(feature = "serde")]
 pub mod serde;

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -3,5 +3,5 @@
 
 #[cfg(feature = "json")]
 pub mod json;
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub mod serde;

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -499,12 +499,11 @@ pub struct AccountDetailsDto {
     pub native_token_foundries: HashMap<FoundryId, FoundryOutputDto>,
 }
 
-impl TryFromDto for AccountDetails {
-    type Dto = AccountDetailsDto;
+impl TryFromDto<AccountDetailsDto> for AccountDetails {
     type Error = crate::wallet::Error;
 
     fn try_from_dto_with_params_inner(
-        dto: Self::Dto,
+        dto: AccountDetailsDto,
         params: crate::types::ValidationParams<'_>,
     ) -> core::result::Result<Self, Self::Error> {
         Ok(Self {

--- a/sdk/src/wallet/account/types/address.rs
+++ b/sdk/src/wallet/account/types/address.rs
@@ -64,3 +64,61 @@ impl AddressWithUnspentOutputs {
         self.address
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
+
+    impl ToJson for Bip44Address {
+        fn to_json(&self) -> Value {
+            crate::json!({
+                "address": self.address(),
+                "keyIndex": self.key_index(),
+                "internal": self.internal(),
+            })
+        }
+    }
+
+    impl FromJson for Bip44Address {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self {
+                address: value["address"].take_value()?,
+                key_index: value["keyIndex"].to_u32()?,
+                internal: value["internal"].to_bool()?,
+            })
+        }
+    }
+
+    impl ToJson for AddressWithUnspentOutputs {
+        fn to_json(&self) -> Value {
+            crate::json!({
+                "address": self.address(),
+                "keyIndex": self.key_index(),
+                "internal": self.internal(),
+                "outputIds": self.output_ids()
+            })
+        }
+    }
+
+    impl FromJson for AddressWithUnspentOutputs {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self {
+                address: value["address"].take_value()?,
+                key_index: value["keyIndex"].to_u32()?,
+                internal: value["internal"].to_bool()?,
+                output_ids: value["outputIds"].take_vec()?,
+            })
+        }
+    }
+}

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -131,12 +131,11 @@ impl From<&OutputData> for OutputDataDto {
     }
 }
 
-impl TryFromDto for OutputData {
-    type Dto = OutputDataDto;
+impl TryFromDto<OutputDataDto> for OutputData {
     type Error = BlockError;
 
     fn try_from_dto_with_params_inner(
-        dto: Self::Dto,
+        dto: OutputDataDto,
         params: crate::types::ValidationParams<'_>,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -214,12 +213,11 @@ impl From<&Transaction> for TransactionDto {
     }
 }
 
-impl TryFromDto for Transaction {
-    type Dto = TransactionDto;
+impl TryFromDto<TransactionDto> for Transaction {
     type Error = BlockError;
 
     fn try_from_dto_with_params_inner(
-        dto: Self::Dto,
+        dto: TransactionDto,
         params: crate::types::ValidationParams<'_>,
     ) -> Result<Self, Self::Error> {
         Ok(Self {

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -440,7 +440,7 @@ mod json {
     impl FromJson for InclusionState {
         type Error = crate::types::block::Error;
 
-        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        fn from_non_null_json(value: Value) -> core::result::Result<Self, Self::Error>
         where
             Self: Sized,
         {

--- a/sdk/src/wallet/account/types/mod.rs
+++ b/sdk/src/wallet/account/types/mod.rs
@@ -348,3 +348,114 @@ impl core::fmt::Display for AccountIdentifier {
         }
     }
 }
+
+#[cfg(feature = "json")]
+mod json {
+    use super::*;
+    use crate::utils::json::{FromJson, JsonExt, ToJson, Value};
+
+    impl ToJson for OutputData {
+        fn to_json(&self) -> Value {
+            crate::json!({
+                "outputId": self.output_id,
+                "metadata": self.metadata,
+                "output": self.output,
+                "isSpent": self.is_spent,
+                "address": self.address,
+                "networkId": self.network_id,
+                "remainder": self.remainder,
+                "chain": self.chain,
+            })
+        }
+    }
+
+    impl FromJson for OutputDataDto {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self {
+                output_id: value["outputId"].take_value()?,
+                metadata: value["metadata"].take_value()?,
+                output: value["output"].take_value()?,
+                is_spent: value["isSpent"].take_value()?,
+                address: value["address"].take_value()?,
+                network_id: value["networkId"].take_value()?,
+                remainder: value["remainder"].take_value()?,
+                chain: value["chain"].take_value()?,
+            })
+        }
+    }
+
+    impl ToJson for Transaction {
+        fn to_json(&self) -> Value {
+            crate::json!({
+                "payload": self.payload,
+                "blockId": self.block_id,
+                "inclusionState": self.inclusion_state,
+                "timestamp": self.timestamp,
+                "transactionId": self.transaction_id,
+                "networkId": self.network_id,
+                "incoming": self.incoming,
+                "note": self.note,
+                "inputs": self.inputs
+            })
+        }
+    }
+
+    impl FromJson for TransactionDto {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(Self {
+                payload: value["payload"].take_value()?,
+                block_id: value["blockId"].take_value()?,
+                inclusion_state: value["inclusionState"].take_value()?,
+                timestamp: value["timestamp"].take_value()?,
+                transaction_id: value["transactionId"].take_value()?,
+                network_id: value["networkId"].take_value()?,
+                incoming: value["incoming"].take_value()?,
+                note: value["note"].take_value()?,
+                inputs: value["inputs"].take_value()?,
+            })
+        }
+    }
+
+    impl ToJson for InclusionState {
+        fn to_json(&self) -> Value {
+            crate::json!(match self {
+                InclusionState::Pending => "Pending",
+                InclusionState::Confirmed => "Confirmed",
+                InclusionState::Conflicting => "Conflicting",
+                InclusionState::UnknownPruned => "UnknownPruned",
+            })
+        }
+    }
+
+    impl FromJson for InclusionState {
+        type Error = crate::types::block::Error;
+
+        fn from_non_null_json(mut value: Value) -> core::result::Result<Self, Self::Error>
+        where
+            Self: Sized,
+        {
+            Ok(match value.to_str()? {
+                "Pending" => Self::Pending,
+                "Confirmed" => Self::Confirmed,
+                "Conflicting" => Self::Conflicting,
+                "UnknownPruned" => Self::UnknownPruned,
+                _ => {
+                    return Err(Self::Error::invalid_type::<InclusionState>(
+                        format!("one of {:?}", ["Pending", "Confirmed", "Conflicting", "UnknownPruned"]),
+                        &value,
+                    ));
+                }
+            })
+        }
+    }
+}

--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -284,7 +284,7 @@ fn unlock_unused_inputs(accounts: &mut [AccountDetails]) -> crate::wallet::Resul
     Ok(())
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde_types")]
 pub(crate) mod dto {
     use serde::Deserialize;
 


### PR DESCRIPTION
# Description of change

This PR is a demonstration of a potential alternative serialization impl for json specifically.

If we proceed with the changes across all types, we would
1. remove specialized `serde` impls and simply derive for all types (perhaps with the exception of the IDs, which make sense as strings)
2. Remove `serde` feature from the core requirements
3. Remove all Dto types in favor of the `json!` macro and `ToJson`/`FromJson` impls

## Links to any relevant issues

#1372

# Stats

The below are on `2.0`, NOT this branch


| profile | features | time | lib size |
| --- | --- | --- | --- |
| debug |  | 9.77s | 18.5 MB |
| debug | serde | 11.67s | 30.1 MB |
| release |  | 10.52s | 6 MB |
| release | serde | 13.15s | 13.2 MB |