### PR TITLE
Added pip install iota-sdk to python readme as first option

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -75,7 +75,7 @@ Python binding to the [iota-sdk library](/README.md).
    .\env\Scripts\activate`
    ```
 
-3. Install the IOTA:
+3. Install the required dependencies and build the wheel by running the following commands:
 
    ```bash
    pip install -r requirements-dev.txt

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -8,7 +8,7 @@ Python binding to the [iota-sdk library](/README.md).
   - [Table of contents](#table-of-contents)
   - [Requirements](#requirements)
   - [Getting Started](#getting-started)
-    - [Install the IOTA SDK via pip](#install-the-iota-sdk-via-pip)
+    - [Install the IOTA SDK via pip](#install-iota-sdk-via-pip)
     - [Install the IOTA SDK](#install-the-iota-sdk)
   - [Client](#client-usage)
   - [Wallet](#wallet-usage)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -24,6 +24,34 @@ Python binding to the [iota-sdk library](/README.md).
 
 ## Getting Started
 
+### Install IOTA SDK via pip
+
+1. (optional) Create a virtual environment and use it. On Linux and macOS, you can run the following commands:
+
+   ```bash
+   python3 -m venv env
+   source env/bin/activate
+   ```
+
+   If you are using Windows, you should run the following instead:
+
+   ```bash
+   python3 -m venv env
+   .\env\Scripts\activate`
+   ```
+
+2. Install the IOTA-SDK using pip:
+
+   ```bash
+   pip install iota-sdk
+   ```
+
+3. (optional) If you want to deactivate the virtual environment, run the following command:
+
+   ```bash
+   deactivate
+   ```
+
 ### Install the IOTA SDK
 
 1. Move to the Python bindings directory:
@@ -46,7 +74,7 @@ Python binding to the [iota-sdk library](/README.md).
    .\env\Scripts\activate`
    ```
 
-3. Install the required dependencies and build the wheel by running the following commands:
+3. Install the IOTA:
 
    ```bash
    pip install -r requirements-dev.txt

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -8,6 +8,7 @@ Python binding to the [iota-sdk library](/README.md).
   - [Table of contents](#table-of-contents)
   - [Requirements](#requirements)
   - [Getting Started](#getting-started)
+    - [Install the IOTA SDK via pip](#install-the-iota-sdk-via-pip)
     - [Install the IOTA SDK](#install-the-iota-sdk)
   - [Client](#client-usage)
   - [Wallet](#wallet-usage)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -38,7 +38,7 @@ Python binding to the [iota-sdk library](/README.md).
 
    ```bash
    python3 -m venv env
-   .\env\Scripts\activate`
+   .\env\Scripts\activate
    ```
 
 2. Install the IOTA-SDK using pip:
@@ -72,7 +72,7 @@ Python binding to the [iota-sdk library](/README.md).
 
    ```bash
    python3 -m venv env
-   .\env\Scripts\activate`
+   .\env\Scripts\activate
    ```
 
 3. Install the required dependencies and build the wheel by running the following commands:


### PR DESCRIPTION
# Description of change

Added pip install iota-sdk to python readme for the ease of installation to the user. 

## Links to any relevant issues

fixes #1396

## Type of change

- Documentation Fix


## Change checklist


- [x] I have followed the contribution guidelines for this project

