### PR TITLE
Add first draft of upload workflow

### DIFF
--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -1,25 +1,77 @@
 name: Build and upload API docs
 
 on:
-  push:
-    branches: [develop, staging]
+  release:
+    types: [published]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-root: bindings/nodejs
+
+      - name: Set Up Node.js 18 and Yarn Cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: yarn
+          cache-dependency-path: bindings/nodejs/yarn.lock
+
+      - name: Install Required Dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
+
+      - name: Echo tag
+        run: echo ${{ github.ref }}
+
+      - name: Get release language
+        id: get_release_language
+        run: |
+          if [[ ${{ github.ref }} == *"python"* ]]; then
+            echo LANGUAGE="python" >> $GITHUB_OUTPUT
+          fi
+          if [[ ${{ github.ref }} == *"nodejs"* ]]; then
+            echo LANGUAGE="nodejs" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get release version
+        id: get_release_version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e 's/.*v\([0-9]*\.[0-9]*\).*/\1/')
+          echo VERSION=$VERSION >> $GITHUB_OUTPUT
+      
       - name: Build python docs
+        if: steps.get_release_language.outputs.LANGUAGE == 'python'
         run: |
           cd bindings/python
           pip install -r requirements-dev.txt
           PYTHONPATH=. pydoc-markdown
-          cd - 
+          cd -
+
       - name: Build nodejs docs
+        if: steps.get_release_language.outputs.LANGUAGE == 'nodejs'
         run: |
           cd bindings/nodejs
           # The SDK still uses yarn classic: https://github.com/iotaledger/iota-sdk/issues/433
           yarn set version classic
           yarn
-          yarn create-api-docs --out ../../docs/references/nodejs
+          yarn create-api-docs --out ../../docs/nodejs
           cd -
+
+      - name: Compress generated docs
+        run: |
+          tar czvf ${{ steps.get_release_language.outputs.LANGUAGE }}.tar.gz docs/*
+
+      - name: Upload docs to AWS S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_IOTA_WIKI }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_IOTA_WIKI }}
+          AWS_DEFAULT_REGION: "eu-central-1"
+        run: |
+          aws s3 cp ${{ steps.get_release_language.outputs.LANGUAGE }}.tar.gz s3://files.iota.org/iota-wiki/iota-sdk/${{ steps.get_release_version.outputs.VERSION }}/ --acl public-read

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -1,0 +1,25 @@
+name: Build and upload API docs
+
+on:
+  push:
+    branches: [develop, staging]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build python docs
+        run: |
+          cd bindings/python
+          pip install -r requirements-dev.txt
+          PYTHONPATH=. pydoc-markdown
+          cd - 
+      - name: Build nodejs docs
+        run: |
+          cd bindings/nodejs
+          # The SDK still uses yarn classic: https://github.com/iotaledger/iota-sdk/issues/433
+          yarn set version classic
+          yarn
+          yarn create-api-docs --out ../../docs/references/nodejs
+          cd -

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -32,15 +32,11 @@ jobs:
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
-        with:
-          cache-root: bindings/nodejs
 
       - name: Set Up Node.js 18 and Yarn Cache
         uses: actions/setup-node@v3
         with:
           node-version: "18"
-          cache: yarn
-          cache-dependency-path: bindings/nodejs/yarn.lock
 
       - name: Install Required Dependencies (Ubuntu)
         run: |

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -4,11 +4,31 @@ on:
   release:
     types: [published]
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
+permissions:
+  actions: 'write'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get release language
+        id: get_release_language
+        run: |
+          if [[ ${{ github.ref }} == *"python"* ]]; then
+            echo LANGUAGE="python" >> $GITHUB_OUTPUT
+          fi
+          if [[ ${{ github.ref }} == *"nodejs"* ]]; then
+            echo LANGUAGE="nodejs" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if release language is supported
+        if: steps.get_release_language.outputs.LANGUAGE != 'python' && steps.get_release_language.outputs.LANGUAGE != 'nodejs'
+        run: gh run cancel ${{ github.run_id }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -26,19 +46,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
-
-      - name: Echo tag
-        run: echo ${{ github.ref }}
-
-      - name: Get release language
-        id: get_release_language
-        run: |
-          if [[ ${{ github.ref }} == *"python"* ]]; then
-            echo LANGUAGE="python" >> $GITHUB_OUTPUT
-          fi
-          if [[ ${{ github.ref }} == *"nodejs"* ]]; then
-            echo LANGUAGE="nodejs" >> $GITHUB_OUTPUT
-          fi
 
       - name: Get release version
         id: get_release_version

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ address.json
 .DS_Store
 book
 .venv*
+
+# Temporary documentation
+/docs

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ book
 .venv*
 
 # Temporary documentation
-/docs
+docs

--- a/bindings/python/pydoc-markdown.yml
+++ b/bindings/python/pydoc-markdown.yml
@@ -9,7 +9,7 @@ processors:
 renderer:
   type: docusaurus
   docs_base_path: ../../docs/
-  relative_output_path: references/python
+  relative_output_path: python
 
   markdown:
     use_fixed_header_levels: true

--- a/bindings/python/pydoc-markdown.yml
+++ b/bindings/python/pydoc-markdown.yml
@@ -8,7 +8,7 @@ processors:
   - type: crossref
 renderer:
   type: docusaurus
-  docs_base_path: ./docs/
+  docs_base_path: ../../docs/
   relative_output_path: references/python
 
   markdown:


### PR DESCRIPTION
# Description of change

This workflow will build and upload the API docs to s3. This keeps all the needed logic in the SDK and reduced wiki build time and complexity.

It will be triggered with every new release.

## Type of change

- Documentation Fix

## How the change has been tested

I tested the workflow by releasing our 2.0 version :trollface: 
https://github.com/Dr-Electron/iota-sdk/releases

The succeeded workflow can be found [here](https://github.com/Dr-Electron/iota-sdk/actions/workflows/upload-docs.yml). The links for to download the reference docs can be found in the `Upload docs to AWS S3` step.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
