### PR TITLE
Python: add Utils::transaction_id()

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.1.1 - 2023-MM-DD
+
+### Added
+
+- `Utils:transaction_id()`;
+
 ## 1.1.0 - 2023-09-29
 
 Stable release.

--- a/bindings/python/examples/exchange/1_create_account.py
+++ b/bindings/python/examples/exchange/1_create_account.py
@@ -14,7 +14,8 @@ from iota_sdk import (ClientOptions, CoinType, StrongholdSecretManager,
 # should not be done in production.
 load_dotenv()
 
-for env_var in ['WALLET_DB_PATH', 'NODE_URL', 'STRONGHOLD_SNAPSHOT_PATH', 'STRONGHOLD_PASSWORD', 'MNEMONIC']:
+for env_var in ['WALLET_DB_PATH', 'NODE_URL',
+                'STRONGHOLD_SNAPSHOT_PATH', 'STRONGHOLD_PASSWORD', 'MNEMONIC']:
     if env_var not in os.environ:
         raise Exception(f'.env {env_var} is undefined, see .env.example')
 

--- a/bindings/python/iota_sdk/utils.py
+++ b/bindings/python/iota_sdk/utils.py
@@ -8,6 +8,7 @@ from iota_sdk.types.address import Address, AddressType, Ed25519Address, AliasAd
 from iota_sdk.types.common import HexStr
 from iota_sdk.types.output_id import OutputId
 from iota_sdk.types.output import Output
+from iota_sdk.types.payload import TransactionPayload
 from json import dumps, loads
 from typing import TYPE_CHECKING, List
 from dacite import from_dict
@@ -174,6 +175,14 @@ class Utils():
         """
         return _call_method('blockId', {
             'block': block.as_dict()
+        })
+
+    @staticmethod
+    def transaction_id(transaction_payload: TransactionPayload) -> HexStr:
+        """ Compute the transaction ID (Blake2b256 hash of the provided transaction payload) of a transaction payload.
+        """
+        return _call_method('transactionId', {
+            'payload': transaction_payload.as_dict()
         })
 
     @staticmethod

--- a/bindings/python/tests/test_offline.py
+++ b/bindings/python/tests/test_offline.py
@@ -58,11 +58,13 @@ class TestTypes(unittest.TestCase):
         transaction_id = '0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649'
         output_index = 42
         output_id = OutputId(transaction_id, output_index)
-        assert repr(output_id) == '0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6492a00'
+        assert repr(
+            output_id) == '0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6492a00'
 
         new_output_id = OutputId.from_string(
             '0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6492a00')
-        assert repr(new_output_id) == '0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6492a00'
+        assert repr(
+            new_output_id) == '0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c6492a00'
         assert new_output_id.transaction_id == transaction_id
         assert new_output_id.output_index == output_index
 


### PR DESCRIPTION
# Description of change

Add Utils::transaction_id() since it was missing

## Links to any relevant issues

Closes #1270 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

```py
from iota_sdk import Client, Utils


client = Client(nodes=['https://api.testnet.shimmer.network'])

block = client.get_block_data(
    '0xbc2c78e637e65a6a26877accdb847db2ca9ceeb43565337eaa1726ca3a3a5ede')
print(f'Transaction id: {Utils.transaction_id(block.payload)}')
```