### PR TITLE
Error fallback variant

### DIFF
--- a/sdk/src/types/block/error.rs
+++ b/sdk/src/types/block/error.rs
@@ -173,10 +173,9 @@ pub enum Error {
     DuplicateOutputChain(ChainId),
     InvalidField(&'static str),
     NullDelegationValidatorId,
+    #[cfg(feature = "std")]
+    Fallback(FallbackError),
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -375,6 +374,7 @@ impl fmt::Display for Error {
             Self::DuplicateOutputChain(chain_id) => write!(f, "duplicate output chain {chain_id}"),
             Self::InvalidField(field) => write!(f, "invalid field: {field}"),
             Self::NullDelegationValidatorId => write!(f, "null delegation validator ID"),
+            Self::Fallback(err) => write!(f, "error: {err}"),
         }
     }
 }
@@ -388,5 +388,29 @@ impl From<CryptoError> for Error {
 impl From<Infallible> for Error {
     fn from(error: Infallible) -> Self {
         match error {}
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct FallbackError(pub(crate) Box<dyn std::error::Error + Send + Sync>);
+
+#[cfg(feature = "std")]
+impl PartialEq for FallbackError {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "std")]
+impl Eq for FallbackError {}
+
+#[cfg(feature = "std")]
+impl fmt::Display for FallbackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/sdk/src/types/block/error.rs
+++ b/sdk/src/types/block/error.rs
@@ -177,6 +177,9 @@ pub enum Error {
     Fallback(FallbackError),
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -390,9 +393,6 @@ impl From<Infallible> for Error {
         match error {}
     }
 }
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
 
 #[cfg(feature = "std")]
 #[derive(Debug)]


### PR DESCRIPTION
# Description of change

Adds a `Fallback` variant to the block error enum.

Keeping it a `draft` for now bc I don't know whether that's the right enum, and whether other enums should have a fallback, too.

## Links to any relevant issues

Closes #1374 
