### PR TITLE
Rework basic output unlock conditions + features

### DIFF
--- a/cli/src/command/account.rs
+++ b/cli/src/command/account.rs
@@ -11,8 +11,8 @@ use iota_sdk::{
         block::{
             address::Bech32Address,
             output::{
-                unlock_condition::AddressUnlockCondition, AccountId, BasicOutputBuilder, FoundryId, NativeToken,
-                NativeTokensBuilder, NftId, Output, OutputId, TokenId,
+                AccountId, BasicOutputBuilder, FoundryId, NativeToken, NativeTokensBuilder, NftId, Output, OutputId,
+                TokenId,
             },
             payload::transaction::TransactionId,
             slot::SlotIndex,
@@ -726,13 +726,14 @@ pub async fn send_native_token_command(
 
         account.client().bech32_hrp_matches(address.hrp()).await?;
 
-        let outputs = [BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
-            .with_native_tokens([NativeToken::new(
-                TokenId::from_str(&token_id)?,
-                U256::from_dec_str(&amount).map_err(|e| Error::Miscellaneous(e.to_string()))?,
-            )?])
-            .finish_output(token_supply)?];
+        let outputs = [
+            BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure, address)
+                .with_native_tokens([NativeToken::new(
+                    TokenId::from_str(&token_id)?,
+                    U256::from_dec_str(&amount).map_err(|e| Error::Miscellaneous(e.to_string()))?,
+                )?])
+                .finish_output(token_supply)?,
+        ];
 
         account.send_outputs(outputs, None).await?
     } else {

--- a/sdk/examples/client/output/build_basic_output.rs
+++ b/sdk/examples/client/output/build_basic_output.rs
@@ -15,8 +15,7 @@ use iota_sdk::{
         output::{
             feature::{MetadataFeature, SenderFeature, TagFeature},
             unlock_condition::{
-                AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition,
-                TimelockUnlockCondition,
+                ExpirationUnlockCondition, StorageDepositReturnUnlockCondition, TimelockUnlockCondition,
             },
             BasicOutputBuilder,
         },
@@ -43,8 +42,7 @@ async fn main() -> Result<()> {
         .unwrap_or("rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy".to_string());
     let address = Address::try_from_bech32(address)?;
 
-    let basic_output_builder = BasicOutputBuilder::new_with_amount(1_000_000)
-        .add_unlock_condition(AddressUnlockCondition::new(address.clone()));
+    let basic_output_builder = BasicOutputBuilder::new_with_amount(1_000_000, address.clone());
 
     let outputs = [
         // most simple output
@@ -52,12 +50,12 @@ async fn main() -> Result<()> {
         // with metadata feature block
         basic_output_builder
             .clone()
-            .add_feature(MetadataFeature::new(METADATA)?)
+            .with_metadata_feature(MetadataFeature::new(METADATA)?)
             .finish_output(token_supply)?,
         // with storage deposit return
         basic_output_builder
             .clone()
-            .add_unlock_condition(StorageDepositReturnUnlockCondition::new(
+            .with_storage_deposit_return_unlock_condition(StorageDepositReturnUnlockCondition::new(
                 address.clone(),
                 1_000_000,
                 token_supply,
@@ -66,21 +64,21 @@ async fn main() -> Result<()> {
         // with expiration
         basic_output_builder
             .clone()
-            .add_unlock_condition(ExpirationUnlockCondition::new(address.clone(), 1)?)
+            .with_expiration_unlock_condition(ExpirationUnlockCondition::new(address.clone(), 1)?)
             .finish_output(token_supply)?,
         // with timelock
         basic_output_builder
             .clone()
-            .add_unlock_condition(TimelockUnlockCondition::new(1)?)
+            .with_timelock_unlock_condition(TimelockUnlockCondition::new(1)?)
             .finish_output(token_supply)?,
         // with tag feature
         basic_output_builder
             .clone()
-            .add_feature(TagFeature::new(METADATA)?)
+            .with_tag_feature(TagFeature::new(METADATA)?)
             .finish_output(token_supply)?,
         // with sender feature
         basic_output_builder
-            .add_feature(SenderFeature::new(address))
+            .with_sender_feature(SenderFeature::new(address))
             .finish_output(token_supply)?,
     ];
 

--- a/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
@@ -9,10 +9,7 @@
 use iota_sdk::{
     types::block::{
         address::Bech32Address,
-        output::{
-            unlock_condition::{AddressUnlockCondition, TimelockUnlockCondition},
-            BasicOutputBuilder,
-        },
+        output::{unlock_condition::TimelockUnlockCondition, BasicOutputBuilder},
         slot::SlotIndex,
     },
     wallet::Result,
@@ -41,12 +38,12 @@ async fn main() -> Result<()> {
         // TODO better time-based UX ?
         // Create an output with amount 1_000_000 and a timelock of 1000 slots.
         let slot_index = SlotIndex::from(1000);
-        let basic_output = BasicOutputBuilder::new_with_amount(1_000_000)
-            .add_unlock_condition(AddressUnlockCondition::new(Bech32Address::try_from_str(
-                "rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu",
-            )?))
-            .add_unlock_condition(TimelockUnlockCondition::new(slot_index)?)
-            .finish_output(account.client().get_token_supply().await?)?;
+        let basic_output = BasicOutputBuilder::new_with_amount(
+            1_000_000,
+            Bech32Address::try_from_str("rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu")?,
+        )
+        .with_timelock_unlock_condition(TimelockUnlockCondition::new(slot_index)?)
+        .finish_output(account.client().get_token_supply().await?)?;
 
         let transaction = account.send_outputs(vec![basic_output], None).await?;
         println!("Transaction sent: {}", transaction.transaction_id);

--- a/sdk/examples/how_tos/outputs/unlock_conditions.rs
+++ b/sdk/examples/how_tos/outputs/unlock_conditions.rs
@@ -15,9 +15,8 @@ use iota_sdk::{
         output::{
             dto::OutputDto,
             unlock_condition::{
-                AddressUnlockCondition, ExpirationUnlockCondition, GovernorAddressUnlockCondition,
-                ImmutableAccountAddressUnlockCondition, StateControllerAddressUnlockCondition,
-                StorageDepositReturnUnlockCondition, TimelockUnlockCondition,
+                ExpirationUnlockCondition, GovernorAddressUnlockCondition, ImmutableAccountAddressUnlockCondition,
+                StateControllerAddressUnlockCondition, StorageDepositReturnUnlockCondition, TimelockUnlockCondition,
             },
             AccountId, AccountOutputBuilder, BasicOutputBuilder, FoundryOutputBuilder, SimpleTokenScheme, TokenScheme,
         },
@@ -42,8 +41,7 @@ async fn main() -> Result<()> {
 
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(50, 0, 100)?);
 
-    let basic_output_builder = BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-        .add_unlock_condition(AddressUnlockCondition::new(address.clone()));
+    let basic_output_builder = BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure, address.clone());
     let account_output_builder =
         AccountOutputBuilder::new_with_minimum_storage_deposit(rent_structure, AccountId::null());
     let foundry_output_builder =
@@ -55,7 +53,7 @@ async fn main() -> Result<()> {
         // with storage deposit return unlock condition
         basic_output_builder
             .clone()
-            .add_unlock_condition(StorageDepositReturnUnlockCondition::new(
+            .with_storage_deposit_return_unlock_condition(StorageDepositReturnUnlockCondition::new(
                 address.clone(),
                 1000000,
                 token_supply,
@@ -64,11 +62,11 @@ async fn main() -> Result<()> {
         // with timeout unlock condition
         basic_output_builder
             .clone()
-            .add_unlock_condition(TimelockUnlockCondition::new(1)?)
+            .with_timelock_unlock_condition(TimelockUnlockCondition::new(1)?)
             .finish_output(token_supply)?,
         // with expiration unlock condition
         basic_output_builder
-            .add_unlock_condition(ExpirationUnlockCondition::new(address.clone(), 1)?)
+            .with_expiration_unlock_condition(ExpirationUnlockCondition::new(address.clone(), 1)?)
             .finish_output(token_supply)?,
         // with governor and state controller unlock condition
         account_output_builder

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -13,7 +13,7 @@
 use iota_sdk::{
     types::block::{
         address::Bech32Address,
-        output::{unlock_condition::AddressUnlockCondition, BasicOutputBuilder, UnlockCondition},
+        output::{BasicOutputBuilder, UnlockCondition},
     },
     wallet::Result,
     Wallet,
@@ -42,8 +42,7 @@ async fn main() -> Result<()> {
 
     println!("ADDRESSES:\n{:#?}", account_addresses);
 
-    let output = BasicOutputBuilder::new_with_amount(AMOUNT)
-        .add_unlock_condition(AddressUnlockCondition::new(account_addresses[0].as_ref().clone()))
+    let output = BasicOutputBuilder::new_with_amount(AMOUNT, account_addresses[0].clone())
         .finish_output(account.client().get_token_supply().await?)?;
 
     let controlled_by_account = if let [UnlockCondition::Address(address_unlock_condition)] = output

--- a/sdk/examples/wallet/events.rs
+++ b/sdk/examples/wallet/events.rs
@@ -14,10 +14,7 @@ use iota_sdk::{
         constants::SHIMMER_COIN_TYPE,
         secret::{mnemonic::MnemonicSecretManager, SecretManager},
     },
-    types::block::{
-        address::Address,
-        output::{unlock_condition::AddressUnlockCondition, BasicOutputBuilder},
-    },
+    types::block::{address::Address, output::BasicOutputBuilder},
     wallet::{ClientOptions, Result, Wallet},
 };
 
@@ -56,9 +53,10 @@ async fn main() -> Result<()> {
     println!("Balance BEFORE:\n{:#?}", balance.base_coin());
 
     // send transaction
-    let outputs = [BasicOutputBuilder::new_with_amount(SEND_AMOUNT)
-        .add_unlock_condition(AddressUnlockCondition::new(Address::try_from_bech32(RECV_ADDRESS)?))
-        .finish_output(account.client().get_token_supply().await?)?];
+    let outputs = [
+        BasicOutputBuilder::new_with_amount(SEND_AMOUNT, Address::try_from_bech32(RECV_ADDRESS)?)
+            .finish_output(account.client().get_token_supply().await?)?,
+    ];
 
     let transaction = account.send_outputs(outputs, None).await?;
     println!("Transaction sent: {}", transaction.transaction_id);

--- a/sdk/examples/wallet/split_funds.rs
+++ b/sdk/examples/wallet/split_funds.rs
@@ -16,7 +16,7 @@ use iota_sdk::{
         constants::SHIMMER_COIN_TYPE,
         secret::{mnemonic::MnemonicSecretManager, SecretManager},
     },
-    types::block::output::{unlock_condition::AddressUnlockCondition, BasicOutputBuilder},
+    types::block::output::BasicOutputBuilder,
     wallet::{account::types::Bip44Address, Account, ClientOptions, Result, Wallet},
 };
 
@@ -65,8 +65,7 @@ async fn main() -> Result<()> {
         let outputs_per_transaction = addresses_chunk
             .into_iter()
             .map(|a| {
-                BasicOutputBuilder::new_with_amount(SEND_AMOUNT)
-                    .add_unlock_condition(AddressUnlockCondition::new(a.address()))
+                BasicOutputBuilder::new_with_amount(SEND_AMOUNT, a.address())
                     .finish_output(token_supply)
                     .unwrap()
             })

--- a/sdk/src/client/api/block_builder/input_selection/mod.rs
+++ b/sdk/src/client/api/block_builder/input_selection/mod.rs
@@ -237,10 +237,7 @@ impl InputSelection {
                 return false;
             }
 
-            // PANIC: safe to unwrap as non basic/account/foundry/nft outputs are already filtered out.
-            let unlock_conditions = input.output.unlock_conditions().unwrap();
-
-            if unlock_conditions.is_time_locked(self.slot_index) {
+            if input.output.is_time_locked(self.slot_index) {
                 return false;
             }
 

--- a/sdk/src/client/api/block_builder/input_selection/requirement/amount.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/amount.rs
@@ -22,12 +22,9 @@ pub(crate) fn sdruc_not_expired(
     output: &Output,
     slot_index: SlotIndex,
 ) -> Option<&StorageDepositReturnUnlockCondition> {
-    // PANIC: safe to unwrap as outputs without unlock conditions have been filtered out already.
-    let unlock_conditions = output.unlock_conditions().unwrap();
-
-    unlock_conditions.storage_deposit_return().and_then(|sdr| {
-        let expired = unlock_conditions
-            .expiration()
+    output.storage_deposit_return_unlock_condition().and_then(|sdr| {
+        let expired = output
+            .expiration_unlock_condition()
             .map_or(false, |expiration| slot_index >= expiration.slot_index());
 
         // We only have to send the storage deposit return back if the output is not expired

--- a/sdk/src/client/api/block_builder/input_selection/requirement/ed25519.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/ed25519.rs
@@ -41,16 +41,19 @@ impl InputSelection {
         address: &Address,
     ) -> (bool, Option<AccountTransition>) {
         if input.output.is_account() {
-            // PANIC: safe to unwrap as outputs without unlock conditions have been filtered out already.
-            let unlock_conditions = input.output.unlock_conditions().unwrap();
-
             // PANIC: safe to unwrap as accounts have a state controller address.
-            if unlock_conditions.state_controller_address().unwrap().address() == address {
+            if input
+                .output
+                .state_controller_address_unlock_condition()
+                .unwrap()
+                .address()
+                == address
+            {
                 return (self.addresses.contains(address), Some(AccountTransition::State));
             }
 
             // PANIC: safe to unwrap as accounts have a governor address.
-            if unlock_conditions.governor_address().unwrap().address() == address {
+            if input.output.governor_address_unlock_condition().unwrap().address() == address {
                 return (self.addresses.contains(address), Some(AccountTransition::Governance));
             }
 

--- a/sdk/src/client/api/block_builder/input_selection/requirement/mod.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/mod.rs
@@ -126,7 +126,7 @@ impl InputSelection {
             };
 
             // Add a sender requirement if the sender feature is present.
-            if let Some(sender) = output.features().and_then(Features::sender) {
+            if let Some(sender) = output.sender_feature() {
                 let requirement = Requirement::Sender(sender.address().clone());
                 log::debug!("Adding {requirement:?} from output");
                 self.requirements.push(requirement);

--- a/sdk/src/types/block/error.rs
+++ b/sdk/src/types/block/error.rs
@@ -163,11 +163,11 @@ pub enum Error {
     StorageDepositReturnOverflow,
     TimelockUnlockConditionZero,
     TooManyCommitmentInputs,
-    UnallowedFeature {
+    DisallowedFeature {
         index: usize,
         kind: u8,
     },
-    UnallowedUnlockCondition {
+    DisallowedUnlockCondition {
         index: usize,
         kind: u8,
     },
@@ -373,10 +373,10 @@ impl fmt::Display for Error {
                 )
             }
             Self::TooManyCommitmentInputs => write!(f, "too many commitment inputs"),
-            Self::UnallowedFeature { index, kind } => {
+            Self::DisallowedFeature { index, kind } => {
                 write!(f, "unallowed feature at index {index} with kind {kind}")
             }
-            Self::UnallowedUnlockCondition { index, kind } => {
+            Self::DisallowedUnlockCondition { index, kind } => {
                 write!(f, "unallowed unlock condition at index {index} with kind {kind}")
             }
             Self::UnlockConditionsNotUniqueSorted => write!(f, "unlock conditions are not unique and/or sorted"),

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -3,21 +3,29 @@
 
 use alloc::collections::BTreeSet;
 
-use packable::Packable;
+use getset::{CopyGetters, Getters};
+use packable::{
+    error::{UnpackError, UnpackErrorExt},
+    Packable,
+};
 
+use super::{
+    feature::{MetadataFeature, SenderFeature, TagFeature},
+    unlock_condition::{ExpirationUnlockCondition, StorageDepositReturnUnlockCondition, TimelockUnlockCondition},
+    verify_output_amount, AddressUnlockCondition,
+};
 use crate::types::{
     block::{
         address::Address,
         output::{
-            feature::{verify_allowed_features, Feature, FeatureFlags, Features},
-            unlock_condition::{
-                verify_allowed_unlock_conditions, UnlockCondition, UnlockConditionFlags, UnlockConditions,
-            },
-            verify_output_amount_min, verify_output_amount_packable, verify_output_amount_supply, NativeToken,
-            NativeTokens, Output, OutputBuilderAmount, OutputId, Rent, RentStructure,
+            feature::{Feature, Features},
+            unlock_condition::{UnlockCondition, UnlockConditions},
+            verify_output_amount_min, verify_output_amount_supply, NativeToken, NativeTokens, Output,
+            OutputBuilderAmount, OutputId, Rent, RentStructure,
         },
         protocol::ProtocolParameters,
         semantic::{TransactionFailureReason, ValidationContext},
+        slot::SlotIndex,
         unlock::Unlock,
         Error,
     },
@@ -31,31 +39,41 @@ pub struct BasicOutputBuilder {
     amount: OutputBuilderAmount,
     mana: u64,
     native_tokens: BTreeSet<NativeToken>,
-    unlock_conditions: BTreeSet<UnlockCondition>,
-    features: BTreeSet<Feature>,
+    address_unlock_condition: AddressUnlockCondition,
+    storage_deposit_return_unlock_condition: Option<StorageDepositReturnUnlockCondition>,
+    timelock_unlock_condition: Option<TimelockUnlockCondition>,
+    expiration_unlock_condition: Option<ExpirationUnlockCondition>,
+    sender_feature: Option<SenderFeature>,
+    metadata_feature: Option<MetadataFeature>,
+    tag_feature: Option<TagFeature>,
 }
 
 impl BasicOutputBuilder {
-    /// Creates a [`BasicOutputBuilder`] with a provided amount.
+    /// Creates a [`BasicOutputBuilder`] with a provided amount and an address.
     #[inline(always)]
-    pub fn new_with_amount(amount: u64) -> Self {
-        Self::new(OutputBuilderAmount::Amount(amount))
+    pub fn new_with_amount(amount: u64, address: impl Into<Address>) -> Self {
+        Self::new(OutputBuilderAmount::Amount(amount), address)
     }
 
-    /// Creates an [`BasicOutputBuilder`] with a provided rent structure.
+    /// Creates an [`BasicOutputBuilder`] with a provided rent structure and an address.
     /// The amount will be set to the minimum storage deposit.
     #[inline(always)]
-    pub fn new_with_minimum_storage_deposit(rent_structure: RentStructure) -> Self {
-        Self::new(OutputBuilderAmount::MinimumStorageDeposit(rent_structure))
+    pub fn new_with_minimum_storage_deposit(rent_structure: RentStructure, address: impl Into<Address>) -> Self {
+        Self::new(OutputBuilderAmount::MinimumStorageDeposit(rent_structure), address)
     }
 
-    fn new(amount: OutputBuilderAmount) -> Self {
+    fn new(amount: OutputBuilderAmount, address: impl Into<Address>) -> Self {
         Self {
             amount,
             mana: Default::default(),
             native_tokens: BTreeSet::new(),
-            unlock_conditions: BTreeSet::new(),
-            features: BTreeSet::new(),
+            address_unlock_condition: AddressUnlockCondition::new(address),
+            storage_deposit_return_unlock_condition: Default::default(),
+            timelock_unlock_condition: Default::default(),
+            expiration_unlock_condition: Default::default(),
+            sender_feature: Default::default(),
+            metadata_feature: Default::default(),
+            tag_feature: Default::default(),
         }
     }
 
@@ -94,79 +112,102 @@ impl BasicOutputBuilder {
         self
     }
 
-    /// Adds an [`UnlockCondition`] to the builder, if one does not already exist of that type.
+    /// Sets the address.
     #[inline(always)]
-    pub fn add_unlock_condition(mut self, unlock_condition: impl Into<UnlockCondition>) -> Self {
-        self.unlock_conditions.insert(unlock_condition.into());
+    pub fn with_address(mut self, address: impl Into<Address>) -> Self {
+        self.address_unlock_condition = AddressUnlockCondition::from(address.into());
         self
     }
 
-    /// Sets the [`UnlockConditions`]s in the builder, overwriting any existing values.
+    /// Sets the address.
     #[inline(always)]
-    pub fn with_unlock_conditions(
-        mut self,
-        unlock_conditions: impl IntoIterator<Item = impl Into<UnlockCondition>>,
-    ) -> Self {
-        self.unlock_conditions = unlock_conditions.into_iter().map(Into::into).collect();
+    pub fn with_address_unlock_condition(mut self, address: impl Into<AddressUnlockCondition>) -> Self {
+        self.address_unlock_condition = address.into();
         self
     }
 
-    /// Replaces an [`UnlockCondition`] of the builder with a new one, or adds it.
-    pub fn replace_unlock_condition(mut self, unlock_condition: impl Into<UnlockCondition>) -> Self {
-        self.unlock_conditions.replace(unlock_condition.into());
-        self
-    }
-
-    /// Clears all [`UnlockConditions`]s from the builder.
+    /// Clears the unlock conditions (other than the address).
     #[inline(always)]
     pub fn clear_unlock_conditions(mut self) -> Self {
-        self.unlock_conditions.clear();
+        self.storage_deposit_return_unlock_condition = None;
+        self.timelock_unlock_condition = None;
+        self.expiration_unlock_condition = None;
         self
     }
 
-    /// Adds a [`Feature`] to the builder, if one does not already exist of that type.
+    /// Sets the storage deposit return unlock condition.
     #[inline(always)]
-    pub fn add_feature(mut self, feature: impl Into<Feature>) -> Self {
-        self.features.insert(feature.into());
+    pub fn with_storage_deposit_return_unlock_condition(
+        mut self,
+        storage_deposit_return_unlock_condition: impl Into<Option<StorageDepositReturnUnlockCondition>>,
+    ) -> Self {
+        self.storage_deposit_return_unlock_condition = storage_deposit_return_unlock_condition.into();
         self
     }
 
-    /// Sets the [`Feature`]s in the builder, overwriting any existing values.
+    /// Sets the timelock unlock condition.
     #[inline(always)]
-    pub fn with_features(mut self, features: impl IntoIterator<Item = impl Into<Feature>>) -> Self {
-        self.features = features.into_iter().map(Into::into).collect();
+    pub fn with_timelock_unlock_condition(
+        mut self,
+        timelock_unlock_condition: impl Into<Option<TimelockUnlockCondition>>,
+    ) -> Self {
+        self.timelock_unlock_condition = timelock_unlock_condition.into();
         self
     }
 
-    /// Replaces a [`Feature`] of the builder with a new one, or adds it.
-    pub fn replace_feature(mut self, feature: impl Into<Feature>) -> Self {
-        self.features.replace(feature.into());
+    /// Sets the expiration unlock condition.
+    #[inline(always)]
+    pub fn with_expiration_unlock_condition(
+        mut self,
+        expiration_unlock_condition: impl Into<Option<ExpirationUnlockCondition>>,
+    ) -> Self {
+        self.expiration_unlock_condition = expiration_unlock_condition.into();
         self
     }
 
-    /// Clears all [`Feature`]s from the builder.
+    /// Sets the sender feature.
+    #[inline(always)]
+    pub fn with_sender_feature(mut self, sender_feature: impl Into<Option<SenderFeature>>) -> Self {
+        self.sender_feature = sender_feature.into();
+        self
+    }
+
+    /// Sets the metadata feature.
+    #[inline(always)]
+    pub fn with_metadata_feature(mut self, metadata_feature: impl Into<Option<MetadataFeature>>) -> Self {
+        self.metadata_feature = metadata_feature.into();
+        self
+    }
+
+    /// Sets the tag feature.
+    #[inline(always)]
+    pub fn with_tag_feature(mut self, tag_feature: impl Into<Option<TagFeature>>) -> Self {
+        self.tag_feature = tag_feature.into();
+        self
+    }
+
+    /// Clears the features.
     #[inline(always)]
     pub fn clear_features(mut self) -> Self {
-        self.features.clear();
+        self.sender_feature = None;
+        self.metadata_feature = None;
+        self.tag_feature = None;
         self
     }
 
     ///
     pub fn finish(self) -> Result<BasicOutput, Error> {
-        let unlock_conditions = UnlockConditions::from_set(self.unlock_conditions)?;
-
-        verify_unlock_conditions::<true>(&unlock_conditions)?;
-
-        let features = Features::from_set(self.features)?;
-
-        verify_features::<true>(&features)?;
-
         let mut output = BasicOutput {
             amount: 1u64,
             mana: self.mana,
             native_tokens: NativeTokens::from_set(self.native_tokens)?,
-            unlock_conditions,
-            features,
+            address_unlock_condition: self.address_unlock_condition,
+            storage_deposit_return_unlock_condition: self.storage_deposit_return_unlock_condition,
+            timelock_unlock_condition: self.timelock_unlock_condition,
+            expiration_unlock_condition: self.expiration_unlock_condition,
+            sender_feature: self.sender_feature,
+            metadata_feature: self.metadata_feature,
+            tag_feature: self.tag_feature,
         };
 
         output.amount = match self.amount {
@@ -204,108 +245,140 @@ impl From<&BasicOutput> for BasicOutputBuilder {
             amount: OutputBuilderAmount::Amount(output.amount),
             mana: output.mana,
             native_tokens: output.native_tokens.iter().copied().collect(),
-            unlock_conditions: output.unlock_conditions.iter().cloned().collect(),
-            features: output.features.iter().cloned().collect(),
+            address_unlock_condition: output.address_unlock_condition.clone(),
+            storage_deposit_return_unlock_condition: output.storage_deposit_return_unlock_condition.clone(),
+            timelock_unlock_condition: output.timelock_unlock_condition.clone(),
+            expiration_unlock_condition: output.expiration_unlock_condition.clone(),
+            sender_feature: output.sender_feature.clone(),
+            metadata_feature: output.metadata_feature.clone(),
+            tag_feature: output.tag_feature.clone(),
         }
     }
 }
 
 /// Describes a basic output with optional features.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Packable)]
-#[packable(unpack_error = Error)]
-#[packable(unpack_visitor = ProtocolParameters)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Getters, CopyGetters)]
 pub struct BasicOutput {
     /// Amount of IOTA coins to deposit with this output.
-    #[packable(verify_with = verify_output_amount_packable)]
+    #[getset(get_copy = "pub")]
     amount: u64,
     /// Amount of stored Mana held by this output.
+    #[getset(get_copy = "pub")]
     mana: u64,
     /// Native tokens held by this output.
+    #[getset(get = "pub")]
     native_tokens: NativeTokens,
-    /// Define how the output can be unlocked in a transaction.
-    #[packable(verify_with = verify_unlock_conditions_packable)]
-    unlock_conditions: UnlockConditions,
-    #[packable(verify_with = verify_features_packable)]
-    /// Features of the output.
-    features: Features,
+    /// The condition for unlocking this output with an address.
+    #[getset(get = "pub")]
+    address_unlock_condition: AddressUnlockCondition,
+    /// The optional condition for unlocking this output with a returned storage deposit.
+    storage_deposit_return_unlock_condition: Option<StorageDepositReturnUnlockCondition>,
+    /// The optional condition for unlocking this output with a timelock.
+    timelock_unlock_condition: Option<TimelockUnlockCondition>,
+    /// The optional condition for unlocking this output with an expiration.
+    expiration_unlock_condition: Option<ExpirationUnlockCondition>,
+    /// Optional sender feature of the output.
+    sender_feature: Option<SenderFeature>,
+    /// Optional metadata feature of the output.
+    metadata_feature: Option<MetadataFeature>,
+    /// Optional tag feature of the output.
+    tag_feature: Option<TagFeature>,
 }
 
 impl BasicOutput {
     /// The [`Output`](crate::types::block::output::Output) kind of an [`BasicOutput`].
     pub const KIND: u8 = 0;
 
-    /// The set of allowed [`UnlockCondition`]s for an [`BasicOutput`].
-    const ALLOWED_UNLOCK_CONDITIONS: UnlockConditionFlags = UnlockConditionFlags::ADDRESS
-        .union(UnlockConditionFlags::STORAGE_DEPOSIT_RETURN)
-        .union(UnlockConditionFlags::TIMELOCK)
-        .union(UnlockConditionFlags::EXPIRATION);
-    /// The set of allowed [`Feature`]s for an [`BasicOutput`].
-    pub const ALLOWED_FEATURES: FeatureFlags = FeatureFlags::SENDER
-        .union(FeatureFlags::METADATA)
-        .union(FeatureFlags::TAG);
-
     /// Creates a new [`BasicOutputBuilder`] with a provided amount.
     #[inline(always)]
-    pub fn build_with_amount(amount: u64) -> BasicOutputBuilder {
-        BasicOutputBuilder::new_with_amount(amount)
+    pub fn build_with_amount(amount: u64, address: impl Into<Address>) -> BasicOutputBuilder {
+        BasicOutputBuilder::new_with_amount(amount, address)
     }
 
     /// Creates a new [`BasicOutputBuilder`] with a provided rent structure.
     /// The amount will be set to the minimum storage deposit.
     #[inline(always)]
-    pub fn build_with_minimum_storage_deposit(rent_structure: RentStructure) -> BasicOutputBuilder {
-        BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
+    pub fn build_with_minimum_storage_deposit(
+        rent_structure: RentStructure,
+        address: impl Into<Address>,
+    ) -> BasicOutputBuilder {
+        BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure, address)
     }
 
-    ///
-    #[inline(always)]
-    pub fn amount(&self) -> u64 {
-        self.amount
-    }
-
-    #[inline(always)]
-    pub fn mana(&self) -> u64 {
-        self.mana
-    }
-
-    ///
-    #[inline(always)]
-    pub fn native_tokens(&self) -> &NativeTokens {
-        &self.native_tokens
-    }
-
-    ///
-    #[inline(always)]
-    pub fn unlock_conditions(&self) -> &UnlockConditions {
-        &self.unlock_conditions
-    }
-
-    ///
-    #[inline(always)]
-    pub fn features(&self) -> &Features {
-        &self.features
-    }
-
-    ///
+    /// Gets the address from the [`AddressUnlockCondition`]`.
     #[inline(always)]
     pub fn address(&self) -> &Address {
-        // A BasicOutput must have an AddressUnlockCondition.
-        self.unlock_conditions
-            .address()
-            .map(|unlock_condition| unlock_condition.address())
-            .unwrap()
+        self.address_unlock_condition.address()
+    }
+
+    pub fn storage_deposit_return_unlock_condition(&self) -> Option<&StorageDepositReturnUnlockCondition> {
+        self.storage_deposit_return_unlock_condition.as_ref()
+    }
+
+    pub fn timelock_unlock_condition(&self) -> Option<&TimelockUnlockCondition> {
+        self.timelock_unlock_condition.as_ref()
+    }
+
+    pub fn expiration_unlock_condition(&self) -> Option<&ExpirationUnlockCondition> {
+        self.expiration_unlock_condition.as_ref()
+    }
+
+    pub fn unlock_conditions(&self) -> UnlockConditions {
+        // Unwrap: safe because we know the unlock conditions are valid
+        UnlockConditions::from_vec(
+            [
+                Some(self.address_unlock_condition.clone().into()),
+                self.storage_deposit_return_unlock_condition
+                    .clone()
+                    .map(UnlockCondition::from),
+                self.timelock_unlock_condition.clone().map(UnlockCondition::from),
+                self.expiration_unlock_condition.clone().map(UnlockCondition::from),
+            ]
+            .into_iter()
+            .filter_map(|v| v)
+            .collect(),
+        )
+        .unwrap()
+    }
+
+    pub fn sender_feature(&self) -> Option<&SenderFeature> {
+        self.sender_feature.as_ref()
+    }
+
+    pub fn metadata_feature(&self) -> Option<&MetadataFeature> {
+        self.metadata_feature.as_ref()
+    }
+
+    pub fn tag_feature(&self) -> Option<&TagFeature> {
+        self.tag_feature.as_ref()
+    }
+
+    pub fn features(&self) -> Features {
+        // Unwrap: safe because we know the features are valid
+        Features::from_vec(
+            [
+                self.sender_feature.clone().map(Feature::from),
+                self.tag_feature.clone().map(Feature::from),
+                self.metadata_feature.clone().map(Feature::from),
+            ]
+            .into_iter()
+            .filter_map(|v| v)
+            .collect(),
+        )
+        .unwrap()
     }
 
     ///
     pub fn unlock(
         &self,
-        _output_id: &OutputId,
         unlock: &Unlock,
         inputs: &[(&OutputId, &Output)],
         context: &mut ValidationContext<'_>,
     ) -> Result<(), TransactionFailureReason> {
-        self.unlock_conditions()
-            .locked_address(self.address(), context.essence.creation_slot())
+        self.expiration_unlock_condition
+            .as_ref()
+            .and_then(|uc| uc.return_address_expired(context.essence.creation_slot()))
+            .unwrap_or_else(|| self.address())
             .unlock(unlock, inputs, context)
     }
 
@@ -313,45 +386,123 @@ impl BasicOutput {
     /// Simple deposit outputs are basic outputs with only an address unlock condition, no native tokens and no
     /// features. They are used to return storage deposits.
     pub fn simple_deposit_address(&self) -> Option<&Address> {
-        if let [UnlockCondition::Address(address)] = self.unlock_conditions().as_ref() {
-            if self.mana == 0 && self.native_tokens.is_empty() && self.features.is_empty() {
-                return Some(address.address());
-            }
+        if self.storage_deposit_return_unlock_condition.is_none()
+            && self.timelock_unlock_condition.is_none()
+            && self.expiration_unlock_condition.is_none()
+            && self.sender_feature.is_none()
+            && self.metadata_feature.is_none()
+            && self.tag_feature.is_none()
+            && self.mana == 0
+            && self.native_tokens.is_empty()
+        {
+            return Some(self.address());
         }
 
         None
     }
+
+    /// Returns the address to be unlocked.
+    #[inline(always)]
+    pub fn locked_address<'a>(&'a self, address: &'a Address, slot_index: SlotIndex) -> &'a Address {
+        self.expiration_unlock_condition()
+            .and_then(|e| e.return_address_expired(slot_index))
+            .unwrap_or(address)
+    }
+
+    /// Returns whether a time lock exists and is still relevant.
+    #[inline(always)]
+    pub fn is_time_locked(&self, slot_index: impl Into<SlotIndex>) -> bool {
+        let slot_index = slot_index.into();
+
+        self.timelock_unlock_condition()
+            .map_or(false, |timelock| slot_index < timelock.slot_index())
+    }
+
+    /// Returns whether an expiration exists and is expired.
+    #[inline(always)]
+    pub fn is_expired(&self, slot_index: impl Into<SlotIndex>) -> bool {
+        let slot_index = slot_index.into();
+
+        self.expiration_unlock_condition()
+            .map_or(false, |expiration| slot_index >= expiration.slot_index())
+    }
 }
 
-fn verify_unlock_conditions<const VERIFY: bool>(unlock_conditions: &UnlockConditions) -> Result<(), Error> {
-    if VERIFY {
-        if unlock_conditions.address().is_none() {
-            Err(Error::MissingAddressUnlockCondition)
-        } else {
-            verify_allowed_unlock_conditions(unlock_conditions, BasicOutput::ALLOWED_UNLOCK_CONDITIONS)
+impl Packable for BasicOutput {
+    type UnpackError = Error;
+    type UnpackVisitor = ProtocolParameters;
+
+    fn pack<P: packable::packer::Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
+        self.amount.pack(packer)?;
+        self.mana.pack(packer)?;
+        self.native_tokens.pack(packer)?;
+        let unlock_conditions = self.unlock_conditions();
+        unlock_conditions.pack(packer)?;
+        let features = self.features();
+        features.pack(packer)?;
+        Ok(())
+    }
+
+    fn unpack<U: packable::unpacker::Unpacker, const VERIFY: bool>(
+        unpacker: &mut U,
+        params: &Self::UnpackVisitor,
+    ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
+        let amount = u64::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        verify_output_amount(amount, params.token_supply()).map_err(UnpackError::Packable)?;
+        let mana = u64::unpack::<_, VERIFY>(unpacker, &()).coerce()?;
+        let native_tokens = NativeTokens::unpack::<_, VERIFY>(unpacker, &())?;
+        let unlock_conditions = UnlockConditions::unpack::<_, VERIFY>(unpacker, params)?;
+        let (
+            mut address_unlock_condition,
+            mut storage_deposit_return_unlock_condition,
+            mut timelock_unlock_condition,
+            mut expiration_unlock_condition,
+        ) = Default::default();
+        for (index, unlock_condition) in unlock_conditions.into_iter().enumerate() {
+            match unlock_condition {
+                UnlockCondition::Address(uc) => address_unlock_condition = Some(uc),
+                UnlockCondition::StorageDepositReturn(uc) => storage_deposit_return_unlock_condition = Some(uc),
+                UnlockCondition::Timelock(uc) => timelock_unlock_condition = Some(uc),
+                UnlockCondition::Expiration(uc) => expiration_unlock_condition = Some(uc),
+                _ => {
+                    return Err(UnpackError::Packable(Error::DisallowedUnlockCondition {
+                        index,
+                        kind: unlock_condition.kind(),
+                    }));
+                }
+            }
         }
-    } else {
-        Ok(())
+        let Some(address_unlock_condition) = address_unlock_condition else {
+            return Err(UnpackError::Packable(Error::MissingAddressUnlockCondition));
+        };
+        let features = Features::unpack::<_, VERIFY>(unpacker, &())?;
+        let (mut sender_feature, mut metadata_feature, mut tag_feature) = Default::default();
+        for (index, feature) in features.into_iter().enumerate() {
+            match feature {
+                Feature::Sender(f) => sender_feature = Some(f),
+                Feature::Metadata(f) => metadata_feature = Some(f),
+                Feature::Tag(f) => tag_feature = Some(f),
+                _ => {
+                    return Err(UnpackError::Packable(Error::DisallowedFeature {
+                        index,
+                        kind: feature.kind(),
+                    }));
+                }
+            }
+        }
+        Ok(Self {
+            amount,
+            mana,
+            native_tokens,
+            address_unlock_condition,
+            storage_deposit_return_unlock_condition,
+            timelock_unlock_condition,
+            expiration_unlock_condition,
+            sender_feature,
+            metadata_feature,
+            tag_feature,
+        })
     }
-}
-
-fn verify_unlock_conditions_packable<const VERIFY: bool>(
-    unlock_conditions: &UnlockConditions,
-    _: &ProtocolParameters,
-) -> Result<(), Error> {
-    verify_unlock_conditions::<VERIFY>(unlock_conditions)
-}
-
-fn verify_features<const VERIFY: bool>(features: &Features) -> Result<(), Error> {
-    if VERIFY {
-        verify_allowed_features(features, BasicOutput::ALLOWED_FEATURES)
-    } else {
-        Ok(())
-    }
-}
-
-fn verify_features_packable<const VERIFY: bool>(features: &Features, _: &ProtocolParameters) -> Result<(), Error> {
-    verify_features::<VERIFY>(features)
 }
 
 #[cfg(feature = "serde")]
@@ -403,16 +554,63 @@ pub(crate) mod dto {
         type Error = Error;
 
         fn try_from_dto_with_params_inner(dto: Self::Dto, params: ValidationParams<'_>) -> Result<Self, Self::Error> {
-            let mut builder = BasicOutputBuilder::new_with_amount(dto.amount)
-                .with_native_tokens(dto.native_tokens)
-                .with_mana(dto.mana)
-                .with_features(dto.features);
-
-            for u in dto.unlock_conditions {
-                builder = builder.add_unlock_condition(UnlockCondition::try_from_dto_with_params(u, &params)?);
+            if let Some(token_supply) = params.token_supply() {
+                verify_output_amount(dto.amount, token_supply)?;
+            }
+            let (
+                mut address_unlock_condition,
+                mut storage_deposit_return_unlock_condition,
+                mut timelock_unlock_condition,
+                mut expiration_unlock_condition,
+            ) = Default::default();
+            for (index, unlock_condition) in dto.unlock_conditions.into_iter().enumerate() {
+                match unlock_condition {
+                    UnlockConditionDto::Address(uc) => address_unlock_condition = Some(uc),
+                    UnlockConditionDto::StorageDepositReturn(uc) => {
+                        storage_deposit_return_unlock_condition = Some(
+                            StorageDepositReturnUnlockCondition::try_from_dto_with_params(uc, &params)?,
+                        )
+                    }
+                    UnlockConditionDto::Timelock(uc) => timelock_unlock_condition = Some(uc),
+                    UnlockConditionDto::Expiration(uc) => expiration_unlock_condition = Some(uc),
+                    _ => {
+                        return Err(Error::DisallowedUnlockCondition {
+                            index,
+                            kind: unlock_condition.kind(),
+                        });
+                    }
+                }
+            }
+            let Some(address_unlock_condition) = address_unlock_condition else {
+                return Err(Error::MissingAddressUnlockCondition);
+            };
+            let (mut sender_feature, mut metadata_feature, mut tag_feature) = Default::default();
+            for (index, feature) in dto.features.into_iter().enumerate() {
+                match feature {
+                    Feature::Sender(f) => sender_feature = Some(f),
+                    Feature::Metadata(f) => metadata_feature = Some(f),
+                    Feature::Tag(f) => tag_feature = Some(f),
+                    _ => {
+                        return Err(Error::DisallowedFeature {
+                            index,
+                            kind: feature.kind(),
+                        });
+                    }
+                }
             }
 
-            builder.finish_with_params(params)
+            Ok(Self {
+                amount: dto.amount,
+                mana: dto.mana,
+                native_tokens: NativeTokens::from_vec(dto.native_tokens)?,
+                address_unlock_condition,
+                storage_deposit_return_unlock_condition,
+                timelock_unlock_condition,
+                expiration_unlock_condition,
+                sender_feature,
+                metadata_feature,
+                tag_feature,
+            })
         }
     }
 
@@ -426,45 +624,85 @@ pub(crate) mod dto {
             params: impl Into<ValidationParams<'a>> + Send,
         ) -> Result<Self, Error> {
             let params = params.into();
-            let mut builder = match amount {
-                OutputBuilderAmount::Amount(amount) => BasicOutputBuilder::new_with_amount(amount),
-                OutputBuilderAmount::MinimumStorageDeposit(rent_structure) => {
-                    BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
+            let (
+                mut address_unlock_condition,
+                mut storage_deposit_return_unlock_condition,
+                mut timelock_unlock_condition,
+                mut expiration_unlock_condition,
+            ) = Default::default();
+            for (index, unlock_condition) in unlock_conditions.into_iter().enumerate() {
+                match unlock_condition {
+                    UnlockConditionDto::Address(uc) => address_unlock_condition = Some(uc),
+                    UnlockConditionDto::StorageDepositReturn(uc) => {
+                        storage_deposit_return_unlock_condition = Some(
+                            StorageDepositReturnUnlockCondition::try_from_dto_with_params(uc, &params)?,
+                        )
+                    }
+                    UnlockConditionDto::Timelock(uc) => timelock_unlock_condition = Some(uc),
+                    UnlockConditionDto::Expiration(uc) => expiration_unlock_condition = Some(uc),
+                    _ => {
+                        return Err(Error::DisallowedUnlockCondition {
+                            index,
+                            kind: unlock_condition.kind(),
+                        });
+                    }
                 }
             }
-            .with_mana(mana);
-
-            if let Some(native_tokens) = native_tokens {
-                builder = builder.with_native_tokens(native_tokens);
+            let Some(address_unlock_condition) = address_unlock_condition else {
+                return Err(Error::MissingAddressUnlockCondition);
+            };
+            let (mut sender_feature, mut metadata_feature, mut tag_feature) = Default::default();
+            for (index, feature) in features.into_iter().flatten().enumerate() {
+                match feature {
+                    Feature::Sender(f) => sender_feature = Some(f),
+                    Feature::Metadata(f) => metadata_feature = Some(f),
+                    Feature::Tag(f) => tag_feature = Some(f),
+                    _ => {
+                        return Err(Error::DisallowedFeature {
+                            index,
+                            kind: feature.kind(),
+                        });
+                    }
+                }
             }
-
-            let unlock_conditions = unlock_conditions
-                .into_iter()
-                .map(|u| UnlockCondition::try_from_dto_with_params(u, &params))
-                .collect::<Result<Vec<UnlockCondition>, Error>>()?;
-            builder = builder.with_unlock_conditions(unlock_conditions);
-
-            if let Some(features) = features {
-                builder = builder.with_features(features);
+            match amount {
+                OutputBuilderAmount::Amount(amount) => {
+                    BasicOutputBuilder::new_with_amount(amount, address_unlock_condition.address().clone())
+                }
+                OutputBuilderAmount::MinimumStorageDeposit(rent_structure) => {
+                    BasicOutputBuilder::new_with_minimum_storage_deposit(
+                        rent_structure,
+                        address_unlock_condition.address().clone(),
+                    )
+                }
             }
-
-            builder.finish_with_params(params)
+            .with_mana(mana)
+            .with_native_tokens(native_tokens.into_iter().flatten())
+            .with_storage_deposit_return_unlock_condition(storage_deposit_return_unlock_condition)
+            .with_timelock_unlock_condition(timelock_unlock_condition)
+            .with_expiration_unlock_condition(expiration_unlock_condition)
+            .with_sender_feature(sender_feature)
+            .with_metadata_feature(metadata_feature)
+            .with_tag_feature(tag_feature)
+            .finish_with_params(params)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::types::{
         block::{
-            output::{dto::OutputDto, FoundryId, SimpleTokenScheme, TokenId},
+            output::{
+                dto::OutputDto, unlock_condition::dto::UnlockConditionDto, FoundryId, SimpleTokenScheme, TokenId,
+            },
             protocol::protocol_parameters,
             rand::{
-                address::rand_account_address,
+                address::{rand_account_address, rand_address},
                 output::{
-                    feature::rand_allowed_features, rand_basic_output, unlock_condition::rand_address_unlock_condition,
+                    feature::{rand_metadata_feature, rand_sender_feature, rand_tag_feature},
+                    rand_basic_output,
                 },
             },
         },
@@ -493,15 +731,35 @@ mod tests {
         assert_eq!(output, output_split);
 
         let foundry_id = FoundryId::build(&rand_account_address(), 0, SimpleTokenScheme::KIND);
-        let address = rand_address_unlock_condition();
+        let address = rand_address();
 
         let test_split_dto = |builder: BasicOutputBuilder| {
             let output_split = BasicOutput::try_from_dtos(
                 builder.amount,
                 builder.mana,
                 Some(builder.native_tokens.iter().copied().collect()),
-                builder.unlock_conditions.iter().map(Into::into).collect(),
-                Some(builder.features.iter().cloned().collect()),
+                [
+                    Some(builder.address_unlock_condition.clone().into()),
+                    builder
+                        .storage_deposit_return_unlock_condition
+                        .clone()
+                        .map(UnlockCondition::from),
+                    builder.timelock_unlock_condition.clone().map(UnlockCondition::from),
+                    builder.expiration_unlock_condition.clone().map(UnlockCondition::from),
+                ]
+                .into_iter()
+                .filter_map(|v| v.as_ref().map(UnlockConditionDto::from))
+                .collect(),
+                Some(
+                    [
+                        builder.sender_feature.clone().map(Feature::from),
+                        builder.metadata_feature.clone().map(Feature::from),
+                        builder.tag_feature.clone().map(Feature::from),
+                    ]
+                    .into_iter()
+                    .filter_map(|v| v)
+                    .collect(),
+                ),
                 protocol_parameters.token_supply(),
             )
             .unwrap();
@@ -511,16 +769,18 @@ mod tests {
             );
         };
 
-        let builder = BasicOutput::build_with_amount(100)
+        let builder = BasicOutput::build_with_amount(100, address.clone())
             .add_native_token(NativeToken::new(TokenId::from(foundry_id), 1000).unwrap())
-            .add_unlock_condition(address.clone())
-            .with_features(rand_allowed_features(BasicOutput::ALLOWED_FEATURES));
+            .with_sender_feature(rand_sender_feature())
+            .with_metadata_feature(rand_metadata_feature())
+            .with_tag_feature(rand_tag_feature());
         test_split_dto(builder);
 
-        let builder = BasicOutput::build_with_minimum_storage_deposit(protocol_parameters.rent_structure())
+        let builder = BasicOutput::build_with_minimum_storage_deposit(protocol_parameters.rent_structure(), address)
             .add_native_token(NativeToken::new(TokenId::from(foundry_id), 1000).unwrap())
-            .add_unlock_condition(address)
-            .with_features(rand_allowed_features(BasicOutput::ALLOWED_FEATURES));
+            .with_sender_feature(rand_sender_feature())
+            .with_metadata_feature(rand_metadata_feature())
+            .with_tag_feature(rand_tag_feature());
         test_split_dto(builder);
     }
 }

--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -237,7 +237,7 @@ fn verify_unique_sorted<const VERIFY: bool>(features: &[Feature], _: &()) -> Res
 pub(crate) fn verify_allowed_features(features: &Features, allowed_features: FeatureFlags) -> Result<(), Error> {
     for (index, feature) in features.iter().enumerate() {
         if !allowed_features.contains(feature.flag()) {
-            return Err(Error::UnallowedFeature {
+            return Err(Error::DisallowedFeature {
                 index,
                 kind: feature.kind(),
             });

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -58,6 +58,13 @@ pub use self::{
     token_scheme::{SimpleTokenScheme, TokenScheme},
     unlock_condition::{UnlockCondition, UnlockConditions},
 };
+use self::{
+    feature::{BlockIssuerFeature, IssuerFeature, MetadataFeature, SenderFeature, StakingFeature, TagFeature},
+    unlock_condition::{
+        ExpirationUnlockCondition, GovernorAddressUnlockCondition, ImmutableAccountAddressUnlockCondition,
+        StateControllerAddressUnlockCondition, StorageDepositReturnUnlockCondition, TimelockUnlockCondition,
+    },
+};
 use super::protocol::ProtocolParameters;
 use crate::types::block::{address::Address, semantic::ValidationContext, slot::SlotIndex, Error};
 
@@ -197,23 +204,155 @@ impl Output {
     }
 
     /// Returns the unlock conditions of an [`Output`], if any.
-    pub fn unlock_conditions(&self) -> Option<&UnlockConditions> {
+    pub fn unlock_conditions(&self) -> Option<UnlockConditions> {
         match self {
             Self::Basic(output) => Some(output.unlock_conditions()),
-            Self::Account(output) => Some(output.unlock_conditions()),
-            Self::Foundry(output) => Some(output.unlock_conditions()),
-            Self::Nft(output) => Some(output.unlock_conditions()),
-            Self::Delegation(output) => Some(output.unlock_conditions()),
+            // TODO: temporary clones
+            Self::Account(output) => Some(output.unlock_conditions().clone()),
+            Self::Foundry(output) => Some(output.unlock_conditions().clone()),
+            Self::Nft(output) => Some(output.unlock_conditions().clone()),
+            Self::Delegation(output) => Some(output.unlock_conditions().clone()),
+        }
+    }
+
+    pub fn address_unlock_condition(&self) -> Option<&AddressUnlockCondition> {
+        match self {
+            Output::Basic(o) => Some(o.address_unlock_condition()),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn storage_deposit_return_unlock_condition(&self) -> Option<&StorageDepositReturnUnlockCondition> {
+        match self {
+            Output::Basic(o) => o.storage_deposit_return_unlock_condition(),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn expiration_unlock_condition(&self) -> Option<&ExpirationUnlockCondition> {
+        match self {
+            Output::Basic(o) => o.expiration_unlock_condition(),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn timelock_unlock_condition(&self) -> Option<&TimelockUnlockCondition> {
+        match self {
+            Output::Basic(o) => o.timelock_unlock_condition(),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn state_controller_address_unlock_condition(&self) -> Option<&StateControllerAddressUnlockCondition> {
+        match self {
+            Output::Basic(_) => None,
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn governor_address_unlock_condition(&self) -> Option<&GovernorAddressUnlockCondition> {
+        match self {
+            Output::Basic(_) => None,
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn immutable_account_address_unlock_condition(&self) -> Option<&ImmutableAccountAddressUnlockCondition> {
+        match self {
+            Output::Basic(_) => None,
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn sender_feature(&self) -> Option<&SenderFeature> {
+        match self {
+            Output::Basic(o) => o.sender_feature(),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn metadata_feature(&self) -> Option<&MetadataFeature> {
+        match self {
+            Output::Basic(o) => o.metadata_feature(),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn tag_feature(&self) -> Option<&TagFeature> {
+        match self {
+            Output::Basic(o) => o.tag_feature(),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn issuer_feature(&self) -> Option<&IssuerFeature> {
+        match self {
+            Output::Basic(_) => None,
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn block_issuer_feature(&self) -> Option<&BlockIssuerFeature> {
+        match self {
+            Output::Basic(_) => None,
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    pub fn staking_feature(&self) -> Option<&StakingFeature> {
+        match self {
+            Output::Basic(_) => None,
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
         }
     }
 
     /// Returns the features of an [`Output`], if any.
-    pub fn features(&self) -> Option<&Features> {
+    pub fn features(&self) -> Option<Features> {
         match self {
             Self::Basic(output) => Some(output.features()),
-            Self::Account(output) => Some(output.features()),
-            Self::Foundry(output) => Some(output.features()),
-            Self::Nft(output) => Some(output.features()),
+            // TODO: temporary clones
+            Self::Account(output) => Some(output.features().clone()),
+            Self::Foundry(output) => Some(output.features().clone()),
+            Self::Nft(output) => Some(output.features().clone()),
             Self::Delegation(_) => None,
         }
     }
@@ -288,6 +427,42 @@ impl Output {
         }
     }
 
+    /// Returns the address to be unlocked.
+    #[inline(always)]
+    pub fn locked_address<'a>(&'a self, address: &'a Address, slot_index: SlotIndex) -> &'a Address {
+        match self {
+            Output::Basic(o) => o.locked_address(address, slot_index),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    /// Returns whether a time lock exists and is still relevant.
+    #[inline(always)]
+    pub fn is_time_locked(&self, slot_index: impl Into<SlotIndex>) -> bool {
+        match self {
+            Output::Basic(o) => o.is_time_locked(slot_index),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
+    /// Returns whether an expiration exists and is expired.
+    #[inline(always)]
+    pub fn is_expired(&self, slot_index: impl Into<SlotIndex>) -> bool {
+        match self {
+            Output::Basic(o) => o.is_expired(slot_index),
+            Output::Account(_) => todo!(),
+            Output::Foundry(_) => todo!(),
+            Output::Nft(_) => todo!(),
+            Output::Delegation(_) => todo!(),
+        }
+    }
+
     ///
     pub fn verify_state_transition(
         current_state: Option<&Self>,
@@ -340,10 +515,7 @@ impl Output {
             });
         }
 
-        if let Some(return_condition) = self
-            .unlock_conditions()
-            .and_then(UnlockConditions::storage_deposit_return)
-        {
+        if let Some(return_condition) = self.storage_deposit_return_unlock_condition() {
             // We can't return more tokens than were originally contained in the output.
             // `Return Amount` ≤ `Amount`.
             if return_condition.amount() > self.amount() {
@@ -457,8 +629,7 @@ pub(crate) fn verify_output_amount_packable<const VERIFY: bool>(
 fn minimum_storage_deposit(address: &Address, rent_structure: RentStructure, token_supply: u64) -> u64 {
     // PANIC: This can never fail because the amount will always be within the valid range. Also, the actual value is
     // not important, we are only interested in the storage requirements of the type.
-    BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-        .add_unlock_condition(AddressUnlockCondition::new(address.clone()))
+    BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure, address.clone())
         .finish_with_params(token_supply)
         .unwrap()
         .amount()

--- a/sdk/src/types/block/output/rent.rs
+++ b/sdk/src/types/block/output/rent.rs
@@ -8,7 +8,7 @@ use packable::Packable;
 use crate::types::block::{
     address::{Address, Ed25519Address},
     output::{
-        unlock_condition::{AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition},
+        unlock_condition::{ExpirationUnlockCondition, StorageDepositReturnUnlockCondition},
         BasicOutputBuilder, NativeTokens, Output, OutputId,
     },
     slot::SlotIndex,
@@ -186,8 +186,9 @@ impl MinimumStorageDepositBasicOutput {
         Self {
             config,
             token_supply,
-            builder: BasicOutputBuilder::new_with_amount(Output::AMOUNT_MIN).add_unlock_condition(
-                AddressUnlockCondition::new(Address::from(Ed25519Address::from([0; Ed25519Address::LENGTH]))),
+            builder: BasicOutputBuilder::new_with_amount(
+                Output::AMOUNT_MIN,
+                Ed25519Address::from([0; Ed25519Address::LENGTH]),
             ),
         }
     }
@@ -200,21 +201,23 @@ impl MinimumStorageDepositBasicOutput {
     }
 
     pub fn with_storage_deposit_return(mut self) -> Result<Self, Error> {
-        self.builder = self
-            .builder
-            .add_unlock_condition(StorageDepositReturnUnlockCondition::new(
-                Address::from(Ed25519Address::from([0; Ed25519Address::LENGTH])),
-                Output::AMOUNT_MIN,
-                self.token_supply,
-            )?);
+        self.builder =
+            self.builder
+                .with_storage_deposit_return_unlock_condition(StorageDepositReturnUnlockCondition::new(
+                    Address::from(Ed25519Address::from([0; Ed25519Address::LENGTH])),
+                    Output::AMOUNT_MIN,
+                    self.token_supply,
+                )?);
         Ok(self)
     }
 
     pub fn with_expiration(mut self) -> Result<Self, Error> {
-        self.builder = self.builder.add_unlock_condition(ExpirationUnlockCondition::new(
-            Address::from(Ed25519Address::from([0; Ed25519Address::LENGTH])),
-            1,
-        )?);
+        self.builder = self
+            .builder
+            .with_expiration_unlock_condition(ExpirationUnlockCondition::new(
+                Address::from(Ed25519Address::from([0; Ed25519Address::LENGTH])),
+                1,
+            )?);
         Ok(self)
     }
 

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -372,7 +372,7 @@ pub(crate) fn verify_allowed_unlock_conditions(
 ) -> Result<(), Error> {
     for (index, unlock_condition) in unlock_conditions.iter().enumerate() {
         if !allowed_unlock_conditions.contains(unlock_condition.flag()) {
-            return Err(Error::UnallowedUnlockCondition {
+            return Err(Error::DisallowedUnlockCondition {
                 index,
                 kind: unlock_condition.kind(),
             });

--- a/sdk/src/types/block/rand/output/mod.rs
+++ b/sdk/src/types/block/rand/output/mod.rs
@@ -10,7 +10,9 @@ pub mod unlock_condition;
 
 use primitive_types::U256;
 
+use self::feature::{rand_metadata_feature, rand_sender_feature, rand_tag_feature};
 pub use self::metadata::rand_output_metadata;
+use super::address::rand_address;
 use crate::types::block::{
     output::{
         unlock_condition::ImmutableAccountAddressUnlockCondition, AccountId, AccountOutput, BasicOutput, FoundryOutput,
@@ -23,8 +25,7 @@ use crate::types::block::{
         output::{
             feature::rand_allowed_features,
             unlock_condition::{
-                rand_address_unlock_condition, rand_address_unlock_condition_different_from,
-                rand_governor_address_unlock_condition_different_from,
+                rand_address_unlock_condition_different_from, rand_governor_address_unlock_condition_different_from,
                 rand_state_controller_address_unlock_condition_different_from,
             },
         },
@@ -40,9 +41,10 @@ pub fn rand_output_id() -> OutputId {
 /// Generates a random [`BasicOutput`](BasicOutput).
 pub fn rand_basic_output(token_supply: u64) -> BasicOutput {
     // TODO: Add `NativeTokens`
-    BasicOutput::build_with_amount(rand_number_range(Output::AMOUNT_MIN..token_supply))
-        .with_features(rand_allowed_features(BasicOutput::ALLOWED_FEATURES))
-        .add_unlock_condition(rand_address_unlock_condition())
+    BasicOutput::build_with_amount(rand_number_range(Output::AMOUNT_MIN..token_supply), rand_address())
+        .with_sender_feature(rand_sender_feature())
+        .with_metadata_feature(rand_metadata_feature())
+        .with_tag_feature(rand_tag_feature())
         .finish_with_params(token_supply)
         .unwrap()
 }

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -636,8 +636,7 @@ fn serialize() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.clone())
             .unwrap(),
     );

--- a/sdk/src/wallet/account/operations/balance.rs
+++ b/sdk/src/wallet/account/operations/balance.rs
@@ -190,24 +190,21 @@ where
                                         // If output has a StorageDepositReturnUnlockCondition, the amount of it should
                                         // be subtracted, because this part
                                         // needs to be sent back
-                                        let amount = output
-                                            .unlock_conditions()
-                                            .and_then(|u| u.storage_deposit_return())
-                                            .map_or_else(
-                                                || output.amount(),
-                                                |sdr| {
-                                                    if account_addresses
-                                                        .iter()
-                                                        .any(|a| a.address.inner == *sdr.return_address())
-                                                    {
-                                                        // sending to ourself, we get the full amount
-                                                        output.amount()
-                                                    } else {
-                                                        // Sending to someone else
-                                                        output.amount() - sdr.amount()
-                                                    }
-                                                },
-                                            );
+                                        let amount = output.storage_deposit_return_unlock_condition().map_or_else(
+                                            || output.amount(),
+                                            |sdr| {
+                                                if account_addresses
+                                                    .iter()
+                                                    .any(|a| a.address.inner == *sdr.return_address())
+                                                {
+                                                    // sending to ourself, we get the full amount
+                                                    output.amount()
+                                                } else {
+                                                    // Sending to someone else
+                                                    output.amount() - sdr.amount()
+                                                }
+                                            },
+                                        );
 
                                         // add nft_id for nft outputs
                                         if let Output::Nft(output) = &output {

--- a/sdk/src/wallet/account/operations/output_consolidation.rs
+++ b/sdk/src/wallet/account/operations/output_consolidation.rs
@@ -10,9 +10,7 @@ use crate::{
     types::block::{
         address::Bech32Address,
         input::INPUT_COUNT_MAX,
-        output::{
-            unlock_condition::AddressUnlockCondition, BasicOutputBuilder, NativeTokens, NativeTokensBuilder, Output,
-        },
+        output::{BasicOutputBuilder, NativeTokens, NativeTokensBuilder, Output},
         slot::SlotIndex,
     },
 };
@@ -249,15 +247,15 @@ where
             custom_inputs.push(output_data.output_id);
         }
 
-        let consolidation_output = [BasicOutputBuilder::new_with_amount(total_amount)
-            .add_unlock_condition(AddressUnlockCondition::new(
-                params
-                    .target_address
-                    .map(|bech32| bech32.into_inner())
-                    .unwrap_or_else(|| outputs_to_consolidate[0].address.clone()),
-            ))
-            .with_native_tokens(total_native_tokens.finish()?)
-            .finish_output(token_supply)?];
+        let consolidation_output = [BasicOutputBuilder::new_with_amount(
+            total_amount,
+            params
+                .target_address
+                .map(|bech32| bech32.into_inner())
+                .unwrap_or_else(|| outputs_to_consolidate[0].address.clone()),
+        )
+        .with_native_tokens(total_native_tokens.finish()?)
+        .finish_output(token_supply)?];
 
         let options = Some(TransactionOptions {
             custom_inputs: Some(custom_inputs),

--- a/sdk/src/wallet/account/operations/participation/mod.rs
+++ b/sdk/src/wallet/account/operations/participation/mod.rs
@@ -80,7 +80,7 @@ where
             .filter(|output_data| {
                 is_valid_participation_output(&output_data.output)
                 // Check that the metadata exists, because otherwise we aren't participating for anything
-                    && output_data.output.features().and_then(|f| f.metadata()).is_some()
+                    && output_data.output.metadata_feature().is_some()
                     // Don't add spent cached outputs, we have their data already and it can't change anymore
                     && !spent_cached_outputs.contains_key(&output_data.output_id)
             })
@@ -90,7 +90,7 @@ where
         let mut spent_outputs = HashSet::new();
         for output_data in participation_outputs {
             // PANIC: the filter already checks that the metadata exists.
-            let metadata = output_data.output.features().and_then(|f| f.metadata()).unwrap();
+            let metadata = output_data.output.metadata_feature().unwrap();
             if let Ok(participations) = Participations::from_bytes(&mut metadata.data()) {
                 for participation in participations.participations {
                     // Skip events that aren't in `event_ids` if not None

--- a/sdk/src/wallet/account/operations/participation/voting.rs
+++ b/sdk/src/wallet/account/operations/participation/voting.rs
@@ -8,7 +8,7 @@ use crate::{
         block::{
             output::{
                 feature::{MetadataFeature, TagFeature},
-                BasicOutputBuilder, Feature,
+                BasicOutputBuilder,
             },
             payload::TaggedDataPayload,
         },
@@ -104,10 +104,8 @@ where
         .to_bytes()?;
 
         let new_output = BasicOutputBuilder::from(output)
-            .with_features([
-                Feature::Tag(TagFeature::new(PARTICIPATION_TAG)?),
-                Feature::Metadata(MetadataFeature::new(participation_bytes.clone())?),
-            ])
+            .with_tag_feature(TagFeature::new(PARTICIPATION_TAG)?)
+            .with_metadata_feature(MetadataFeature::new(participation_bytes.clone())?)
             .finish_output(self.client().get_token_supply().await?)?;
 
         self.prepare_transaction(
@@ -176,10 +174,8 @@ where
         .to_bytes()?;
 
         let new_output = BasicOutputBuilder::from(output)
-            .with_features([
-                Feature::Tag(TagFeature::new(PARTICIPATION_TAG)?),
-                Feature::Metadata(MetadataFeature::new(participation_bytes.clone())?),
-            ])
+            .with_tag_feature(TagFeature::new(PARTICIPATION_TAG)?)
+            .with_metadata_feature(MetadataFeature::new(participation_bytes.clone())?)
             .finish_output(self.client().get_token_supply().await?)?;
 
         self.prepare_transaction(

--- a/sdk/src/wallet/account/operations/transaction/high_level/send.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send.rs
@@ -9,9 +9,7 @@ use crate::{
     types::block::{
         address::Bech32Address,
         output::{
-            unlock_condition::{
-                AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition,
-            },
+            unlock_condition::{ExpirationUnlockCondition, StorageDepositReturnUnlockCondition},
             BasicOutputBuilder, MinimumStorageDepositBasicOutput,
         },
         slot::SlotIndex,
@@ -174,8 +172,7 @@ where
                 .unwrap_or_else(|| default_return_address.address.clone());
 
             // Get the minimum required amount for an output assuming it does not need a storage deposit.
-            let output = BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-                .add_unlock_condition(AddressUnlockCondition::new(address))
+            let output = BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure, address)
                 .finish_output(token_supply)?;
 
             if amount >= output.amount() {
@@ -208,7 +205,7 @@ where
                     // address_and_amount.amount
                     BasicOutputBuilder::from(output.as_basic())
                         .with_amount(amount + storage_deposit_amount)
-                        .add_unlock_condition(
+                        .with_storage_deposit_return_unlock_condition(
                             // We send the storage_deposit_amount back to the sender, so only the additional amount is
                             // sent
                             StorageDepositReturnUnlockCondition::new(
@@ -217,7 +214,10 @@ where
                                 token_supply,
                             )?,
                         )
-                        .add_unlock_condition(ExpirationUnlockCondition::new(return_address, expiration_slot_index)?)
+                        .with_expiration_unlock_condition(ExpirationUnlockCondition::new(
+                            return_address,
+                            expiration_slot_index,
+                        )?)
                         .finish_output(token_supply)?,
                 )
             }

--- a/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
+++ b/sdk/src/wallet/account/operations/transaction/high_level/send_native_tokens.rs
@@ -10,9 +10,7 @@ use crate::{
     types::block::{
         address::Bech32Address,
         output::{
-            unlock_condition::{
-                AddressUnlockCondition, ExpirationUnlockCondition, StorageDepositReturnUnlockCondition,
-            },
+            unlock_condition::{ExpirationUnlockCondition, StorageDepositReturnUnlockCondition},
             BasicOutputBuilder, MinimumStorageDepositBasicOutput, NativeToken, NativeTokens, TokenId,
         },
         slot::SlotIndex,
@@ -187,10 +185,9 @@ where
                 });
 
             outputs.push(
-                BasicOutputBuilder::new_with_amount(storage_deposit_amount)
+                BasicOutputBuilder::new_with_amount(storage_deposit_amount, address)
                     .with_native_tokens(native_tokens)
-                    .add_unlock_condition(AddressUnlockCondition::new(address))
-                    .add_unlock_condition(
+                    .with_storage_deposit_return_unlock_condition(
                         // We send the full storage_deposit_amount back to the sender, so only the native tokens are
                         // sent
                         StorageDepositReturnUnlockCondition::new(
@@ -199,7 +196,10 @@ where
                             token_supply,
                         )?,
                     )
-                    .add_unlock_condition(ExpirationUnlockCondition::new(return_address, expiration_slot_index)?)
+                    .with_expiration_unlock_condition(ExpirationUnlockCondition::new(
+                        return_address,
+                        expiration_slot_index,
+                    )?)
                     .finish_output(token_supply)?,
             )
         }

--- a/sdk/tests/client/input_signing_data.rs
+++ b/sdk/tests/client/input_signing_data.rs
@@ -12,7 +12,7 @@ use iota_sdk::{
     types::{
         block::{
             address::Address,
-            output::{unlock_condition::AddressUnlockCondition, BasicOutput, OutputId, OutputMetadata},
+            output::{BasicOutput, OutputId, OutputMetadata},
             payload::transaction::TransactionId,
             protocol::protocol_parameters,
             slot::SlotCommitmentId,
@@ -28,12 +28,12 @@ fn input_signing_data_conversion() {
 
     let bip44_chain = Bip44::new(SHIMMER_COIN_TYPE);
 
-    let output = BasicOutput::build_with_amount(1_000_000)
-        .add_unlock_condition(AddressUnlockCondition::new(
-            Address::try_from_bech32("rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy").unwrap(),
-        ))
-        .finish_output(protocol_parameters.token_supply())
-        .unwrap();
+    let output = BasicOutput::build_with_amount(
+        1_000_000,
+        Address::try_from_bech32("rms1qpllaj0pyveqfkwxmnngz2c488hfdtmfrj3wfkgxtk4gtyrax0jaxzt70zy").unwrap(),
+    )
+    .finish_output(protocol_parameters.token_supply())
+    .unwrap();
 
     let input_signing_data = InputSigningData {
         output,

--- a/sdk/tests/client/mod.rs
+++ b/sdk/tests/client/mod.rs
@@ -106,8 +106,7 @@ fn build_basic_output(
     timelock: Option<u32>,
     expiration: Option<(Bech32Address, u32)>,
 ) -> Output {
-    let mut builder =
-        BasicOutputBuilder::new_with_amount(amount).add_unlock_condition(AddressUnlockCondition::new(bech32_address));
+    let mut builder = BasicOutputBuilder::new_with_amount(amount, bech32_address);
 
     if let Some(native_tokens) = native_tokens {
         builder = builder.with_native_tokens(
@@ -118,20 +117,21 @@ fn build_basic_output(
     }
 
     if let Some(bech32_sender) = bech32_sender {
-        builder = builder.add_feature(SenderFeature::new(bech32_sender));
+        builder = builder.with_sender_feature(SenderFeature::new(bech32_sender));
     }
 
     if let Some((address, amount)) = sdruc {
-        builder = builder
-            .add_unlock_condition(StorageDepositReturnUnlockCondition::new(address, amount, TOKEN_SUPPLY).unwrap());
+        builder = builder.with_storage_deposit_return_unlock_condition(
+            StorageDepositReturnUnlockCondition::new(address, amount, TOKEN_SUPPLY).unwrap(),
+        );
     }
 
     if let Some(timelock) = timelock {
-        builder = builder.add_unlock_condition(TimelockUnlockCondition::new(timelock).unwrap());
+        builder = builder.with_timelock_unlock_condition(TimelockUnlockCondition::new(timelock).unwrap());
     }
 
     if let Some((address, timestamp)) = expiration {
-        builder = builder.add_unlock_condition(ExpirationUnlockCondition::new(address, timestamp).unwrap());
+        builder = builder.with_expiration_unlock_condition(ExpirationUnlockCondition::new(address, timestamp).unwrap());
     }
 
     builder.finish_output(TOKEN_SUPPLY).unwrap()

--- a/sdk/tests/types/output/basic.rs
+++ b/sdk/tests/types/output/basic.rs
@@ -3,7 +3,7 @@
 
 use iota_sdk::types::{
     block::{
-        output::{BasicOutput, Feature, FoundryId, NativeToken, Output, Rent, SimpleTokenScheme, TokenId},
+        output::{BasicOutput, FoundryId, NativeToken, Output, Rent, SimpleTokenScheme, TokenId},
         protocol::protocol_parameters,
         rand::{
             address::rand_account_address,
@@ -28,11 +28,10 @@ fn builder() {
     let sender_2 = rand_sender_feature();
     let amount = 500_000;
 
-    let mut builder = BasicOutput::build_with_amount(amount)
+    let mut builder = BasicOutput::build_with_amount(amount, address_1.address().clone())
         .add_native_token(NativeToken::new(TokenId::from(foundry_id), 1000).unwrap())
-        .add_unlock_condition(address_1.clone())
-        .add_feature(sender_1.clone())
-        .replace_feature(sender_2.clone());
+        .with_sender_feature(sender_1.clone())
+        .with_sender_feature(sender_2.clone());
 
     let output = builder.clone().finish().unwrap();
     assert_eq!(output.amount(), amount);
@@ -42,7 +41,7 @@ fn builder() {
     builder = builder
         .clear_unlock_conditions()
         .clear_features()
-        .replace_unlock_condition(address_2.clone());
+        .with_address_unlock_condition(address_2.clone());
     let output = builder.clone().finish().unwrap();
     assert_eq!(output.unlock_conditions().address(), Some(&address_2));
     assert!(output.features().is_empty());
@@ -51,8 +50,9 @@ fn builder() {
 
     let output = builder
         .with_minimum_storage_deposit(protocol_parameters.rent_structure())
-        .add_unlock_condition(rand_address_unlock_condition())
-        .with_features([Feature::from(metadata.clone()), sender_1.clone().into()])
+        .with_address_unlock_condition(rand_address_unlock_condition())
+        .with_metadata_feature(metadata.clone())
+        .with_sender_feature(sender_1.clone())
         .finish_with_params(ValidationParams::default().with_protocol_parameters(protocol_parameters.clone()))
         .unwrap();
 

--- a/sdk/tests/types/payload.rs
+++ b/sdk/tests/types/payload.rs
@@ -4,7 +4,7 @@
 use iota_sdk::types::block::{
     address::{Address, Ed25519Address},
     input::{Input, UtxoInput},
-    output::{unlock_condition::AddressUnlockCondition, BasicOutput, Output},
+    output::{BasicOutput, Output},
     payload::{
         transaction::{RegularTransactionEssence, TransactionId, TransactionPayload},
         Payload, TaggedDataPayload,
@@ -31,8 +31,7 @@ fn transaction() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(&protocol_parameters)
             .unwrap(),
     );

--- a/sdk/tests/types/transaction_essence.rs
+++ b/sdk/tests/types/transaction_essence.rs
@@ -4,7 +4,7 @@
 use iota_sdk::types::block::{
     address::{Address, Ed25519Address},
     input::{Input, UtxoInput},
-    output::{unlock_condition::AddressUnlockCondition, BasicOutput, Output},
+    output::{BasicOutput, Output},
     payload::transaction::{RegularTransactionEssence, TransactionEssence, TransactionId},
     protocol::protocol_parameters,
     rand::{mana::rand_mana_allotment, output::rand_inputs_commitment},
@@ -25,8 +25,7 @@ fn essence_kind() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );

--- a/sdk/tests/types/transaction_payload.rs
+++ b/sdk/tests/types/transaction_payload.rs
@@ -4,7 +4,7 @@
 use iota_sdk::types::block::{
     address::{Address, Ed25519Address},
     input::{Input, UtxoInput},
-    output::{unlock_condition::AddressUnlockCondition, BasicOutput, Output},
+    output::{BasicOutput, Output},
     payload::transaction::{RegularTransactionEssence, TransactionId, TransactionPayload},
     protocol::protocol_parameters,
     rand::{mana::rand_mana_allotment, output::rand_inputs_commitment},
@@ -36,8 +36,7 @@ fn builder_no_essence_too_few_unlocks() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -72,8 +71,7 @@ fn builder_no_essence_too_many_unlocks() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -111,8 +109,7 @@ fn pack_unpack_valid() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -152,8 +149,7 @@ fn getters() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );

--- a/sdk/tests/types/transaction_regular_essence.rs
+++ b/sdk/tests/types/transaction_regular_essence.rs
@@ -48,8 +48,7 @@ fn build_valid() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -73,8 +72,7 @@ fn build_valid_with_payload() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -99,8 +97,7 @@ fn build_valid_add_inputs_outputs() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -125,8 +122,7 @@ fn build_invalid_payload_kind() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -164,8 +160,7 @@ fn build_invalid_input_count_low() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -190,8 +185,7 @@ fn build_invalid_input_count_high() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -234,8 +228,7 @@ fn build_invalid_output_count_high() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -261,8 +254,7 @@ fn build_invalid_duplicate_utxo() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -286,8 +278,7 @@ fn build_invalid_accumulated_output() {
     let address1 = Address::from(Ed25519Address::new(bytes1));
     let amount1 = protocol_parameters.token_supply() - 1_000_000;
     let output1 = Output::Basic(
-        BasicOutput::build_with_amount(amount1)
-            .add_unlock_condition(AddressUnlockCondition::new(address1))
+        BasicOutput::build_with_amount(amount1, address1)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -296,8 +287,7 @@ fn build_invalid_accumulated_output() {
     let address2 = Address::from(Ed25519Address::new(bytes2));
     let amount2 = 2_000_000;
     let output2 = Output::Basic(
-        BasicOutput::build_with_amount(amount2)
-            .add_unlock_condition(AddressUnlockCondition::new(address2))
+        BasicOutput::build_with_amount(amount2, address2)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     );
@@ -321,8 +311,7 @@ fn getters() {
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
     let outputs = [Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(protocol_parameters.token_supply())
             .unwrap(),
     )];
@@ -349,8 +338,7 @@ fn duplicate_output_nft() {
     let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
-    let basic = BasicOutput::build_with_amount(amount)
-        .add_unlock_condition(AddressUnlockCondition::new(address.clone()))
+    let basic = BasicOutput::build_with_amount(amount, address.clone())
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
     let nft_id = NftId::from(bytes);
@@ -380,8 +368,7 @@ fn duplicate_output_nft_null() {
     let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
-    let basic = BasicOutput::build_with_amount(amount)
-        .add_unlock_condition(AddressUnlockCondition::new(address.clone()))
+    let basic = BasicOutput::build_with_amount(amount, address.clone())
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
     let nft_id = NftId::null();
@@ -408,8 +395,7 @@ fn duplicate_output_account() {
     let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
-    let basic = BasicOutput::build_with_amount(amount)
-        .add_unlock_condition(AddressUnlockCondition::new(address.clone()))
+    let basic = BasicOutput::build_with_amount(amount, address.clone())
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
     let account_id = AccountId::from(bytes);
@@ -440,8 +426,7 @@ fn duplicate_output_foundry() {
     let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
     let address = Address::from(Ed25519Address::new(bytes));
     let amount = 1_000_000;
-    let basic = BasicOutput::build_with_amount(amount)
-        .add_unlock_condition(AddressUnlockCondition::new(address))
+    let basic = BasicOutput::build_with_amount(amount, address)
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
     let account_id = AccountId::from(bytes);
@@ -477,8 +462,7 @@ fn transactions_capabilities() {
     let address = Address::from(Ed25519Address::new(prefix_hex::decode(ED25519_ADDRESS_1).unwrap()));
     let amount = 1_000_000;
     let output = Output::Basic(
-        BasicOutput::build_with_amount(amount)
-            .add_unlock_condition(AddressUnlockCondition::new(address))
+        BasicOutput::build_with_amount(amount, address)
             .finish_with_params(&protocol_parameters)
             .unwrap(),
     );

--- a/sdk/tests/wallet/claim_outputs.rs
+++ b/sdk/tests/wallet/claim_outputs.rs
@@ -131,13 +131,13 @@ async fn claim_2_basic_outputs_no_outputs_in_claim_account() -> Result<()> {
     // TODO more fitting value
     let expiration_slot = account_0.client().get_slot_index().await? + 86400;
 
-    let output = BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-        .add_unlock_condition(AddressUnlockCondition::new(account_1.first_address_bech32().await))
-        .add_unlock_condition(ExpirationUnlockCondition::new(
-            account_0.first_address_bech32().await,
-            expiration_slot,
-        )?)
-        .finish_output(token_supply)?;
+    let output =
+        BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure, account_1.first_address_bech32().await)
+            .with_expiration_unlock_condition(ExpirationUnlockCondition::new(
+                account_0.first_address_bech32().await,
+                expiration_slot,
+            )?)
+            .finish_output(token_supply)?;
     let amount = output.amount();
 
     let outputs = vec![output; 2];
@@ -326,22 +326,26 @@ async fn claim_2_native_tokens_no_outputs_in_claim_account() -> Result<()> {
     let tx = account_0
         .send_outputs(
             [
-                BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-                    .add_unlock_condition(AddressUnlockCondition::new(account_1.first_address_bech32().await))
-                    .add_unlock_condition(ExpirationUnlockCondition::new(
-                        account_0.first_address_bech32().await,
-                        account_0.client().get_slot_index().await? + 5000,
-                    )?)
-                    .add_native_token(NativeToken::new(create_tx_0.token_id, native_token_amount)?)
-                    .finish_output(token_supply)?,
-                BasicOutputBuilder::new_with_minimum_storage_deposit(rent_structure)
-                    .add_unlock_condition(AddressUnlockCondition::new(account_1.first_address_bech32().await))
-                    .add_unlock_condition(ExpirationUnlockCondition::new(
-                        account_0.first_address_bech32().await,
-                        account_0.client().get_slot_index().await? + 5000,
-                    )?)
-                    .add_native_token(NativeToken::new(create_tx_1.token_id, native_token_amount)?)
-                    .finish_output(token_supply)?,
+                BasicOutputBuilder::new_with_minimum_storage_deposit(
+                    rent_structure,
+                    account_1.first_address_bech32().await,
+                )
+                .with_expiration_unlock_condition(ExpirationUnlockCondition::new(
+                    account_0.first_address_bech32().await,
+                    account_0.client().get_slot_index().await? + 5000,
+                )?)
+                .add_native_token(NativeToken::new(create_tx_0.token_id, native_token_amount)?)
+                .finish_output(token_supply)?,
+                BasicOutputBuilder::new_with_minimum_storage_deposit(
+                    rent_structure,
+                    account_1.first_address_bech32().await,
+                )
+                .with_expiration_unlock_condition(ExpirationUnlockCondition::new(
+                    account_0.first_address_bech32().await,
+                    account_0.client().get_slot_index().await? + 5000,
+                )?)
+                .add_native_token(NativeToken::new(create_tx_1.token_id, native_token_amount)?)
+                .finish_output(token_supply)?,
             ],
             None,
         )

--- a/sdk/tests/wallet/events.rs
+++ b/sdk/tests/wallet/events.rs
@@ -6,7 +6,7 @@ use iota_sdk::{
     types::block::{
         address::{Address, Bech32Address, Ed25519Address},
         input::{Input, UtxoInput},
-        output::{unlock_condition::AddressUnlockCondition, BasicOutput, Output, OutputId},
+        output::{BasicOutput, Output, OutputId},
         payload::transaction::{RegularTransactionEssence, TransactionEssence, TransactionId},
         protocol::protocol_parameters,
         rand::{
@@ -89,8 +89,7 @@ fn wallet_events_serde() {
         let address = Address::from(Ed25519Address::new(bytes));
         let amount = 1_000_000;
         let output = Output::Basic(
-            BasicOutput::build_with_amount(amount)
-                .add_unlock_condition(AddressUnlockCondition::new(address))
+            BasicOutput::build_with_amount(amount, address)
                 .finish_with_params(protocol_parameters.token_supply())
                 .unwrap(),
         );

--- a/sdk/tests/wallet/output_preparation.rs
+++ b/sdk/tests/wallet/output_preparation.rs
@@ -47,7 +47,7 @@ async fn output_preparation() -> Result<()> {
     assert_eq!(output.amount(), 46800);
     // address and sdr unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 46300);
 
     let output = account
@@ -189,7 +189,7 @@ async fn output_preparation() -> Result<()> {
         )
         .await?;
     assert_eq!(output.amount(), 49000);
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 48999);
 
     // address and storage deposit unlock condition, because of the metadata feature block, 213000 is not enough for the
@@ -412,7 +412,7 @@ async fn output_preparation() -> Result<()> {
     let minimum_storage_deposit = output.rent_cost(rent_structure);
     assert_eq!(output.amount(), minimum_storage_deposit);
     assert_eq!(output.amount(), 187900);
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 145300);
     // address and storage deposit unlock condition, because of the metadata feature block, 42600 is not enough for the
     // required storage deposit
@@ -458,7 +458,7 @@ async fn output_preparation_sdr() -> Result<()> {
     assert_eq!(output.amount(), 50601);
     // address and sdr unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 42600);
 
     let output = account
@@ -479,7 +479,7 @@ async fn output_preparation_sdr() -> Result<()> {
     assert_eq!(output.amount(), 85199);
     // address and sdr unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 42600);
 
     // ReturnStrategy::Return provided
@@ -504,7 +504,7 @@ async fn output_preparation_sdr() -> Result<()> {
     assert_eq!(output.amount(), 85199);
     // address and sdr unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 42600);
 
     // ReturnStrategy::Gift provided
@@ -736,7 +736,7 @@ async fn prepare_output_remainder_dust() -> Result<()> {
     // storage deposit returned, address and SDR unlock condition
     assert_eq!(output.unlock_conditions().unwrap().len(), 2);
     // We have ReturnStrategy::Return, so leftover amount gets returned
-    let sdr = output.unlock_conditions().unwrap().storage_deposit_return().unwrap();
+    let sdr = output.storage_deposit_return_unlock_condition().unwrap();
     assert_eq!(sdr.amount(), 63900 - 100);
 
     tear_down(storage_path)


### PR DESCRIPTION
# Description of change

This PR is a test to see if it's feasible to use static typing for unlock conditions and features instead of arrays of enums. So far I have only changed the `BasicOutput`.

# Downsides
1. In order to get a `UnlockConditions` or `Features` from an output, you must now clone. This is usually not necessary since you can just use the specific getter most of the time, but it's useful for certain things.
2. There is a lot of repeated code in Unpack/TryFromDto/try_from_dtos that really should be shared somehow. Unfortunately, this is not very straightforward.
