### PR TITLE
Print NFT, Alias, Foundry alias addresses

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -27,10 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `outputs` and `unspent_outputs` include spent/unspent information;
 - `UTC` suffix to the formatted date of `transactions`;
 - `addresses` handles NFT and Alias addresses;
+- `AccountCommand::Address` command that accepts either a list index or a `Bech32Address`;
 
 ### Changed
 
 - `AccountCommand::Output` accepts either a list index or an `OutputId`;
+- `addresses` prints an indexed list of addresses and their type instead of address details;
 
 ### Fixed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `outputs` and `unspent_outputs` print the booked milestone timestamps and sort by them;
 - `outputs` and `unspent_outputs` include spent/unspent information;
 - `UTC` suffix to the formatted date of `transactions`;
+- `addresses` handles NFT and Alias addresses;
 
 ### Changed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.2.0 - 2023-xx-xx
+## 1.2.0 - 2023-10-26
 
 ### Added
 

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -9,14 +9,15 @@ use rustyline::{error::ReadlineError, history::MemHistory, Config, Editor};
 use crate::{
     command::{
         account::{
-            addresses_command, balance_command, burn_native_token_command, burn_nft_command, claim_command,
-            claimable_outputs_command, consolidate_command, create_alias_outputs_command, create_native_token_command,
-            decrease_voting_power_command, destroy_alias_command, destroy_foundry_command, faucet_command,
-            increase_voting_power_command, melt_native_token_command, mint_native_token, mint_nft_command,
-            new_address_command, node_info_command, output_command, outputs_command, participation_overview_command,
-            send_command, send_native_token_command, send_nft_command, stop_participating_command, sync_command,
-            transaction_command, transactions_command, unspent_outputs_command, vote_command, voting_output_command,
-            voting_power_command, AccountCli, AccountCommand,
+            address_command, addresses_command, balance_command, burn_native_token_command, burn_nft_command,
+            claim_command, claimable_outputs_command, consolidate_command, create_alias_outputs_command,
+            create_native_token_command, decrease_voting_power_command, destroy_alias_command, destroy_foundry_command,
+            faucet_command, increase_voting_power_command, melt_native_token_command, mint_native_token,
+            mint_nft_command, new_address_command, node_info_command, output_command, outputs_command,
+            participation_overview_command, send_command, send_native_token_command, send_nft_command,
+            stop_participating_command, sync_command, transaction_command, transactions_command,
+            unspent_outputs_command, vote_command, voting_output_command, voting_power_command, AccountCli,
+            AccountCommand,
         },
         account_completion::AccountPromptHelper,
     },
@@ -103,6 +104,7 @@ pub async fn account_prompt_internal(
                         }
                     };
                     match account_cli.command {
+                        AccountCommand::Address { index } => address_command(account, index).await,
                         AccountCommand::Addresses => addresses_command(account).await,
                         AccountCommand::Balance { addresses } => balance_command(account, addresses).await,
                         AccountCommand::BurnNativeToken { token_id, amount } => {

--- a/cli/src/account.rs
+++ b/cli/src/account.rs
@@ -106,7 +106,7 @@ pub async fn account_prompt_internal(
                         }
                     };
                     match account_cli.command {
-                        AccountCommand::Address { index } => address_command(account, index).await,
+                        AccountCommand::Address { selector } => address_command(account, selector).await,
                         AccountCommand::Addresses => addresses_command(account).await,
                         AccountCommand::Balance { addresses } => balance_command(account, addresses).await,
                         AccountCommand::BurnNativeToken { token_id, amount } => {

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -958,7 +958,6 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 }
 
 async fn print_address(account: &Account, address: &Bech32Address) -> Result<(), Error> {
-    println_log_info!("Address");
     println_log_info!("{:<11}{}", "Bech32:", address);
     println_log_info!("{:<11}{}", "Hex:", address.inner());
     println_log_info!("{:<11}{}", "Type:", address.inner().kind_str());
@@ -1019,22 +1018,21 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
         }
     }
 
-    // base tokens table
-    println_log_info!("Base Tokens");
-    println_log_info!("{:<8}{}", "Amount:", amount);
+    // Coins table
+    println_log_info!("{:<11}{}", "Coins:", amount);
 
-    // outputs table
+    // Outputs table
     if !outputs.is_empty() {
-        println_log_info!("Outputs");
+        println_log_info!("Outputs:");
         for (id, kind) in outputs {
-            println_log_info!("  {kind}\t{id}");
+            println_log_info!("  {id}\t{kind}");
         }
     }
 
-    // native tokens table
+    // Native tokens table
     let native_tokens = native_tokens.finish_vec()?;
     if !native_tokens.is_empty() {
-        println_log_info!("Native Tokens");
+        println_log_info!("Native Tokens:");
         for (id, amount) in native_tokens
             .into_iter()
             .map(|nt| (*nt.token_id(), nt.amount().to_string()))
@@ -1046,7 +1044,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
 
     // NFT table
     if !nfts.is_empty() {
-        println_log_info!("NFTs");
+        println_log_info!("NFTs:");
         for id in nfts.into_iter() {
             println_log_info!("  {id}");
         }
@@ -1054,7 +1052,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
 
     // Aliases table
     if !aliases.is_empty() {
-        println_log_info!("Aliases");
+        println_log_info!("Aliases:");
         for id in aliases.into_iter() {
             println_log_info!("  {id}");
         }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1116,7 +1116,7 @@ async fn get_addresses_sorted(account: &Account) -> Result<Vec<Bech32Address>, E
         .addresses()
         .await?
         .iter()
-        .map(|address| address.address().clone())
+        .map(|address| *address.address())
         .chain(
             account
                 .unspent_outputs(FilterOptions {

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -957,9 +957,11 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 }
 
 async fn print_address(account: &Account, address: &Bech32Address) -> Result<(), Error> {
-    println_log_info!("{:<11}{}", "Bech32:", address);
-    println_log_info!("{:<11}{}", "Hex:", address.inner());
-    println_log_info!("{:<11}{}", "Type:", address.inner().kind_str());
+    let mut formatted_string = String::new();
+
+    formatted_string.push_str(&format!("{:<11}{}\n", "Bech32:", address));
+    formatted_string.push_str(&format!("{:<11}{}\n", "Hex:", address.inner()));
+    formatted_string.push_str(&format!("{:<11}{}\n", "Type:", address.inner().kind_str()));
 
     let unspent_outputs = account.unspent_outputs(None).await?;
     let current_time = iota_sdk::utils::unix_timestamp_now().as_secs() as u32;
@@ -1004,43 +1006,45 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     }
 
     // Coins table
-    println_log_info!("{:<11}{}", "Coins:", amount);
+    formatted_string.push_str(&format!("{:<11}{}\n", "Coins:", amount));
 
     // Outputs table
     if !outputs.is_empty() {
-        println_log_info!("Outputs:");
+        formatted_string.push_str("Outputs:\n");
         for (id, kind) in outputs {
-            println_log_info!("  {id}\t{kind}");
+            formatted_string.push_str(&format!("  {id}\t{kind}\n"));
         }
     }
 
     // Native tokens table
     let native_tokens = native_tokens.finish_vec()?;
     if !native_tokens.is_empty() {
-        println_log_info!("Native Tokens:");
+        formatted_string.push_str("Native Tokens:\n");
         for (id, amount) in native_tokens
             .into_iter()
             .map(|nt| (*nt.token_id(), nt.amount().to_string()))
         {
-            println_log_info!("  {id}\t{amount}");
+            formatted_string.push_str(&format!("  {id}\t{amount}\n"));
         }
     }
 
     // NFT table
     if !nfts.is_empty() {
-        println_log_info!("NFTs:");
+        formatted_string.push_str("NFTs:\n");
         for id in nfts.into_iter() {
-            println_log_info!("  {id}");
+            formatted_string.push_str(&format!("  {id}\n"));
         }
     }
 
     // Aliases table
     if !aliases.is_empty() {
-        println_log_info!("Aliases:");
+        formatted_string.push_str("Aliases:\n");
         for id in aliases.into_iter() {
-            println_log_info!("  {id}");
+            formatted_string.push_str(&format!("  {id}\n"));
         }
     }
+
+    println_log_info!("{formatted_string}");
 
     Ok(())
 }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -971,8 +971,6 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     let mut aliases = Vec::new();
 
     for (output_id, output_data) in unspent_outputs.into_iter().map(|data| (data.output_id, data)) {
-        outputs.push((output_id, output_data.output.kind_str().to_string()));
-
         // Panic: cannot fail for outputs belonging to an account.
         let (required_address, _) = output_data
             .output
@@ -980,14 +978,18 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
             .unwrap();
 
         if address.inner() == &required_address {
+            outputs.push((output_id, output_data.output.kind_str().to_string()));
+
             if let Some(nts) = output_data.output.native_tokens() {
                 native_tokens.add_native_tokens(nts.clone())?;
             }
+
             match &output_data.output {
                 Output::Alias(alias) => aliases.push(alias.alias_id_non_null(&output_id)),
                 Output::Nft(nft) => nfts.push(nft.nft_id_non_null(&output_id)),
                 Output::Basic(_) | Output::Foundry(_) | Output::Treasury(_) => {}
             }
+
             let sdr_amount = output_data
                 .output
                 .unlock_conditions()

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -971,7 +971,6 @@ fn print_addresses(mut addresses: Vec<Bech32Address>) -> Result<(), Error> {
     Ok(())
 }
 
-// TODO: display AccountAddress infos (key_index, change_address, etc) in the `addresses` command generated list?
 async fn print_address(account: &Account, address: &Bech32Address) -> Result<(), Error> {
     let mut formatted_table = String::from("Address");
     formatted_table.push_str(&format!(

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -11,8 +11,8 @@ use iota_sdk::{
         block::{
             address::{Address, Bech32Address, ToBech32Ext},
             output::{
-                unlock_condition::AddressUnlockCondition, AliasId, BasicOutputBuilder, FoundryId, NativeToken,
-                NativeTokensBuilder, NftId, Output, OutputId, TokenId,
+                unlock_condition::AddressUnlockCondition, AliasId, AliasOutput, BasicOutputBuilder, FoundryId,
+                NativeToken, NativeTokensBuilder, NftId, NftOutput, Output, OutputId, TokenId,
             },
             payload::transaction::TransactionId,
             ConvertTo,
@@ -21,7 +21,7 @@ use iota_sdk::{
     wallet::{
         account::{
             types::{AccountIdentifier, OutputData, Transaction},
-            Account, ConsolidationParams, OutputsToClaim, SyncOptions, TransactionOptions,
+            Account, ConsolidationParams, FilterOptions, OutputsToClaim, SyncOptions, TransactionOptions,
         },
         CreateNativeTokenParams, MintNftParams, SendNativeTokensParams, SendNftParams, SendParams,
     },
@@ -1119,7 +1119,10 @@ async fn get_addresses_sorted(account: &Account) -> Result<Vec<Bech32Address>, E
         .map(|address| address.address().clone())
         .chain(
             account
-                .unspent_outputs(None)
+                .unspent_outputs(FilterOptions {
+                    output_types: Some(vec![AliasOutput::KIND, NftOutput::KIND]),
+                    ..Default::default()
+                })
                 .await?
                 .into_iter()
                 .filter_map(|data| match data.output {

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 IOTA Stiftung
+// Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
@@ -958,17 +958,11 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 }
 
 async fn print_address(account: &Account, address: &Bech32Address) -> Result<(), Error> {
-    let mut formatted_table = String::from("Address");
-    formatted_table.push_str(&format!(
-        "{0}{1:<11}{2}{0}{3:<11}{4}{0}{5:<11}{6}",
-        "\n  ",
-        "Bech32:",
-        address,
-        "Hex:",
-        address.inner(),
-        "Type:",
-        address.inner().kind_str(),
-    ));
+    let mut formatted_table = String::new();
+    writeln!(&mut formatted_table, "Address");
+    writeln!(&mut formatted_table, "{:<11}{}", "Bech32:", address);
+    writeln!(&mut formatted_table, "{:<11}{}", "Hex:", address.inner());
+    writeln!(&mut formatted_table, "{:<11}{}", "Type:", address.inner().kind_str());
 
     let unspent_outputs = account
         .unspent_outputs(None)
@@ -1027,42 +1021,43 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     }
 
     // base tokens table
-    formatted_table.push_str("\nBase Tokens");
-    formatted_table.push_str(&format!("{0}{1:<8}{2}", "\n  ", "Amount:", amount));
+    writeln!(&mut formatted_table, "Base Tokens");
+    writeln!(&mut formatted_table, "{:<8}{}", "Amount:", amount);
 
     // outputs table
     if outputs.len() > 0 {
-        formatted_table.push_str("\nOutputs");
+        writeln!(&mut formatted_table, "Outputs");
         for (id, kind) in outputs {
-            formatted_table.push_str(&format!("{0}{id}\t{kind}", "\n  "));
+            writeln!(&mut formatted_table, "  {kind}\t{id}");
         }
     }
 
     // native tokens table
     let native_tokens = native_tokens.finish_vec()?;
     if native_tokens.len() > 0 {
-        formatted_table.push_str("\nNative Tokens");
+        writeln!(&mut formatted_table, "Native Tokens");
         for (id, amount) in native_tokens
             .into_iter()
             .map(|nt| (*nt.token_id(), nt.amount().to_string()))
         {
-            formatted_table.push_str(&format!("{0}{id}{0}Amount: {amount}", "\n  "));
+            writeln!(&mut formatted_table, "  {id}");
+            writeln!(&mut formatted_table, "  Amount: {amount}");
         }
     }
 
     // NFT table
     if nfts.len() > 0 {
-        formatted_table.push_str("\nNFTs");
+        writeln!(&mut formatted_table, "NFTs");
         for id in nfts.into_iter() {
-            formatted_table.push_str(&format!("{0}{id}", "\n  "));
+            writeln!(&mut formatted_table, "  {id}");
         }
     }
 
     // Aliases table
     if aliases.len() > 0 {
-        formatted_table.push_str("\nAliases");
+        writeln!(&mut formatted_table, "Aliases");
         for id in aliases.into_iter() {
-            formatted_table.push_str(&format!("{0}{id}", "\n  "));
+            writeln!(&mut formatted_table, "  {id}");
         }
     }
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
+use std::{fmt::Write, str::FromStr};
 
 use clap::{CommandFactory, Parser, Subcommand};
 use iota_sdk::{

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -969,9 +969,9 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 
 // TODO: display AccountAddress infos (key_index, change_address, etc) in the `addresses` command generated list?
 async fn print_address(account: &Account, address: &Bech32Address) -> Result<(), Error> {
-    let mut formatted_table = String::from("Address:");
+    let mut formatted_table = String::from("Address");
     formatted_table.push_str(&format!(
-        "{0}{1:<11}{2}{0}{3:<11}{4}{0}{5:<11}{6}\n",
+        "{0}{1:<11}{2}{0}{3:<11}{4}{0}{5:<11}{6}",
         "\n  ",
         "Bech32:",
         address,
@@ -1033,50 +1033,44 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
         }
     }
 
-    let mut row_count = 0;
+    // base token table
+    formatted_table.push_str("\n\nBase Tokens");
+    formatted_table.push_str(&format!("{0}{1:<8}{2}", "\n  ", "Amount:", amount));
 
     // outputs table
-    formatted_table.push_str("\nOutputs:");
-    for (id, kind) in outputs {
-        formatted_table.push_str(&format!("{0}{1:<6}{id}{0}{2:<6}{kind}", "\n  ", "Id:", "Type:"));
-        row_count += 1;
+    if outputs.len() > 0 {
+        formatted_table.push_str("\n\nOutputs");
+        for (id, kind) in outputs {
+            formatted_table.push_str(&format!("{0}{1:<6}{id}{0}{2:<6}{kind}", "\n  ", "Id:", "Type:"));
+        }
     }
-    formatted_table.push_str(if row_count == 0 { "\n  None\n" } else { "\n" });
 
-    // base token table
-    formatted_table.push_str("\nBase Tokens:");
-    formatted_table.push_str(&format!("{0}{1:<8}{2}\n", "\n  ", "Amount:", amount));
-
-    formatted_table.push_str("\nNative Tokens:");
-    row_count = 0;
-    for (id, amount) in native_tokens
-        .finish_vec()?
-        .into_iter()
-        .map(|nt| (*nt.token_id(), nt.amount().to_string()))
-    {
-        formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{amount}", "\n  ", "Id:", "Amount:"));
-        row_count += 1;
+    let native_tokens = native_tokens.finish_vec()?;
+    if native_tokens.len() > 0 {
+        formatted_table.push_str("\n\nNative Tokens");
+        for (id, amount) in native_tokens
+            .into_iter()
+            .map(|nt| (*nt.token_id(), nt.amount().to_string()))
+        {
+            formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{amount}", "\n  ", "Id:", "Amount:"));
+        }
     }
-    formatted_table.push_str(if row_count == 0 { "\n  None\n" } else { "\n" });
 
     // NFT table
-    formatted_table.push_str("\nNFTs:");
-    row_count = 0;
-    for (id, bech32) in nfts.into_iter() {
-        formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
-        row_count += 1;
+    if nfts.len() > 0 {
+        formatted_table.push_str("\n\nNFTs");
+        for (id, bech32) in nfts.into_iter() {
+            formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
+        }
     }
-    formatted_table.push_str(if row_count == 0 { "\n  None\n" } else { "\n" });
 
     // Aliases table
-    formatted_table.push_str("\nAliases:");
-    row_count = 0;
-    for (id, bech32) in aliases.into_iter() {
-        formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
-        row_count += 1;
+    if aliases.len() > 0 {
+        formatted_table.push_str("\n\nAliases");
+        for (id, bech32) in aliases.into_iter() {
+            formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
+        }
     }
-    // NOTE: always make sure this is the last line bc it doesn't add another new-line.
-    formatted_table.push_str(if row_count == 0 { "\n  None" } else { "" });
 
     println_log_info!("{formatted_table}");
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Write, str::FromStr};
+use std::str::FromStr;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use iota_sdk::{
@@ -958,11 +958,10 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 }
 
 async fn print_address(account: &Account, address: &Bech32Address) -> Result<(), Error> {
-    let mut formatted_table = String::new();
-    writeln!(&mut formatted_table, "Address");
-    writeln!(&mut formatted_table, "{:<11}{}", "Bech32:", address);
-    writeln!(&mut formatted_table, "{:<11}{}", "Hex:", address.inner());
-    writeln!(&mut formatted_table, "{:<11}{}", "Type:", address.inner().kind_str());
+    println_log_info!("Address");
+    println_log_info!("{:<11}{}", "Bech32:", address);
+    println_log_info!("{:<11}{}", "Hex:", address.inner());
+    println_log_info!("{:<11}{}", "Type:", address.inner().kind_str());
 
     let unspent_outputs = account
         .unspent_outputs(None)
@@ -1021,47 +1020,45 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     }
 
     // base tokens table
-    writeln!(&mut formatted_table, "Base Tokens");
-    writeln!(&mut formatted_table, "{:<8}{}", "Amount:", amount);
+    println_log_info!("Base Tokens");
+    println_log_info!("{:<8}{}", "Amount:", amount);
 
     // outputs table
     if !outputs.is_empty() {
-        writeln!(&mut formatted_table, "Outputs");
+        println_log_info!("Outputs");
         for (id, kind) in outputs {
-            writeln!(&mut formatted_table, "  {kind}\t{id}");
+            println_log_info!("  {kind}\t{id}");
         }
     }
 
     // native tokens table
     let native_tokens = native_tokens.finish_vec()?;
     if !native_tokens.is_empty() {
-        writeln!(&mut formatted_table, "Native Tokens");
+        println_log_info!("Native Tokens");
         for (id, amount) in native_tokens
             .into_iter()
             .map(|nt| (*nt.token_id(), nt.amount().to_string()))
         {
-            writeln!(&mut formatted_table, "  {id}");
-            writeln!(&mut formatted_table, "  Amount: {amount}");
+            println_log_info!("  {id}");
+            println_log_info!("  Amount: {amount}");
         }
     }
 
     // NFT table
     if !nfts.is_empty() {
-        writeln!(&mut formatted_table, "NFTs");
+        println_log_info!("NFTs");
         for id in nfts.into_iter() {
-            writeln!(&mut formatted_table, "  {id}");
+            println_log_info!("  {id}");
         }
     }
 
     // Aliases table
     if !aliases.is_empty() {
-        writeln!(&mut formatted_table, "Aliases");
+        println_log_info!("Aliases");
         for id in aliases.into_iter() {
-            writeln!(&mut formatted_table, "  {id}");
+            println_log_info!("  {id}");
         }
     }
-
-    println_log_info!("{formatted_table}");
 
     Ok(())
 }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -1016,14 +1016,8 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
                 native_tokens.add_native_tokens(nts.clone())?;
             }
             match &output_data.output {
-                Output::Nft(nft) => nfts.push((
-                    nft.nft_id_non_null(&output_id),
-                    nft.nft_address(&output_id).to_bech32(*address.hrp()),
-                )),
-                Output::Alias(alias) => aliases.push((
-                    alias.alias_id_non_null(&output_id),
-                    alias.alias_address(&output_id).to_bech32(*address.hrp()),
-                )),
+                Output::Nft(nft) => nfts.push(nft.nft_id_non_null(&output_id)),
+                Output::Alias(alias) => aliases.push(alias.alias_id_non_null(&output_id)),
                 Output::Basic(_) | Output::Foundry(_) | Output::Treasury(_) => {}
             }
             let unlock_conditions = output_data
@@ -1039,42 +1033,43 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
         }
     }
 
-    // base token table
-    formatted_table.push_str("\n\nBase Tokens");
+    // base tokens table
+    formatted_table.push_str("\nBase Tokens");
     formatted_table.push_str(&format!("{0}{1:<8}{2}", "\n  ", "Amount:", amount));
 
     // outputs table
     if outputs.len() > 0 {
-        formatted_table.push_str("\n\nOutputs");
+        formatted_table.push_str("\nOutputs");
         for (id, kind) in outputs {
-            formatted_table.push_str(&format!("{0}{1:<6}{id}{0}{2:<6}{kind}", "\n  ", "Id:", "Type:"));
+            formatted_table.push_str(&format!("{0}{id}\t{kind}", "\n  "));
         }
     }
 
+    // native tokens table
     let native_tokens = native_tokens.finish_vec()?;
     if native_tokens.len() > 0 {
-        formatted_table.push_str("\n\nNative Tokens");
+        formatted_table.push_str("\nNative Tokens");
         for (id, amount) in native_tokens
             .into_iter()
             .map(|nt| (*nt.token_id(), nt.amount().to_string()))
         {
-            formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{amount}", "\n  ", "Id:", "Amount:"));
+            formatted_table.push_str(&format!("{0}{id}{0}Amount: {amount}", "\n  "));
         }
     }
 
     // NFT table
     if nfts.len() > 0 {
-        formatted_table.push_str("\n\nNFTs");
-        for (id, bech32) in nfts.into_iter() {
-            formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
+        formatted_table.push_str("\nNFTs");
+        for id in nfts.into_iter() {
+            formatted_table.push_str(&format!("{0}{id}", "\n  "));
         }
     }
 
     // Aliases table
     if aliases.len() > 0 {
-        formatted_table.push_str("\n\nAliases");
-        for (id, bech32) in aliases.into_iter() {
-            formatted_table.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
+        formatted_table.push_str("\nAliases");
+        for id in aliases.into_iter() {
+            formatted_table.push_str(&format!("{0}{id}", "\n  "));
         }
     }
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -686,7 +686,7 @@ pub async fn mint_nft_command(
 pub async fn new_address_command(account: &Account) -> Result<(), Error> {
     let address = account.generate_ed25519_addresses(1, None).await?;
 
-    print_address(account, &address[0].address()).await?;
+    print_address(account, address[0].address()).await?;
 
     Ok(())
 }
@@ -980,7 +980,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
                     Output::Basic(basic) => basic.address() == address.inner(),
                     Output::Nft(nft) => &Address::Nft(nft.nft_address(&data.output_id)) == address.inner(),
                     Output::Alias(alias) => &Address::Alias(alias.alias_address(&data.output_id)) == address.inner(),
-                    Output::Foundry(foundry) => &Address::Alias(foundry.alias_address().clone()) == address.inner(),
+                    Output::Foundry(foundry) => &Address::Alias(*foundry.alias_address()) == address.inner(),
                     _ => false,
                 }
         })
@@ -1031,7 +1031,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     formatted_table.push_str(&format!("{0}{1:<8}{2}", "\n  ", "Amount:", amount));
 
     // outputs table
-    if outputs.len() > 0 {
+    if !outputs.is_empty() {
         formatted_table.push_str("\nOutputs");
         for (id, kind) in outputs {
             formatted_table.push_str(&format!("{0}{id}\t{kind}", "\n  "));
@@ -1040,7 +1040,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
 
     // native tokens table
     let native_tokens = native_tokens.finish_vec()?;
-    if native_tokens.len() > 0 {
+    if !native_tokens.is_empty() {
         formatted_table.push_str("\nNative Tokens");
         for (id, amount) in native_tokens
             .into_iter()
@@ -1051,7 +1051,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     }
 
     // NFT table
-    if nfts.len() > 0 {
+    if !nfts.is_empty() {
         formatted_table.push_str("\nNFTs");
         for id in nfts.into_iter() {
             formatted_table.push_str(&format!("{0}{id}", "\n  "));
@@ -1059,7 +1059,7 @@ async fn print_address(account: &Account, address: &Bech32Address) -> Result<(),
     }
 
     // Aliases table
-    if aliases.len() > 0 {
+    if !aliases.is_empty() {
         formatted_table.push_str("\nAliases");
         for id in aliases.into_iter() {
             formatted_table.push_str(&format!("{0}{id}", "\n  "));
@@ -1127,7 +1127,7 @@ async fn get_addresses_sorted(account: &Account) -> Result<Vec<Bech32Address>, E
         .filter_map(|data| match data.output {
             Output::Alias(alias) => Some(Address::Alias(alias.alias_address(&data.output_id))),
             Output::Nft(nft) => Some(Address::Nft(nft.nft_address(&data.output_id))),
-            Output::Basic(basic) => Some(basic.address().clone()),
+            Output::Basic(basic) => Some(*basic.address()),
             _ => None,
         })
         .map(|address| address.to_bech32_unchecked(hrp))

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -310,7 +310,6 @@ impl FromStr for OutputSelector {
 /// Select by Bech32 address or list index
 #[derive(Debug, Copy, Clone)]
 pub enum AddressSelector {
-    // TODO: change to AccountAddress? (Note that AccountAddress isn't Copy)
     Address(Bech32Address),
     Index(usize),
 }

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -964,7 +964,6 @@ async fn print_address(account: &Account, address: &AccountAddress) -> Result<()
     let mut native_tokens = NativeTokensBuilder::new();
     let mut nfts = Vec::new();
     let mut aliases = Vec::new();
-    let mut foundries = Vec::new();
 
     let hrp = address.address().hrp();
 
@@ -996,10 +995,7 @@ async fn print_address(account: &Account, address: &AccountAddress) -> Result<()
                             alias.alias_id_non_null(output_id),
                             alias.alias_address(output_id).to_bech32(*hrp),
                         )),
-                        Output::Foundry(foundry) => {
-                            foundries.push((foundry.id(), *foundry.alias_address().to_bech32(*hrp)))
-                        }
-                        Output::Basic(_) | Output::Treasury(_) => {}
+                        Output::Basic(_) | Output::Foundry(_) | Output::Treasury(_) => {}
                     }
                     let unlock_conditions = output_data
                         .output
@@ -1037,19 +1033,13 @@ async fn print_address(account: &Account, address: &AccountAddress) -> Result<()
 
     formatted_string.push_str("\nNFTs:");
     for (id, bech32) in nfts.into_iter() {
-        formatted_string.push_str(&format!(
-            "{0}{1:<12}{id}{0}{2:<12}{bech32}",
-            "\n  ", "Id/Address:", "Bech32:"
-        ));
+        formatted_string.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
     }
     formatted_string.push_str("\n");
 
     formatted_string.push_str("\nAliases:");
     for (id, bech32) in aliases.into_iter() {
-        formatted_string.push_str(&format!(
-            "{0}{1:<12}{id}{0}{2:<12}{bech32}",
-            "\n  ", "Id/Address:", "Bech32:"
-        ));
+        formatted_string.push_str(&format!("{0}{1:<8}{id}{0}{2:<8}{bech32}", "\n  ", "Id:", "Bech32:"));
     }
     formatted_string.push_str("\n");
 

--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -922,12 +922,14 @@ pub async fn voting_output_command(account: &Account) -> Result<(), Error> {
 
 async fn print_address(account: &Account, address: &AccountAddress) -> Result<(), Error> {
     let mut log = format!(
-        "Address: {}\n{:<9}{}\n{:<9}{}",
+        "Address: {}\n{:<9}{}\n{:<9}{}\n{:<9}{}",
         address.key_index(),
         "Bech32:",
         address.address(),
         "Hex:",
-        address.address().inner()
+        address.address().inner(),
+        "Type:",
+        address.address().kind_str(),
     );
 
     if *address.internal() {

--- a/cli/src/command/account_completion.rs
+++ b/cli/src/command/account_completion.rs
@@ -13,6 +13,7 @@ pub struct AccountCompleter;
 
 const ACCOUNT_COMMANDS: &[&str] = &[
     "accounts",
+    "address",
     "addresses",
     "balance",
     "burn-native-token",

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.2 - 2023-MM-DD
 
+### Added
+
+- `Address::kind_str` method;
+
 ### Fixed
 
 - `Account::claim_outputs()` if an input has less amount than min storage deposit;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `impl From<&OutputId> for {AliasAddress, NftAddress}`;
 - `Address::kind_str` method;
+- `Display` for `Address`;
 
 ### Fixed
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -26,6 +26,7 @@ derive_more = { version = "0.99.17", default-features = false, features = [
     "as_ref",
     "deref",
     "deref_mut",
+    "display"
 ] }
 getset = { version = "0.1.2", default-features = false }
 hashbrown = { version = "0.14.1", default-features = false, features = [

--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -6,7 +6,7 @@ mod bech32;
 mod ed25519;
 mod nft;
 
-use derive_more::{From, Display};
+use derive_more::{Display, From};
 
 pub use self::{
     alias::AliasAddress,

--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -48,6 +48,16 @@ impl core::fmt::Debug for Address {
     }
 }
 
+impl core::fmt::Display for Address {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Ed25519(address) => address.fmt(f),
+            Self::Alias(address) => address.fmt(f),
+            Self::Nft(address) => address.fmt(f),
+        }
+    }
+}
+
 impl Address {
     /// Returns the address kind of an [`Address`].
     pub fn kind(&self) -> u8 {

--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -68,6 +68,15 @@ impl Address {
         }
     }
 
+    /// Returns the address kind of an [`Address`] as a string.
+    pub fn kind_str(&self) -> &str {
+        match self {
+            Self::Ed25519(_) => "Ed25519",
+            Self::Alias(_) => "Alias",
+            Self::Nft(_) => "Nft",
+        }
+    }
+
     /// Checks whether the address is an [`Ed25519Address`].
     pub fn is_ed25519(&self) -> bool {
         matches!(self, Self::Ed25519(_))

--- a/sdk/src/types/block/address/mod.rs
+++ b/sdk/src/types/block/address/mod.rs
@@ -6,7 +6,7 @@ mod bech32;
 mod ed25519;
 mod nft;
 
-use derive_more::From;
+use derive_more::{From, Display};
 
 pub use self::{
     alias::AliasAddress,
@@ -23,7 +23,7 @@ use crate::types::block::{
 };
 
 /// A generic address supporting different address kinds.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, From, packable::Packable)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, From, Display, packable::Packable)]
 #[packable(tag_type = u8, with_error = Error::InvalidAddressKind)]
 #[packable(unpack_error = Error)]
 pub enum Address {
@@ -39,16 +39,6 @@ pub enum Address {
 }
 
 impl core::fmt::Debug for Address {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::Ed25519(address) => address.fmt(f),
-            Self::Alias(address) => address.fmt(f),
-            Self::Nft(address) => address.fmt(f),
-        }
-    }
-}
-
-impl core::fmt::Display for Address {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Ed25519(address) => address.fmt(f),

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -62,6 +62,7 @@ use crate::{
     types::{
         api::core::response::OutputWithMetadataResponse,
         block::{
+            address::Bech32Address,
             output::{dto::FoundryOutputDto, AliasId, FoundryId, FoundryOutput, NftId, Output, OutputId, TokenId},
             payload::{
                 transaction::{TransactionEssence, TransactionId},
@@ -89,6 +90,8 @@ pub struct FilterOptions {
     pub foundry_ids: Option<HashSet<FoundryId>>,
     /// Return all nft outputs matching these IDs.
     pub nft_ids: Option<HashSet<NftId>>,
+    /// Return all outputs matching this address.
+    pub address: Option<Bech32Address>,
 }
 
 /// Details of an account.
@@ -364,6 +367,12 @@ impl AccountInner {
 
                 if let Some(output_types) = &filter.output_types {
                     if !output_types.contains(&output.output.kind()) {
+                        continue;
+                    }
+                }
+
+                if let Some(address) = &filter.address {
+                    if &output.address != address.inner() {
                         continue;
                     }
                 }

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -62,7 +62,6 @@ use crate::{
     types::{
         api::core::response::OutputWithMetadataResponse,
         block::{
-            address::Bech32Address,
             output::{dto::FoundryOutputDto, AliasId, FoundryId, FoundryOutput, NftId, Output, OutputId, TokenId},
             payload::{
                 transaction::{TransactionEssence, TransactionId},
@@ -90,8 +89,6 @@ pub struct FilterOptions {
     pub foundry_ids: Option<HashSet<FoundryId>>,
     /// Return all nft outputs matching these IDs.
     pub nft_ids: Option<HashSet<NftId>>,
-    /// Return all outputs matching this address.
-    pub address: Option<Bech32Address>,
 }
 
 /// Details of an account.
@@ -367,12 +364,6 @@ impl AccountInner {
 
                 if let Some(output_types) = &filter.output_types {
                     if !output_types.contains(&output.output.kind()) {
-                        continue;
-                    }
-                }
-
-                if let Some(address) = &filter.address {
-                    if &output.address != address.inner() {
                         continue;
                     }
                 }

--- a/sdk/src/wallet/account/operations/syncing/mod.rs
+++ b/sdk/src/wallet/account/operations/syncing/mod.rs
@@ -201,7 +201,9 @@ where
             }
 
             for (alias_or_nft_address, ed25519_address) in new_alias_and_nft_addresses.drain() {
-                let output_ids = self.get_output_ids_for_address(alias_or_nft_address.clone(), options).await?;
+                let output_ids = self
+                    .get_output_ids_for_address(alias_or_nft_address.clone(), options)
+                    .await?;
 
                 // Update address with unspent outputs
                 let address_with_unspent_outputs = addresses_with_unspent_outputs

--- a/sdk/src/wallet/account/operations/syncing/mod.rs
+++ b/sdk/src/wallet/account/operations/syncing/mod.rs
@@ -180,11 +180,8 @@ where
         let mut new_outputs_data = outputs_data.clone();
 
         loop {
-            // Clear, so we only get new addresses
-            new_alias_and_nft_addresses.clear();
-
             // Add new alias and nft addresses
-            for output_data in new_outputs_data.drain(0..) {
+            for output_data in new_outputs_data.drain(..) {
                 match &output_data.output {
                     Output::Alias(alias_output) => {
                         let alias_address = alias_output.alias_address(&output_data.output_id);
@@ -203,13 +200,13 @@ where
                 break;
             }
 
-            for (alias_or_nft_address, ed25519_address) in &new_alias_and_nft_addresses {
+            for (alias_or_nft_address, ed25519_address) in new_alias_and_nft_addresses.drain() {
                 let output_ids = self.get_output_ids_for_address(alias_or_nft_address.clone(), options).await?;
 
                 // Update address with unspent outputs
                 let address_with_unspent_outputs = addresses_with_unspent_outputs
                     .iter_mut()
-                    .find(|a| &a.address.inner == ed25519_address)
+                    .find(|a| a.address.inner == ed25519_address)
                     .ok_or_else(|| {
                         crate::wallet::Error::AddressNotFoundInAccount(ed25519_address.to_bech32(bech32_hrp))
                     })?;

--- a/sdk/src/wallet/account/operations/syncing/mod.rs
+++ b/sdk/src/wallet/account/operations/syncing/mod.rs
@@ -181,6 +181,7 @@ where
 
         loop {
             // Add new alias and nft addresses
+            #[allow(clippy::iter_with_drain)]
             for output_data in new_outputs_data.drain(..) {
                 match &output_data.output {
                     Output::Alias(alias_output) => {
@@ -201,9 +202,7 @@ where
             }
 
             for (alias_or_nft_address, ed25519_address) in new_alias_and_nft_addresses.drain() {
-                let output_ids = self
-                    .get_output_ids_for_address(alias_or_nft_address.clone(), options)
-                    .await?;
+                let output_ids = self.get_output_ids_for_address(alias_or_nft_address, options).await?;
 
                 // Update address with unspent outputs
                 let address_with_unspent_outputs = addresses_with_unspent_outputs


### PR DESCRIPTION
# Description of change

* Changes the `addresses` command to just print all account addresses as an indexed list (in a similar fashion as the outputs and transactions lists)
* Introduces a new `address <selector>` command which either takes an index of an address (as indexed by the `addresses` command) or accepts a `Bech32Address` and then displays its details (i.e. outputs, summed output amount, owned assets like NTs, NFTs, and Aliases)

## Links to any relevant issues

Closes #1320 


