### PR TITLE
Allow `QueryParameter::UnlockableByAddress` for more routes

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added `SeedSecretManager` to `SecretManagerType`;
+- Added `UnlockableByAddress` to `AliasQueryParameter, NftQueryParameter, QueryParameter`;
 
 ### Removed
 

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.1 - 2023-MM-DD
 
+### Added
+
+- `UnlockableByAddress` to `AliasQueryParameter, NftQueryParameter, QueryParameter`;
+
 ### Fixed
 
 - Added `SeedSecretManager` to `SecretManagerType`;
-- Added `UnlockableByAddress` to `AliasQueryParameter, NftQueryParameter, QueryParameter`;
 
 ### Removed
 

--- a/bindings/nodejs/lib/types/client/query-parameters.ts
+++ b/bindings/nodejs/lib/types/client/query-parameters.ts
@@ -23,6 +23,7 @@ export type QueryParameter =
     | Issuer
     | StateController
     | Governor
+    | UnlockableByAddress
     | CommonQueryParameters;
 
 /** Query parameters for filtering Alias Outputs */
@@ -31,6 +32,7 @@ export type AliasQueryParameter =
     | Governor
     | Issuer
     | Sender
+    | UnlockableByAddress
     | CommonQueryParameters;
 
 /** Query parameters for filtering Foundry Outputs */
@@ -51,6 +53,7 @@ export type NftQueryParameter =
     | Issuer
     | Sender
     | Tag
+    | UnlockableByAddress
     | CommonQueryParameters;
 
 /** Shared query parameters*/

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `QueryParameter::UnlockableByAddress` to allowed query parameters for `Client::{alias_output_ids(), basic_output_ids(), nft_output_ids()}`;
 
+### Changed
+
+- Use `QueryParameter::UnlockableByAddress` for syncing also without default SyncOptions;
+
 ### Fixed
 
 - Update protocol params and addresses with correct bech32 HRP in `Wallet::set_client_options()`;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `QueryParameter::UnlockableByAddress` to allowed query paramaters for `Client::{alias_output_ids(), basic_output_ids(), nft_output_ids()}`;
+- `QueryParameter::UnlockableByAddress` to allowed query parameters for `Client::{alias_output_ids(), basic_output_ids(), nft_output_ids()}`;
 
 ### Fixed
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.1 - 2023-MM-DD
 
+### Added
+
+- Added `QueryParameter::UnlockableByAddress` to allowed query paramaters for `Client::{alias_output_ids(), basic_output_ids(), nft_output_ids()}`;
+
 ### Fixed
 
 - Update protocol params and addresses with correct bech32 HRP in `Wallet::set_client_options()`;

--- a/sdk/src/client/node_api/indexer/query_parameters.rs
+++ b/sdk/src/client/node_api/indexer/query_parameters.rs
@@ -245,7 +245,8 @@ pub(crate) fn verify_query_parameters_basic_outputs(query_parameters: Vec<QueryP
         QueryParameter::CreatedBefore,
         QueryParameter::CreatedAfter,
         QueryParameter::PageSize,
-        QueryParameter::Cursor
+        QueryParameter::Cursor,
+        QueryParameter::UnlockableByAddress
     )?;
 
     Ok(QueryParameters::new(query_parameters))
@@ -264,7 +265,8 @@ pub(crate) fn verify_query_parameters_alias_outputs(query_parameters: Vec<QueryP
         QueryParameter::CreatedBefore,
         QueryParameter::CreatedAfter,
         QueryParameter::PageSize,
-        QueryParameter::Cursor
+        QueryParameter::Cursor,
+        QueryParameter::UnlockableByAddress
     )?;
 
     Ok(QueryParameters::new(query_parameters))
@@ -310,7 +312,8 @@ pub(crate) fn verify_query_parameters_nft_outputs(query_parameters: Vec<QueryPar
         QueryParameter::CreatedBefore,
         QueryParameter::CreatedAfter,
         QueryParameter::PageSize,
-        QueryParameter::Cursor
+        QueryParameter::Cursor,
+        QueryParameter::UnlockableByAddress
     )?;
 
     Ok(QueryParameters::new(query_parameters))

--- a/sdk/src/wallet/account/operations/syncing/addresses/output_ids/alias_foundry.rs
+++ b/sdk/src/wallet/account/operations/syncing/addresses/output_ids/alias_foundry.rs
@@ -3,9 +3,6 @@
 
 use std::collections::HashSet;
 
-#[cfg(not(target_family = "wasm"))]
-use futures::FutureExt;
-
 use crate::{
     client::{node_api::indexer::query_parameters::QueryParameter, secret::SecretManage},
     types::{
@@ -33,63 +30,13 @@ where
         sync_options: &SyncOptions,
     ) -> crate::wallet::Result<Vec<OutputId>> {
         log::debug!("[SYNC] get_alias_and_foundry_output_ids");
-        let client = self.client();
         let bech32_address = bech32_address.convert()?;
 
-        let mut output_ids = HashSet::new();
-
-        #[cfg(target_family = "wasm")]
-        {
-            output_ids.extend(
-                client
-                    .alias_output_ids([QueryParameter::Governor(bech32_address)])
-                    .await?
-                    .items,
-            );
-            output_ids.extend(
-                client
-                    .alias_output_ids([QueryParameter::StateController(bech32_address)])
-                    .await?
-                    .items,
-            );
-        }
-
-        #[cfg(not(target_family = "wasm"))]
-        {
-            let tasks = [
-                // Get outputs where the address is in the governor address unlock condition
-                async move {
-                    let client = client.clone();
-                    task::spawn(async move {
-                        client
-                            .alias_output_ids([QueryParameter::Governor(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-                // Get outputs where the address is in the state controller unlock condition
-                async move {
-                    let client = client.clone();
-                    task::spawn(async move {
-                        client
-                            .alias_output_ids([QueryParameter::StateController(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-            ];
-
-            let results: Vec<crate::wallet::Result<OutputIdsResponse>> = futures::future::try_join_all(tasks).await?;
-
-            for res in results {
-                let found_output_ids = res?;
-                output_ids.extend(found_output_ids.items);
-            }
-        }
+        let mut output_ids = self
+            .client()
+            .alias_output_ids([QueryParameter::UnlockableByAddress(bech32_address)])
+            .await?
+            .items;
 
         // Get all results
         if sync_options.alias.foundry_outputs {
@@ -103,11 +50,11 @@ where
     /// Returns output ids of foundries controlled by the provided aliases
     pub(crate) async fn get_foundry_output_ids(
         &self,
-        alias_output_ids: &HashSet<OutputId>,
+        alias_output_ids: &[OutputId],
     ) -> crate::wallet::Result<Vec<OutputId>> {
         log::debug!("[SYNC] get_foundry_output_ids");
         // Get alias outputs, so we can then get the foundry outputs with the alias addresses
-        let alias_outputs_with_meta = self.get_outputs(alias_output_ids.iter().copied().collect()).await?;
+        let alias_outputs_with_meta = self.get_outputs(alias_output_ids.to_vec()).await?;
 
         let bech32_hrp = self.client().get_bech32_hrp().await?;
 

--- a/sdk/src/wallet/account/operations/syncing/addresses/output_ids/basic.rs
+++ b/sdk/src/wallet/account/operations/syncing/addresses/output_ids/basic.rs
@@ -1,14 +1,6 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(target_family = "wasm"))]
-use std::collections::HashSet;
-
-#[cfg(not(target_family = "wasm"))]
-use futures::FutureExt;
-
-#[cfg(not(target_family = "wasm"))]
-use crate::types::api::plugins::indexer::OutputIdsResponse;
 use crate::{
     client::{node_api::indexer::query_parameters::QueryParameter, secret::SecretManage},
     types::block::{address::Bech32Address, output::OutputId, ConvertTo},
@@ -45,84 +37,11 @@ where
         bech32_address: impl ConvertTo<Bech32Address>,
     ) -> crate::wallet::Result<Vec<OutputId>> {
         let bech32_address = bech32_address.convert()?;
-        // aliases and foundries
-        #[cfg(target_family = "wasm")]
-        {
-            let mut output_ids = Vec::new();
-            output_ids.extend(
-                self.client()
-                    .basic_output_ids([QueryParameter::Address(bech32_address)])
-                    .await?
-                    .items,
-            );
-            output_ids.extend(
-                self.client()
-                    .basic_output_ids([QueryParameter::StorageDepositReturnAddress(bech32_address)])
-                    .await?
-                    .items,
-            );
-            output_ids.extend(
-                self.client()
-                    .basic_output_ids([QueryParameter::ExpirationReturnAddress(bech32_address)])
-                    .await?
-                    .items,
-            );
 
-            Ok(output_ids)
-        }
-
-        #[cfg(not(target_family = "wasm"))]
-        {
-            let client = self.client();
-            let tasks = [
-                // Get basic outputs
-                async move {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        client
-                            .basic_output_ids([QueryParameter::Address(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-                // Get outputs where the address is in the storage deposit return unlock condition
-                async move {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        client
-                            .basic_output_ids([QueryParameter::StorageDepositReturnAddress(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-                // Get outputs where the address is in an expired expiration unlock condition
-                async move {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        client
-                            .basic_output_ids([QueryParameter::ExpirationReturnAddress(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-            ];
-
-            // Get all results
-            let mut output_ids = HashSet::new();
-            let results: Vec<crate::wallet::Result<OutputIdsResponse>> = futures::future::try_join_all(tasks).await?;
-
-            for res in results {
-                let found_output_ids = res?;
-                output_ids.extend(found_output_ids.items);
-            }
-
-            Ok(output_ids.into_iter().collect())
-        }
+        Ok(self
+            .client()
+            .basic_output_ids([QueryParameter::UnlockableByAddress(bech32_address)])
+            .await?
+            .items)
     }
 }

--- a/sdk/src/wallet/account/operations/syncing/addresses/output_ids/nft.rs
+++ b/sdk/src/wallet/account/operations/syncing/addresses/output_ids/nft.rs
@@ -1,14 +1,6 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(target_family = "wasm"))]
-use std::collections::HashSet;
-
-#[cfg(not(target_family = "wasm"))]
-use futures::FutureExt;
-
-#[cfg(not(target_family = "wasm"))]
-use crate::types::api::plugins::indexer::OutputIdsResponse;
 use crate::{
     client::{node_api::indexer::query_parameters::QueryParameter, secret::SecretManage},
     types::block::{address::Bech32Address, output::OutputId, ConvertTo},
@@ -25,82 +17,11 @@ where
         bech32_address: impl ConvertTo<Bech32Address>,
     ) -> crate::wallet::Result<Vec<OutputId>> {
         let bech32_address = bech32_address.convert()?;
-        #[cfg(target_family = "wasm")]
-        {
-            let mut output_ids = Vec::new();
-            output_ids.extend(
-                self.client()
-                    .nft_output_ids([QueryParameter::Address(bech32_address)])
-                    .await?
-                    .items,
-            );
-            output_ids.extend(
-                self.client()
-                    .nft_output_ids([QueryParameter::StorageDepositReturnAddress(bech32_address)])
-                    .await?
-                    .items,
-            );
-            output_ids.extend(
-                self.client()
-                    .nft_output_ids([QueryParameter::ExpirationReturnAddress(bech32_address)])
-                    .await?
-                    .items,
-            );
 
-            Ok(output_ids)
-        }
-        #[cfg(not(target_family = "wasm"))]
-        {
-            let client = self.client();
-            let tasks = [
-                async move {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        // Get nft outputs where the address is in the address unlock condition
-                        client
-                            .nft_output_ids([QueryParameter::Address(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-                async move {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        // Get outputs where the address is in the storage deposit return unlock condition
-                        client
-                            .nft_output_ids([QueryParameter::StorageDepositReturnAddress(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-                async move {
-                    let client = client.clone();
-                    tokio::spawn(async move {
-                        // Get outputs where the address is in the expiration unlock condition
-                        client
-                            .nft_output_ids([QueryParameter::ExpirationReturnAddress(bech32_address)])
-                            .await
-                            .map_err(From::from)
-                    })
-                    .await
-                }
-                .boxed(),
-            ];
-
-            // Get all results
-            let mut output_ids = HashSet::new();
-            let results: Vec<crate::wallet::Result<OutputIdsResponse>> = futures::future::try_join_all(tasks).await?;
-
-            for res in results {
-                let found_output_ids = res?;
-                output_ids.extend(found_output_ids.items);
-            }
-
-            Ok(output_ids.into_iter().collect())
-        }
+        Ok(self
+            .client()
+            .nft_output_ids([QueryParameter::UnlockableByAddress(bech32_address)])
+            .await?
+            .items)
     }
 }


### PR DESCRIPTION
# Description of change

Added `QueryParameter::UnlockableByAddress` to allowed query paramaters for `Client::{alias_output_ids(), basic_output_ids(), nft_output_ids()}` since this is now allowed by the indexer https://github.com/iotaledger/tips/commit/0dd6217a49c7940ee1191ab05b09d4fa6cbff86b

Also changed the syncing in the wallet to make use of it

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/1269

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Running an example with
```Rust
    let output_ids_response = client
        .alias_output_ids([QueryParameter::UnlockableByAddress(address)])
        .await?;
```
and also synced a wallet with
```Rust
SyncOptions {
            nft: NftSyncOptions {
                basic_outputs: true,
                ..Default::default()
            },
            ..Default::default()
        }
```
