### PR TITLE
chore: Update `gon` for CLI on macOS

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -67,8 +67,13 @@ jobs:
           sudo apt-get install libudev-dev libusb-1.0-0-dev
 
       - name: Install gon (macOS)
-        # https://github.com/mitchellh/gon
-        run: brew install mitchellh/gon/gon
+        # Fork of https://github.com/mitchellh/gon
+        # https://github.com/Bearer/gon
+        # Since we're dealing with code signing secrets we want to pin the version of gon
+        run: |
+          wget https://raw.githubusercontent.com/Bearer/homebrew-tap/366bc999e14a8d04e07e24f9387bcbaf89c1bc53/Formula/gon.rb
+          brew install --formula gon.rb
+          rm gon.rb
         if: matrix.os == 'macos-latest'
 
       - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797

--- a/cli/gon-config.json
+++ b/cli/gon-config.json
@@ -2,7 +2,7 @@
   "source": ["../target/production/wallet"],
   "bundle_id": "org.iota.cli-wallet",
   "apple_id": {
-    "password": "@env:AC_PASSWORD"
+    "provider": "UG77RJKZHH"
   },
   "sign": {
     "application_identity": "Developer ID Application: IOTA Stiftung (UG77RJKZHH)"


### PR DESCRIPTION
# Description of change

Updates `gon`, which is used to notarize macOS apps. Since the [original](https://github.com/mitchellh/gon) is no longer maintained, we have to use a [fork](https://github.com/Bearer/gon). This is necessary because Apple will be ending support for `altool` tomorrow and will require `notarytool` in the future (https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool). I didn't realize they made this change until a week ago 😅 

## Links to any relevant issues
N/A

## Type of change

- Chore
- CI fix

## How the change has been tested

[Workflow](https://github.com/iotaledger/iota-sdk/actions/runs/6713417519/job/18245565705) runs successfully

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code