### PR TITLE
Remove BaseTokenResponse::use_metric_prefix

### DIFF
--- a/sdk/src/types/api/core.rs
+++ b/sdk/src/types/api/core.rs
@@ -170,7 +170,6 @@ pub struct BaseTokenResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subunit: Option<String>,
     pub decimals: u32,
-    pub use_metric_prefix: bool,
 }
 
 /// Response of GET /api/core/v3/blocks/validators.


### PR DESCRIPTION
https://github.com/iotaledger/iota.go/commit/00b78ce159766b7b3155d773d96b3353bfa908e6