### PR TITLE
Update rustdoc example for Client

### DIFF
--- a/sdk/src/client/mod.rs
+++ b/sdk/src/client/mod.rs
@@ -7,21 +7,27 @@
 //!
 //! ## Sending a block without a payload
 //!  ```no_run
-//! # use iota_sdk::client::{Client, Result};
+//! # use iota_sdk::{
+//! #    client::{Client, secret::{mnemonic::MnemonicSecretManager, SignBlock}, constants::IOTA_COIN_TYPE},
+//! #    types::block::IssuerId, crypto::keys::bip44::Bip44
+//! # };
 //! # #[tokio::main]
-//! # async fn main() -> Result<()> {
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = Client::builder()
 //!    .with_node("http://localhost:14265")?
 //!    .finish()
 //!    .await?;
-//!
-//! let block = client
-//!    .block()
-//!    .finish()
-//!    .await?;
-//!
-//! println!("Block sent {}", block.id());
-//! # Ok(())}
+//! let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC")?)?;
+//! let protocol_params = client.get_protocol_parameters().await?;
+//! let block_id = client
+//!    .build_basic_block(IssuerId::null(), None)
+//!    .await?
+//!    .sign_ed25519(&secret_manager, Bip44::new(IOTA_COIN_TYPE))
+//!    .await?
+//!    .id(&protocol_params);
+//! println!("Block sent {}", block_id);
+//! # Ok(())
+//! # }
 //! ```
 
 #[cfg(feature = "mqtt")]


### PR DESCRIPTION
# Description of change

Fixes the example Client usage, so that the rustdoc compiles again. Combined with https://github.com/iotaledger/iota-sdk/pull/1563/files, this makes our test run green again.


## Type of change

- Documentation Fix

## How the change has been tested

Rustdoc tests were ran (`cargo test --doc`).

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
