### PR TITLE
Fix `migrate_db_chrysalis_to_stardust()` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anymap",
  "async-trait",

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.1.1 - 2023-MM-DD
+## 1.1.1 - 2023-10-11
 
 ### Added
 

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added `SeedSecretManager` to `SecretManagerType`;
+- `migrateDbChrysalisToStardust()` for some ledger nano wallets;
 
 ### Removed
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update protocol params and addresses with correct bech32 HRP in `Wallet::set_client_options()`;
+- `migrate_db_chrysalis_to_stardust()` for some ledger nano wallets;
 
 ## 1.1.0 - 2023-09-29
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.1.1 - 2023-MM-DD
+## 1.1.1 - 2023-10-11
 
 ### Added
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-sdk"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "The IOTA SDK provides developers with a seamless experience to develop on IOTA by providing account abstractions and clients to interact with node APIs."

--- a/sdk/src/wallet/migration/chrysalis.rs
+++ b/sdk/src/wallet/migration/chrysalis.rs
@@ -319,7 +319,9 @@ pub(crate) mod rocksdb {
                 let value_utf8 =
                     String::from_utf8(value.to_vec()).map_err(|_| Error::Migration("invalid utf8".into()))?;
                 // "iota-wallet-key-checksum_value" is never an encrypted value
-                if key_utf8 == "iota-wallet-key-checksum_value" {
+                // "FIRST_LEDGER_ADDRESS" was at some point not re-encrypted with the correct password and should
+                // therefore also be ignored to not return an error
+                if key_utf8 == "iota-wallet-key-checksum_value" || key_utf8 == "FIRST_LEDGER_ADDRESS" {
                     value_utf8
                 } else if let Ok(value) = serde_json::from_str::<Vec<u8>>(&value_utf8) {
                     decrypt_record(value, encryption_key)?


### PR DESCRIPTION
# Description of change

Fix `migrate_db_chrysalis_to_stardust()` for some ledger nano wallets

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Migrating a db which failed before because the first ledger address was encrypted with another password
