### PR TITLE
Refactor hex decoding

### DIFF
--- a/bindings/python/iota_sdk/types/balance.py
+++ b/bindings/python/iota_sdk/types/balance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import config
-from iota_sdk.types.common import HexStr, json
+from iota_sdk.types.common import hex_str_decoder, HexStr, json
 
 
 @json
@@ -64,11 +64,11 @@ class NativeTokensBalance:
     token_id: HexStr
     total: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     available: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     metadata: Optional[HexStr]
 

--- a/bindings/python/iota_sdk/types/common.py
+++ b/bindings/python/iota_sdk/types/common.py
@@ -113,7 +113,7 @@ def opt_int_encoder(value):
 
 
 def hex_str_decoder(value: str) -> int:
-    """ Parses a given string as a hexadecimal integer """
+    """Parses a given string as a hexadecimal integer."""
     return int(value, 16)
 
 

--- a/bindings/python/iota_sdk/types/common.py
+++ b/bindings/python/iota_sdk/types/common.py
@@ -112,6 +112,11 @@ def opt_int_encoder(value):
     return None
 
 
+def hex_str_decoder(value: str) -> int:
+    """ Parses a given string as a hexadecimal integer """
+    return int(value, 16)
+
+
 @json
 @dataclass
 class AddressAndAmount():

--- a/bindings/python/iota_sdk/types/native_token.py
+++ b/bindings/python/iota_sdk/types/native_token.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass, field
 from dataclasses_json import config
 
-from iota_sdk.types.common import HexStr, json
+from iota_sdk.types.common import hex_str_decoder, HexStr, json
 
 
 @json
@@ -19,5 +19,5 @@ class NativeToken():
     id: HexStr
     amount: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))

--- a/bindings/python/iota_sdk/types/send_params.py
+++ b/bindings/python/iota_sdk/types/send_params.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional, List
 from dataclasses_json import config
-from iota_sdk.types.common import HexStr, json
+from iota_sdk.types.common import hex_str_decoder, HexStr, json
 from iota_sdk.types.native_token import NativeToken
 
 
@@ -73,11 +73,11 @@ class CreateNativeTokenParams():
     """
     circulating_supply: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     maximum_supply: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     foundry_metadata: Optional[str] = None
     account_id: Optional[str] = None

--- a/bindings/python/iota_sdk/types/token_scheme.py
+++ b/bindings/python/iota_sdk/types/token_scheme.py
@@ -4,7 +4,7 @@
 from typing import TypeAlias
 from dataclasses import dataclass, field
 from dataclasses_json import config
-from iota_sdk.types.common import json
+from iota_sdk.types.common import hex_str_decoder, json
 
 
 @json
@@ -20,15 +20,15 @@ class SimpleTokenScheme:
     """
     minted_tokens: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     melted_tokens: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     maximum_supply: int = field(metadata=config(
         encoder=hex,
-        decoder=lambda v: int(v, 16)
+        decoder=hex_str_decoder,
     ))
     type: int = field(default=0, init=False)
 


### PR DESCRIPTION
# Description of change

Factors out the hex string decoding. I'm following the pattern established by `opt_int_encoder` rather than a full-blown custom field like in the issue description, to keep up with existing conventions and not introduce too much magic.

## Links to any relevant issues

Fixes #1555 

## Type of change

- Refactoring

## How the change has been tested

I didn't get `tox` to work yet, so I'm hoping the CI will run the tests for me :)

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
