### PR TITLE
feat(cli): output selector

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -21,16 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.2.0 - 2023-xx-xx
 
+### Added
+
+- `outputs` and `unspent_outputs` now print a list of outputs ordered by their corresponding booked milestone timestamp;
+- `outputs` and `unspent_outputs` now include spent/unspent information;
+
 ### Changed
 
 - `AccountCommand::Output` now accepts either a list index or an `OutputId`;
-- `output`, `outputs`, and `unspent_outputs` now order outputs by their corresponding booked milestone timestamp;
-- `outputs` and `unspent_outputs` now include spent/unspent information;
-- `outputs` and `transactions` now add the suffix `UTC` to the formatted date string;
+- `transactions` now adds the suffix `UTC` to the generated formatted date string;
 
 ### Fixed
 
-- `transaction` and `transactions` index transactions in reversed order;
+- `transaction` and `transactions` indexed transactions in opposite order;
 
 ## 1.1.0 - 2023-09-29
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `AccountCommand::Output` now accepts either an index or an ID;
+- `output` and `outputs` now order outputs by their corresponding booked milestone timestamp;
+
+### Fixed
+
+- `transaction` and `transactions` index transactions in reversed order;
 
 ## 1.1.0 - 2023-09-29
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `AccountCommand::Output` now accepts either an index or an ID;
+- `AccountCommand::Output` now accepts either a list index or an `OutputId`;
 - `output` and `outputs` now order outputs by their corresponding booked milestone timestamp;
 
 ### Fixed

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AccountCommand::Output` now accepts either a list index or an `OutputId`;
 - `output`, `outputs`, and `unspent_outputs` now order outputs by their corresponding booked milestone timestamp;
+- `outputs` and `unspent_outputs` now include spent/unspent information;
+- `outputs` and `transactions` now add the suffix `UTC` to the formatted date string;
 
 ### Fixed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `outputs` and `unspent_outputs` print the booked milestone timestamps and sort by them;
 - `outputs` and `unspent_outputs` include spent/unspent information;
-- `transactions` now adds the suffix `UTC` to the generated formatted date string;
+- `UTC` suffix to the formatted date of `transactions`;
 
 ### Changed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.2.0 - 2023-xx-xx
+
+### Changed
+
+- `AccountCommand::Output` now accepts either an index or an ID;
+
 ## 1.1.0 - 2023-09-29
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `AccountCommand::Output` now accepts either a list index or an `OutputId`;
-- `output` and `outputs` now order outputs by their corresponding booked milestone timestamp;
+- `output`, `outputs`, and `unspent_outputs` now order outputs by their corresponding booked milestone timestamp;
 
 ### Fixed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,13 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `outputs` and `unspent_outputs` now print the booked milestone timestamps and sort by them;
-- `outputs` and `unspent_outputs` now include spent/unspent information;
+- `outputs` and `unspent_outputs` print the booked milestone timestamps and sort by them;
+- `outputs` and `unspent_outputs` include spent/unspent information;
 - `transactions` now adds the suffix `UTC` to the generated formatted date string;
 
 ### Changed
 
-- `AccountCommand::Output` now accepts either a list index or an `OutputId`;
+- `AccountCommand::Output` accepts either a list index or an `OutputId`;
 
 ### Fixed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -25,11 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `outputs` and `unspent_outputs` now print the booked milestone timestamps and sort by them;
 - `outputs` and `unspent_outputs` now include spent/unspent information;
+- `transactions` now adds the suffix `UTC` to the generated formatted date string;
 
 ### Changed
 
 - `AccountCommand::Output` now accepts either a list index or an `OutputId`;
-- `transactions` now adds the suffix `UTC` to the generated formatted date string;
 
 ### Fixed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `outputs` and `unspent_outputs` now print a list of outputs ordered by their corresponding booked milestone timestamp;
+- `outputs` and `unspent_outputs` now print the booked milestone timestamps and sort by them;
 - `outputs` and `unspent_outputs` now include spent/unspent information;
 
 ### Changed

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -164,7 +164,7 @@ pub async fn account_prompt_internal(
                         }
                         AccountCommand::NewAddress => new_address_command(account).await,
                         AccountCommand::NodeInfo => node_info_command(account).await,
-                        AccountCommand::Output { output_id } => output_command(account, output_id).await,
+                        AccountCommand::Output { selector } => output_command(account, selector).await,
                         AccountCommand::Outputs => outputs_command(account).await,
                         AccountCommand::Send {
                             address,

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1023,8 +1023,8 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
                 i,
                 &output_data.output_id,
                 output_data.output.kind_str(),
-                if output_data.is_spent { "spent" } else { "unspent" },
-                formatted_time
+                formatted_time,
+                if output_data.is_spent { "Spent" } else { "Unspent" },
             );
         }
     }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -669,7 +669,7 @@ pub async fn output_command(account: &Account, selector: OutputSelector) -> Resu
         OutputSelector::Id(id) => account.get_output(&id).await,
         OutputSelector::Index(index) => {
             let mut outputs = account.outputs(None).await?;
-            outputs.sort_unstable_by(output_booked_timestamp_and_output_id);
+            outputs.sort_unstable_by(outputs_ordering);
             outputs.into_iter().nth(index)
         }
     };
@@ -803,7 +803,7 @@ pub async fn transaction_command(account: &Account, selector: TransactionSelecto
     let transaction = match selector {
         TransactionSelector::Id(id) => transactions.into_iter().find(|tx| tx.transaction_id == id),
         TransactionSelector::Index(index) => {
-            transactions.sort_unstable_by(transaction_timestamp);
+            transactions.sort_unstable_by(transactions_ordering);
             transactions.into_iter().nth(index)
         }
     };
@@ -820,7 +820,7 @@ pub async fn transaction_command(account: &Account, selector: TransactionSelecto
 /// `transactions` command
 pub async fn transactions_command(account: &Account, show_details: bool) -> Result<(), Error> {
     let mut transactions = account.transactions().await;
-    transactions.sort_unstable_by(transaction_timestamp);
+    transactions.sort_unstable_by(transactions_ordering);
 
     if transactions.is_empty() {
         println_log_info!("No transactions found");
@@ -1004,7 +1004,7 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
         println_log_info!("No outputs found");
     } else {
         println_log_info!("{title}");
-        outputs.sort_unstable_by(output_booked_timestamp_and_output_id);
+        outputs.sort_unstable_by(outputs_ordering);
 
         for (i, output_data) in outputs.into_iter().enumerate() {
             let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked() as u128 * 1000)?;

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1019,10 +1019,11 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
             let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S").to_string();
 
             println_log_info!(
-                "{:<5}{}\t{}\t{}",
+                "{:<5}{}\t{}\t{}\t{} UTC",
                 i,
                 &output_data.output_id,
                 output_data.output.kind_str(),
+                if output_data.is_spent { "spent" } else { "unspent" },
                 formatted_time
             );
         }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -834,7 +834,7 @@ pub async fn transactions_command(account: &Account, show_details: bool) -> Resu
                 println_log_info!("{:#?}", tx);
             } else {
                 let transaction_time = to_utc_date_time(tx.timestamp)?;
-                let formatted_time = transaction_time.format("%Y-%m-%d %H:%M:%S").to_string();
+                let formatted_time = transaction_time.format("%Y-%m-%d %H:%M:%S UTC").to_string();
 
                 println_log_info!("{:<5}{}\t{}", i, tx.transaction_id, formatted_time);
             }
@@ -1016,10 +1016,10 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
         println_log_info!("{title}");
         for (i, output_data) in outputs.into_iter().rev().enumerate() {
             let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked() as u128 * 1000)?;
-            let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S").to_string();
+            let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S UTC").to_string();
 
             println_log_info!(
-                "{:<5}{}\t{}\t{}\t{} UTC",
+                "{:<5}{}\t{}\t{}\t{}",
                 i,
                 &output_data.output_id,
                 output_data.output.kind_str(),

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -674,7 +674,7 @@ pub async fn output_command(account: &Account, selector: OutputSelector) -> Resu
                     .milestone_timestamp_booked()
                     .cmp(&b.metadata.milestone_timestamp_booked())
             });
-            outputs.into_iter().nth(index)
+            outputs.into_iter().rev().nth(index)
         }
     };
 
@@ -700,7 +700,7 @@ pub async fn outputs_command(account: &Account) -> Result<(), Error> {
         println_log_info!("No outputs found");
     } else {
         println_log_info!("Outputs:");
-        for (i, output_data) in outputs.into_iter().enumerate() {
+        for (i, output_data) in outputs.into_iter().rev().enumerate() {
             let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked().into())?;
             let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S").to_string();
 
@@ -833,7 +833,7 @@ pub async fn transaction_command(account: &Account, selector: TransactionSelecto
         TransactionSelector::Id(id) => transactions.into_iter().find(|tx| tx.transaction_id == id),
         TransactionSelector::Index(index) => {
             transactions.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-            transactions.into_iter().nth(index)
+            transactions.into_iter().rev().nth(index)
         }
     };
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -669,12 +669,12 @@ pub async fn output_command(account: &Account, selector: OutputSelector) -> Resu
         OutputSelector::Id(id) => account.get_output(&id).await,
         OutputSelector::Index(index) => {
             let mut outputs = account.outputs(None).await?;
-            outputs.sort_by(|a, b| a.output_id.cmp(&b.output_id));
             outputs.sort_by(|a, b| {
                 b.metadata
                     .milestone_timestamp_booked()
                     .cmp(&a.metadata.milestone_timestamp_booked())
             });
+            outputs.sort_by(|a, b| a.output_id.cmp(&b.output_id));
             outputs.into_iter().nth(index)
         }
     };
@@ -1005,16 +1005,17 @@ async fn print_address(account: &Account, address: &AccountAddress) -> Result<()
 }
 
 async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), Error> {
-    outputs.sort_by(|a, b| {
-        a.metadata
-            .milestone_timestamp_booked()
-            .cmp(&b.metadata.milestone_timestamp_booked())
-    });
-
     if outputs.is_empty() {
         println_log_info!("No outputs found");
     } else {
         println_log_info!("{title}");
+        outputs.sort_by(|a, b| {
+            a.metadata
+                .milestone_timestamp_booked()
+                .cmp(&b.metadata.milestone_timestamp_booked())
+        });
+        outputs.sort_by(|a, b| a.output_id.cmp(&b.output_id));
+
         for (i, output_data) in outputs.into_iter().enumerate() {
             let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked() as u128 * 1000)?;
             let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S UTC").to_string();

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -701,7 +701,7 @@ pub async fn outputs_command(account: &Account) -> Result<(), Error> {
     } else {
         println_log_info!("Outputs:");
         for (i, output_data) in outputs.into_iter().rev().enumerate() {
-            let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked().into())?;
+            let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked() as u128 * 1000)?;
             let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S").to_string();
 
             println_log_info!(

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1009,7 +1009,7 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
         println_log_info!("{title}");
         outputs.sort_by(|a, b| {
             (b.metadata.milestone_timestamp_booked(), a.output_id)
-                .cmp(&(a.metadata.milestone_index_booked(), b.output_id))
+                .cmp(&(a.metadata.milestone_timestamp_booked(), b.output_id))
         });
 
         for (i, output_data) in outputs.into_iter().enumerate() {

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -669,12 +669,13 @@ pub async fn output_command(account: &Account, selector: OutputSelector) -> Resu
         OutputSelector::Id(id) => account.get_output(&id).await,
         OutputSelector::Index(index) => {
             let mut outputs = account.outputs(None).await?;
+            outputs.sort_by(|a, b| a.output_id.cmp(&b.output_id));
             outputs.sort_by(|a, b| {
-                a.metadata
+                b.metadata
                     .milestone_timestamp_booked()
-                    .cmp(&b.metadata.milestone_timestamp_booked())
+                    .cmp(&a.metadata.milestone_timestamp_booked())
             });
-            outputs.into_iter().rev().nth(index)
+            outputs.into_iter().nth(index)
         }
     };
 
@@ -807,8 +808,8 @@ pub async fn transaction_command(account: &Account, selector: TransactionSelecto
     let transaction = match selector {
         TransactionSelector::Id(id) => transactions.into_iter().find(|tx| tx.transaction_id == id),
         TransactionSelector::Index(index) => {
-            transactions.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-            transactions.into_iter().rev().nth(index)
+            transactions.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            transactions.into_iter().nth(index)
         }
     };
 
@@ -829,7 +830,7 @@ pub async fn transactions_command(account: &Account, show_details: bool) -> Resu
     if transactions.is_empty() {
         println_log_info!("No transactions found");
     } else {
-        for (i, tx) in transactions.into_iter().rev().enumerate() {
+        for (i, tx) in transactions.into_iter().enumerate() {
             if show_details {
                 println_log_info!("{:#?}", tx);
             } else {
@@ -1014,7 +1015,7 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
         println_log_info!("No outputs found");
     } else {
         println_log_info!("{title}");
-        for (i, output_data) in outputs.into_iter().rev().enumerate() {
+        for (i, output_data) in outputs.into_iter().enumerate() {
             let booked_time = to_utc_date_time(output_data.metadata.milestone_timestamp_booked() as u128 * 1000)?;
             let formatted_time = booked_time.format("%Y-%m-%d %H:%M:%S UTC").to_string();
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{cmp::Ordering, str::FromStr};
+use std::str::FromStr;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use iota_sdk::{
@@ -670,14 +670,8 @@ pub async fn output_command(account: &Account, selector: OutputSelector) -> Resu
         OutputSelector::Index(index) => {
             let mut outputs = account.outputs(None).await?;
             outputs.sort_by(|a, b| {
-                let cmp = b
-                    .metadata
-                    .milestone_index_booked()
-                    .cmp(&a.metadata.milestone_timestamp_booked());
-                match cmp {
-                    Ordering::Equal => a.output_id.cmp(&b.output_id),
-                    _ => cmp,
-                }
+                (b.metadata.milestone_timestamp_booked(), a.output_id)
+                    .cmp(&(a.metadata.milestone_index_booked(), b.output_id))
             });
             outputs.into_iter().nth(index)
         }
@@ -1014,14 +1008,8 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
     } else {
         println_log_info!("{title}");
         outputs.sort_by(|a, b| {
-            let cmp = b
-                .metadata
-                .milestone_index_booked()
-                .cmp(&a.metadata.milestone_timestamp_booked());
-            match cmp {
-                Ordering::Equal => a.output_id.cmp(&b.output_id),
-                _ => cmp,
-            }
+            (b.metadata.milestone_timestamp_booked(), a.output_id)
+                .cmp(&(a.metadata.milestone_index_booked(), b.output_id))
         });
 
         for (i, output_data) in outputs.into_iter().enumerate() {

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1024,10 +1024,10 @@ async fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), 
     Ok(())
 }
 
-fn output_booked_timestamp_and_output_id(a: &OutputData, b: &OutputData) -> std::cmp::Ordering {
+fn outputs_ordering(a: &OutputData, b: &OutputData) -> std::cmp::Ordering {
     (b.metadata.milestone_timestamp_booked(), a.output_id).cmp(&(a.metadata.milestone_timestamp_booked(), b.output_id))
 }
 
-fn transaction_timestamp(a: &Transaction, b: &Transaction) -> std::cmp::Ordering {
+fn transactions_ordering(a: &Transaction, b: &Transaction) -> std::cmp::Ordering {
     b.timestamp.cmp(&a.timestamp)
 }


### PR DESCRIPTION
# Description of change

Changes the `output` command to expect an `OutputSelector` which allows to select an output in the account/wallet by providing either the corresponding `output id` or its `index` in the list of all account/wallet outputs. It works just like the `TransactionSelector` we already have.

## Links to any relevant issues

Closes #1319

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Not (yet)