### PR TITLE
chore: adding py.typed file to iota_sdk python package

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Utils:transaction_id()`;
+- `py.typed` file to the package;
 
 ## 1.1.0 - 2023-09-29
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -42,4 +42,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=["dacite >= 1.8.1 ; pyhumps >= 3.8.0"],
+    package_data={"iota_sdk": ["py.typed"]}
 )


### PR DESCRIPTION
# Description of change

This signals to static type checkers like mypy to use the type hints included in the source code=

## Links to any relevant issues

Fixes  #1493 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality) - Adds support for type checking for downstream users of the `iota_sdk` Python package

## How the change has been tested

Install `mypy` and run it on a Python file depending on `iota_sdk`.

Before the change:

```bash
$ echo "from iota_sdk import Wallet" > foo.py && mypy foo.py
foo.py:1: error: Skipping analyzing "iota_sdk": module is installed, but missing library stubs or py.typed marker  [import-untyped]
foo.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

```bash
$ echo "from iota_sdk import Wallet" > foo.py && mypy foo.py
Success: no issues found in 1 source file
```

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ x ] I have followed the contribution guidelines for this project
- [ x ] I have performed a self-review of my own code
