### PR TITLE
feat(cli): output selector

### DIFF
--- a/bindings/core/src/method_handler/account.rs
+++ b/bindings/core/src/method_handler/account.rs
@@ -89,7 +89,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
         }
         #[cfg(feature = "participation")]
         AccountMethod::GetVotingPower => {
-            let voting_power = account.get_voting_power().await?;
+            let voting_power = account.get_voting_power().await;
             Response::VotingPower(voting_power.to_string())
         }
         AccountMethod::IncomingTransactions => {
@@ -97,7 +97,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
             Response::Transactions(transactions.iter().map(TransactionDto::from).collect())
         }
         AccountMethod::Outputs { filter_options } => {
-            let outputs = account.outputs(filter_options).await?;
+            let outputs = account.outputs(filter_options).await;
             Response::OutputsData(outputs.iter().map(OutputDataDto::from).collect())
         }
         AccountMethod::PendingTransactions => {
@@ -284,7 +284,7 @@ pub(crate) async fn call_account_method_internal(account: &Account, method: Acco
             Response::Transactions(transactions.iter().map(TransactionDto::from).collect())
         }
         AccountMethod::UnspentOutputs { filter_options } => {
-            let outputs = account.unspent_outputs(filter_options).await?;
+            let outputs = account.unspent_outputs(filter_options).await;
             Response::OutputsData(outputs.iter().map(OutputDataDto::from).collect())
         }
     };

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -167,7 +167,7 @@ pub async fn account_prompt_internal(
                         }
                         AccountCommand::NewAddress => new_address_command(account).await,
                         AccountCommand::NodeInfo => node_info_command(account).await,
-                        AccountCommand::Output { output_id } => output_command(account, output_id).await,
+                        AccountCommand::Output { selector } => output_command(account, selector).await,
                         AccountCommand::Outputs => outputs_command(account).await,
                         AccountCommand::Send {
                             address,

--- a/sdk/examples/how_tos/account/governance_transition.rs
+++ b/sdk/examples/how_tos/account/governance_transition.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
 
     let account_output_data = account
         .unspent_account_output(account_id)
-        .await?
+        .await
         .expect("account not found in unspent outputs");
     println!(
         "Account '{account_id}' found in unspent output: '{}'",

--- a/sdk/examples/how_tos/account/state_transition.rs
+++ b/sdk/examples/how_tos/account/state_transition.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
 
     let account_output_data = account
         .unspent_account_output(account_id)
-        .await?
+        .await
         .expect("account not found in unspent outputs");
     println!(
         "Account '{account_id}' found in unspent output: '{}'",

--- a/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     // unlock condition and it is an `AddressUnlockCondition`, and so they are valid for consolidation. They have the
     // same `AddressUnlockCondition`(the first address of the account), so they will be consolidated into one
     // output.
-    let outputs = account.unspent_outputs(None).await?;
+    let outputs = account.unspent_outputs(None).await;
     println!("Outputs BEFORE consolidation:");
     outputs.iter().enumerate().for_each(|(i, output_data)| {
         println!("OUTPUT #{i}");
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
     println!("Account synced");
 
     // Outputs after consolidation
-    let outputs = account.unspent_outputs(None).await?;
+    let outputs = account.unspent_outputs(None).await;
     println!("Outputs AFTER consolidation:");
     outputs.iter().enumerate().for_each(|(i, output_data)| {
         println!("OUTPUT #{i}");

--- a/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
@@ -26,13 +26,13 @@ async fn main() -> Result<()> {
 
     // Print output ids
     println!("Output ids:");
-    for output in account.outputs(None).await? {
+    for output in account.outputs(None).await {
         println!("{}", output.output_id);
     }
 
     // Print unspent output ids
     println!("Unspent output ids:");
-    for output in account.unspent_outputs(None).await? {
+    for output in account.unspent_outputs(None).await {
         println!("{}", output.output_id);
     }
 

--- a/sdk/examples/wallet/participation.rs
+++ b/sdk/examples/wallet/participation.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
     println!("Account synced");
     println!("New voting power: {}", balance.base_coin().voting_power());
 
-    let voting_output = account.get_voting_output().await?.unwrap();
+    let voting_output = account.get_voting_output().await.unwrap();
     println!("Voting output:\n{:#?}", voting_output.output);
 
     ////////////////////////////////////////////////
@@ -226,7 +226,7 @@ async fn main() -> Result<()> {
     // destroy voting output
     ////////////////////////////////////////////////
 
-    let voting_output = account.get_voting_output().await?.unwrap();
+    let voting_output = account.get_voting_output().await.unwrap();
     println!("Voting output: {:?}", voting_output.output);
 
     // Decrease full amount, there should be no voting output afterwards
@@ -246,7 +246,7 @@ async fn main() -> Result<()> {
     account.sync(None).await?;
     println!("Account synced");
 
-    assert!(account.get_voting_output().await.is_err());
+    assert!(account.get_voting_output().await.is_none());
 
     Ok(())
 }

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
             output_types: Some(vec![BasicOutput::KIND]),
             ..Default::default()
         })
-        .await?
+        .await
         .iter()
         .filter(|data| data.output.amount() >= SEND_AMOUNT)
         .count();

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -314,11 +314,12 @@ impl AccountInner {
         Ok(self.details().await.addresses_with_unspent_outputs().to_vec())
     }
 
+    // TODO: why was this returning a `Result` despite nothing actually possible to fail?
     fn filter_outputs<'a>(
         &self,
         outputs: impl Iterator<Item = &'a OutputData>,
         filter: impl Into<Option<FilterOptions>>,
-    ) -> Result<Vec<OutputData>> {
+    ) -> Vec<OutputData> {
         let filter = filter.into();
 
         if let Some(filter) = filter {
@@ -380,50 +381,53 @@ impl AccountInner {
                 }
             }
 
-            Ok(filtered_outputs)
+            filtered_outputs
         } else {
-            Ok(outputs.cloned().collect())
+            outputs.cloned().collect()
         }
     }
 
     /// Returns outputs of the account
-    pub async fn outputs(&self, filter: impl Into<Option<FilterOptions>> + Send) -> Result<Vec<OutputData>> {
+    pub async fn outputs(&self, filter: impl Into<Option<FilterOptions>> + Send) -> Vec<OutputData> {
         self.filter_outputs(self.details().await.outputs.values(), filter)
     }
 
     /// Returns unspent outputs of the account
-    pub async fn unspent_outputs(&self, filter: impl Into<Option<FilterOptions>> + Send) -> Result<Vec<OutputData>> {
+    pub async fn unspent_outputs(&self, filter: impl Into<Option<FilterOptions>> + Send) -> Vec<OutputData> {
         self.filter_outputs(self.details().await.unspent_outputs.values(), filter)
     }
 
     /// Gets the unspent account output matching the given ID.
-    pub async fn unspent_account_output(&self, account_id: &AccountId) -> Result<Option<OutputData>> {
+    pub async fn unspent_account_output(&self, account_id: &AccountId) -> Option<OutputData> {
         self.unspent_outputs(FilterOptions {
             account_ids: Some([*account_id].into()),
             ..Default::default()
         })
         .await
-        .map(|res| res.get(0).cloned())
+        .get(0)
+        .cloned()
     }
 
     /// Gets the unspent foundry output matching the given ID.
-    pub async fn unspent_foundry_output(&self, foundry_id: &FoundryId) -> Result<Option<OutputData>> {
+    pub async fn unspent_foundry_output(&self, foundry_id: &FoundryId) -> Option<OutputData> {
         self.unspent_outputs(FilterOptions {
             foundry_ids: Some([*foundry_id].into()),
             ..Default::default()
         })
         .await
-        .map(|res| res.get(0).cloned())
+        .get(0)
+        .cloned()
     }
 
     /// Gets the unspent nft output matching the given ID.
-    pub async fn unspent_nft_output(&self, nft_id: &NftId) -> Result<Option<OutputData>> {
+    pub async fn unspent_nft_output(&self, nft_id: &NftId) -> Option<OutputData> {
         self.unspent_outputs(FilterOptions {
             nft_ids: Some([*nft_id].into()),
             ..Default::default()
         })
         .await
-        .map(|res| res.get(0).cloned())
+        .get(0)
+        .cloned()
     }
 
     /// Returns all incoming transactions of the account

--- a/sdk/src/wallet/account/operations/balance.rs
+++ b/sdk/src/wallet/account/operations/balance.rs
@@ -69,7 +69,7 @@ where
         let mut total_native_tokens = NativeTokensBuilder::default();
 
         #[cfg(feature = "participation")]
-        let voting_output = self.get_voting_output().await?;
+        let voting_output = self.get_voting_output().await;
 
         for address_with_unspent_outputs in addresses_with_unspent_outputs {
             #[cfg(feature = "participation")]

--- a/sdk/src/wallet/account/operations/output_claiming.rs
+++ b/sdk/src/wallet/account/operations/output_claiming.rs
@@ -131,7 +131,7 @@ where
     pub(crate) async fn get_basic_outputs_for_additional_inputs(&self) -> crate::wallet::Result<Vec<OutputData>> {
         log::debug!("[OUTPUT_CLAIMING] get_basic_outputs_for_additional_inputs");
         #[cfg(feature = "participation")]
-        let voting_output = self.get_voting_output().await?;
+        let voting_output = self.get_voting_output().await;
         let account_details = self.details().await;
 
         // Get basic outputs only with AddressUnlockCondition and no other unlock condition

--- a/sdk/src/wallet/account/operations/output_consolidation.rs
+++ b/sdk/src/wallet/account/operations/output_consolidation.rs
@@ -126,7 +126,7 @@ where
     pub async fn prepare_consolidate_outputs(&self, params: ConsolidationParams) -> Result<PreparedTransactionData> {
         log::debug!("[OUTPUT_CONSOLIDATION] prepare consolidating outputs if needed");
         #[cfg(feature = "participation")]
-        let voting_output = self.get_voting_output().await?;
+        let voting_output = self.get_voting_output().await;
         let slot_index = self.client().get_slot_index().await?;
         let token_supply = self.client().get_token_supply().await?;
         let mut outputs_to_consolidate = Vec::new();

--- a/sdk/src/wallet/account/operations/participation/mod.rs
+++ b/sdk/src/wallet/account/operations/participation/mod.rs
@@ -74,7 +74,7 @@ where
             "[get_participation_overview] restored_spent_cached_outputs_len: {}",
             restored_spent_cached_outputs_len
         );
-        let outputs = self.outputs(None).await?;
+        let outputs = self.outputs(None).await;
         let participation_outputs = outputs
             .into_iter()
             .filter(|output_data| {
@@ -230,15 +230,14 @@ where
     /// Returns the voting output ("PARTICIPATION" tag).
     ///
     /// If multiple outputs with this tag exist, the one with the largest amount will be returned.
-    pub async fn get_voting_output(&self) -> Result<Option<OutputData>> {
+    pub async fn get_voting_output(&self) -> Option<OutputData> {
         log::debug!("[get_voting_output]");
-        Ok(self
-            .unspent_outputs(None)
-            .await?
+        self.unspent_outputs(None)
+            .await
             .iter()
             .filter(|output_data| is_valid_participation_output(&output_data.output))
             .max_by_key(|output_data| output_data.output.amount())
-            .cloned())
+            .cloned()
     }
 
     /// Gets client for an event.

--- a/sdk/src/wallet/account/operations/participation/voting.rs
+++ b/sdk/src/wallet/account/operations/participation/voting.rs
@@ -67,7 +67,7 @@ where
 
         let voting_output = self
             .get_voting_output()
-            .await?
+            .await
             .ok_or_else(|| crate::wallet::Error::Voting("No unspent voting output found".to_string()))?;
         let output = voting_output.output.as_basic();
 
@@ -143,7 +143,7 @@ where
     pub async fn prepare_stop_participating(&self, event_id: ParticipationEventId) -> Result<PreparedTransactionData> {
         let voting_output = self
             .get_voting_output()
-            .await?
+            .await
             .ok_or_else(|| crate::wallet::Error::Voting("No unspent voting output found".to_string()))?;
         let output = voting_output.output.as_basic();
 

--- a/sdk/src/wallet/account/operations/participation/voting_power.rs
+++ b/sdk/src/wallet/account/operations/participation/voting_power.rs
@@ -26,12 +26,11 @@ where
     crate::client::Error: From<S::Error>,
 {
     /// Returns an account's total voting power (voting or NOT voting).
-    pub async fn get_voting_power(&self) -> Result<u64> {
-        Ok(self
-            .get_voting_output()
-            .await?
+    pub async fn get_voting_power(&self) -> u64 {
+        self.get_voting_output()
+            .await
             // If no voting output exists, return 0
-            .map_or(0, |v| v.output.amount()))
+            .map_or(0, |v| v.output.amount())
     }
 
     /// Designates a given amount of tokens towards an account's "voting power" by creating a
@@ -55,7 +54,7 @@ where
     pub async fn prepare_increase_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
         let token_supply = self.client().get_token_supply().await?;
 
-        let (new_output, tx_options) = match self.get_voting_output().await? {
+        let (new_output, tx_options) = match self.get_voting_output().await {
             Some(current_output_data) => {
                 let output = current_output_data.output.as_basic();
 
@@ -116,7 +115,7 @@ where
         let token_supply = self.client().get_token_supply().await?;
         let current_output_data = self
             .get_voting_output()
-            .await?
+            .await
             .ok_or_else(|| crate::wallet::Error::Voting("No unspent voting output found".to_string()))?;
         let output = current_output_data.output.as_basic();
 

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_nft.rs
@@ -92,7 +92,7 @@ where
     {
         log::debug!("[TRANSACTION] prepare_send_nft");
 
-        let unspent_outputs = self.unspent_outputs(None).await?;
+        let unspent_outputs = self.unspent_outputs(None).await;
         let token_supply = self.client().get_token_supply().await?;
 
         let mut outputs = Vec::new();

--- a/sdk/src/wallet/account/operations/transaction/input_selection.rs
+++ b/sdk/src/wallet/account/operations/transaction/input_selection.rs
@@ -36,7 +36,7 @@ where
         log::debug!("[TRANSACTION] select_inputs");
         // Voting output needs to be requested before to prevent a deadlock
         #[cfg(feature = "participation")]
-        let voting_output = self.get_voting_output().await?;
+        let voting_output = self.get_voting_output().await;
         // lock so the same inputs can't be selected in multiple transactions
         let mut account_details = self.details_mut().await;
         let protocol_parameters = self.client().get_protocol_parameters().await?;

--- a/sdk/src/wallet/account/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/account/operations/transaction/prepare_output.rs
@@ -251,7 +251,7 @@ where
                 )
             } else {
                 // Transition an existing NFT output
-                let unspent_nft_output = self.unspent_nft_output(nft_id).await?;
+                let unspent_nft_output = self.unspent_nft_output(nft_id).await;
 
                 // Find nft output from the inputs
                 let mut first_output_builder = if let Some(nft_output_data) = &unspent_nft_output {

--- a/sdk/tests/wallet/balance.rs
+++ b/sdk/tests/wallet/balance.rs
@@ -266,7 +266,7 @@ async fn balance_voting_power() -> Result<()> {
     let balance = account.sync(None).await?;
     assert_eq!(balance.base_coin().total(), faucet_amount);
     assert_eq!(balance.base_coin().available(), faucet_amount - voting_power);
-    let account_voting_power = account.get_voting_power().await?;
+    let account_voting_power = account.get_voting_power().await;
     assert_eq!(account_voting_power, voting_power);
 
     // Increase voting power to total amount
@@ -277,7 +277,7 @@ async fn balance_voting_power() -> Result<()> {
     let balance = account.sync(None).await?;
     assert_eq!(balance.base_coin().total(), faucet_amount);
     assert_eq!(balance.base_coin().available(), 0);
-    let account_voting_power = account.get_voting_power().await?;
+    let account_voting_power = account.get_voting_power().await;
     assert_eq!(account_voting_power, faucet_amount);
 
     tear_down(storage_path)

--- a/sdk/tests/wallet/consolidation.rs
+++ b/sdk/tests/wallet/consolidation.rs
@@ -31,7 +31,7 @@ async fn consolidation() -> Result<()> {
 
     let balance = account_1.sync(None).await.unwrap();
     assert_eq!(balance.base_coin().available(), 10 * amount);
-    assert_eq!(account_1.unspent_outputs(None).await?.len(), 10);
+    assert_eq!(account_1.unspent_outputs(None).await.len(), 10);
 
     let tx = account_1
         .consolidate_outputs(ConsolidationParams::new().with_force(true))
@@ -44,7 +44,7 @@ async fn consolidation() -> Result<()> {
     // Balance still the same
     assert_eq!(balance.base_coin().available(), 10 * amount);
     // Only one unspent output
-    assert_eq!(account_1.unspent_outputs(None).await?.len(), 1);
+    assert_eq!(account_1.unspent_outputs(None).await.len(), 1);
 
     tear_down(storage_path)
 }

--- a/sdk/tests/wallet/output_preparation.rs
+++ b/sdk/tests/wallet/output_preparation.rs
@@ -771,7 +771,7 @@ async fn prepare_output_only_single_nft() -> Result<()> {
     let balance = account_1.sync(None).await?;
     assert_eq!(balance.nfts().len(), 1);
 
-    let nft_data = &account_1.unspent_outputs(None).await?[0];
+    let nft_data = &account_1.unspent_outputs(None).await[0];
     let nft_id = *balance.nfts().first().unwrap();
     // Send NFT back to first account
     let output = account_1

--- a/sdk/tests/wallet/syncing.rs
+++ b/sdk/tests/wallet/syncing.rs
@@ -131,7 +131,7 @@ async fn sync_only_most_basic_outputs() -> Result<()> {
     assert_eq!(balance.potentially_locked_outputs().len(), 0);
     assert_eq!(balance.nfts().len(), 0);
     assert_eq!(balance.accounts().len(), 0);
-    let unspent_outputs = account_1.unspent_outputs(None).await?;
+    let unspent_outputs = account_1.unspent_outputs(None).await;
     assert_eq!(unspent_outputs.len(), 1);
     unspent_outputs.into_iter().for_each(|output_data| {
         assert!(output_data.output.is_basic());

--- a/sdk/tests/wallet/transactions.rs
+++ b/sdk/tests/wallet/transactions.rs
@@ -95,7 +95,7 @@ async fn send_amount_custom_input() -> Result<()> {
     assert_eq!(balance.base_coin().available(), 10 * amount);
 
     // Send back with custom provided input
-    let custom_input = &account_1.unspent_outputs(None).await?[5];
+    let custom_input = &account_1.unspent_outputs(None).await[5];
     let tx = account_1
         .send_with_params(
             [SendParams::new(amount, account_0.first_address_bech32().await)?],


### PR DESCRIPTION
# Description of change

Changes the `output` command to expect an `OutputSelector` which allows to select an output in the account/wallet by providing either the corresponding `output id` or its `index` in the list of all account/wallet outputs. It works just like the `TransactionSelector` we already have.

Additionally, this PR removes unnecessarily returned `Result`s in output related methods that were returning an `Ok(..)` in any execution branch.

## Links to any relevant issues

Closes #1319

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Not (yet)

