### PR TITLE
Rust: Added env check to examples

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -847,7 +847,7 @@ required-features = ["wallet", "participation"]
 [[example]]
 name = "logger"
 path = "examples/wallet/logger.rs"
-required-features = ["wallet"]
+required-features = ["wallet", "storage"]
 
 [[example]]
 name = "recover_accounts"

--- a/sdk/examples/client/01_generate_addresses.rs
+++ b/sdk/examples/client/01_generate_addresses.rs
@@ -20,9 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/01_generate_addresses.rs
+++ b/sdk/examples/client/01_generate_addresses.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/01_generate_addresses.rs
+++ b/sdk/examples/client/01_generate_addresses.rs
@@ -19,6 +19,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/02_address_balance.rs
+++ b/sdk/examples/client/02_address_balance.rs
@@ -23,9 +23,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/02_address_balance.rs
+++ b/sdk/examples/client/02_address_balance.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/02_address_balance.rs
+++ b/sdk/examples/client/02_address_balance.rs
@@ -22,6 +22,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/block/00_block_no_payload.rs
+++ b/sdk/examples/client/block/00_block_no_payload.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/00_block_no_payload.rs
+++ b/sdk/examples/client/block/00_block_no_payload.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/00_block_no_payload.rs
+++ b/sdk/examples/client/block/00_block_no_payload.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/block/01_block_confirmation_time.rs
+++ b/sdk/examples/client/block/01_block_confirmation_time.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/01_block_confirmation_time.rs
+++ b/sdk/examples/client/block/01_block_confirmation_time.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/01_block_confirmation_time.rs
+++ b/sdk/examples/client/block/01_block_confirmation_time.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/block/02_block_custom_parents.rs
+++ b/sdk/examples/client/block/02_block_custom_parents.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/02_block_custom_parents.rs
+++ b/sdk/examples/client/block/02_block_custom_parents.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/02_block_custom_parents.rs
+++ b/sdk/examples/client/block/02_block_custom_parents.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/block/03_block_custom_payload.rs
+++ b/sdk/examples/client/block/03_block_custom_payload.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/03_block_custom_payload.rs
+++ b/sdk/examples/client/block/03_block_custom_payload.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/block/03_block_custom_payload.rs
+++ b/sdk/examples/client/block/03_block_custom_payload.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/04_block_tagged_data.rs
+++ b/sdk/examples/client/block/04_block_tagged_data.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/04_block_tagged_data.rs
+++ b/sdk/examples/client/block/04_block_tagged_data.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     let tag = std::env::args().nth(1).unwrap_or_else(|| "Hello".to_string());

--- a/sdk/examples/client/block/04_block_tagged_data.rs
+++ b/sdk/examples/client/block/04_block_tagged_data.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/custom_inputs.rs
+++ b/sdk/examples/client/block/custom_inputs.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/custom_inputs.rs
+++ b/sdk/examples/client/block/custom_inputs.rs
@@ -21,6 +21,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
     let faucet_url = std::env::var("FAUCET_URL").unwrap();
 

--- a/sdk/examples/client/block/custom_inputs.rs
+++ b/sdk/examples/client/block/custom_inputs.rs
@@ -22,9 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/output.rs
+++ b/sdk/examples/client/block/output.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/output.rs
+++ b/sdk/examples/client/block/output.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
     let faucet_url = std::env::var("FAUCET_URL").unwrap();
 

--- a/sdk/examples/client/block/output.rs
+++ b/sdk/examples/client/block/output.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/transaction.rs
+++ b/sdk/examples/client/block/transaction.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
     let faucet_url = std::env::var("FAUCET_URL").unwrap();
 

--- a/sdk/examples/client/block/transaction.rs
+++ b/sdk/examples/client/block/transaction.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/block/transaction.rs
+++ b/sdk/examples/client/block/transaction.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "FAUCET_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/custom_remainder_address.rs
+++ b/sdk/examples/client/custom_remainder_address.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let amount = std::env::args()

--- a/sdk/examples/client/custom_remainder_address.rs
+++ b/sdk/examples/client/custom_remainder_address.rs
@@ -20,9 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let amount = std::env::args()

--- a/sdk/examples/client/custom_remainder_address.rs
+++ b/sdk/examples/client/custom_remainder_address.rs
@@ -16,13 +16,19 @@ use iota_sdk::client::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // This example uses secrets in environment variables for simplicity which should not be done in production.
+    dotenvy::dotenv().ok();
+
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let amount = std::env::args()
         .nth(1)
         .map(|s| s.parse::<u64>().unwrap())
         .unwrap_or(9_000_000);
-
-    // This example uses secrets in environment variables for simplicity which should not be done in production.
-    dotenvy::dotenv().ok();
 
     // Create a client instance.
     let client = Client::builder()

--- a/sdk/examples/client/get_block.rs
+++ b/sdk/examples/client/get_block.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/get_block.rs
+++ b/sdk/examples/client/get_block.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/get_block.rs
+++ b/sdk/examples/client/get_block.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/get_block.rs
+++ b/sdk/examples/client/get_block.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/high_level/consolidation.rs
+++ b/sdk/examples/client/high_level/consolidation.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let address_range_start = std::env::args().nth(1).map(|s| s.parse::<u32>().unwrap()).unwrap_or(0);

--- a/sdk/examples/client/high_level/consolidation.rs
+++ b/sdk/examples/client/high_level/consolidation.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let address_range_start = std::env::args().nth(1).map(|s| s.parse::<u32>().unwrap()).unwrap_or(0);

--- a/sdk/examples/client/high_level/consolidation.rs
+++ b/sdk/examples/client/high_level/consolidation.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let address_range_start = std::env::args().nth(1).map(|s| s.parse::<u32>().unwrap()).unwrap_or(0);
     let address_range_len = std::env::args().nth(2).map(|s| s.parse::<u32>().unwrap()).unwrap_or(10);
 

--- a/sdk/examples/client/high_level/inputs_from_transaction_id.rs
+++ b/sdk/examples/client/high_level/inputs_from_transaction_id.rs
@@ -20,6 +20,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/high_level/inputs_from_transaction_id.rs
+++ b/sdk/examples/client/high_level/inputs_from_transaction_id.rs
@@ -21,9 +21,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/high_level/inputs_from_transaction_id.rs
+++ b/sdk/examples/client/high_level/inputs_from_transaction_id.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/high_level/inputs_from_transaction_id.rs
+++ b/sdk/examples/client/high_level/inputs_from_transaction_id.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/high_level/search_address.rs
+++ b/sdk/examples/client/high_level/search_address.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/high_level/search_address.rs
+++ b/sdk/examples/client/high_level/search_address.rs
@@ -20,6 +20,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/high_level/search_address.rs
+++ b/sdk/examples/client/high_level/search_address.rs
@@ -21,9 +21,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/ledger_nano_transaction.rs
+++ b/sdk/examples/client/ledger_nano_transaction.rs
@@ -31,9 +31,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a client instance

--- a/sdk/examples/client/ledger_nano_transaction.rs
+++ b/sdk/examples/client/ledger_nano_transaction.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a client instance

--- a/sdk/examples/client/ledger_nano_transaction.rs
+++ b/sdk/examples/client/ledger_nano_transaction.rs
@@ -30,6 +30,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a client instance
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/logger.rs
+++ b/sdk/examples/client/logger.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Generates a client.log file with logs for debugging.

--- a/sdk/examples/client/logger.rs
+++ b/sdk/examples/client/logger.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Generates a client.log file with logs for debugging.
     // We exclude logs from h2, hyper and rustls to reduce the noise.
     let logger_output_config = fern_logger::LoggerOutputConfigBuilder::new()

--- a/sdk/examples/client/logger.rs
+++ b/sdk/examples/client/logger.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/logger.rs
+++ b/sdk/examples/client/logger.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Generates a client.log file with logs for debugging.

--- a/sdk/examples/client/node_api_core/01_get_routes.rs
+++ b/sdk/examples/client/node_api_core/01_get_routes.rs
@@ -14,11 +14,10 @@ use iota_sdk::client::{Client, Result};
 async fn main() -> Result<()> {
     // If not provided we use the default node from the `.env` file.
     dotenvy::dotenv().ok();
-
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder()

--- a/sdk/examples/client/node_api_core/03_get_tips.rs
+++ b/sdk/examples/client/node_api_core/03_get_tips.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/04_post_block.rs
+++ b/sdk/examples/client/node_api_core/04_post_block.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Take the node URL from command line argument or use one from env as default.

--- a/sdk/examples/client/node_api_core/04_post_block.rs
+++ b/sdk/examples/client/node_api_core/04_post_block.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // If not provided we use the default node from the `.env` file.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["EXPLORER_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/node_api_core/04_post_block.rs
+++ b/sdk/examples/client/node_api_core/04_post_block.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Take the node URL from command line argument or use one from env as default.

--- a/sdk/examples/client/node_api_core/04_post_block.rs
+++ b/sdk/examples/client/node_api_core/04_post_block.rs
@@ -15,10 +15,16 @@ async fn main() -> Result<()> {
     // If not provided we use the default node from the `.env` file.
     dotenvy::dotenv().ok();
 
+    for var in ["EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/05_post_block_raw.rs
+++ b/sdk/examples/client/node_api_core/05_post_block_raw.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Take the node URL from command line argument or use one from env as default.

--- a/sdk/examples/client/node_api_core/05_post_block_raw.rs
+++ b/sdk/examples/client/node_api_core/05_post_block_raw.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // If not provided we use the default node from the `.env` file.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["EXPLORER_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/node_api_core/05_post_block_raw.rs
+++ b/sdk/examples/client/node_api_core/05_post_block_raw.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Take the node URL from command line argument or use one from env as default.

--- a/sdk/examples/client/node_api_core/05_post_block_raw.rs
+++ b/sdk/examples/client/node_api_core/05_post_block_raw.rs
@@ -15,10 +15,16 @@ async fn main() -> Result<()> {
     // If not provided we use the default node from the `.env` file.
     dotenvy::dotenv().ok();
 
+    for var in ["EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/06_get_block.rs
+++ b/sdk/examples/client/node_api_core/06_get_block.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/07_get_block_raw.rs
+++ b/sdk/examples/client/node_api_core/07_get_block_raw.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/08_get_block_metadata.rs
+++ b/sdk/examples/client/node_api_core/08_get_block_metadata.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/09_get_output.rs
+++ b/sdk/examples/client/node_api_core/09_get_output.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/10_get_output_raw.rs
+++ b/sdk/examples/client/node_api_core/10_get_output_raw.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/11_get_output_metadata.rs
+++ b/sdk/examples/client/node_api_core/11_get_output_metadata.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/12_get_receipts.rs
+++ b/sdk/examples/client/node_api_core/12_get_receipts.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/13_get_receipts_migrated_at.rs
+++ b/sdk/examples/client/node_api_core/13_get_receipts_migrated_at.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/14_get_treasury.rs
+++ b/sdk/examples/client/node_api_core/14_get_treasury.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/17_get_milestone_by_id.rs
+++ b/sdk/examples/client/node_api_core/17_get_milestone_by_id.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/18_get_milestone_by_id_raw.rs
+++ b/sdk/examples/client/node_api_core/18_get_milestone_by_id_raw.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/19_get_utxo_changes_by_id.rs
+++ b/sdk/examples/client/node_api_core/19_get_utxo_changes_by_id.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/20_get_milestone_by_index.rs
+++ b/sdk/examples/client/node_api_core/20_get_milestone_by_index.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/21_get_milestone_by_index_raw.rs
+++ b/sdk/examples/client/node_api_core/21_get_milestone_by_index_raw.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_core/22_get_utxo_changes_by_index.rs
+++ b/sdk/examples/client/node_api_core/22_get_utxo_changes_by_index.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_indexer/01_get_alias_output.rs
+++ b/sdk/examples/client/node_api_indexer/01_get_alias_output.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_indexer/02_get_alias_outputs.rs
+++ b/sdk/examples/client/node_api_indexer/02_get_alias_outputs.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder()

--- a/sdk/examples/client/node_api_indexer/03_get_foundry_output.rs
+++ b/sdk/examples/client/node_api_indexer/03_get_foundry_output.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_indexer/04_get_foundry_outputs.rs
+++ b/sdk/examples/client/node_api_indexer/04_get_foundry_outputs.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder()

--- a/sdk/examples/client/node_api_indexer/05_get_nft_output.rs
+++ b/sdk/examples/client/node_api_indexer/05_get_nft_output.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/node_api_indexer/06_get_nft_outputs.rs
+++ b/sdk/examples/client/node_api_indexer/06_get_nft_outputs.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder()

--- a/sdk/examples/client/node_api_indexer/07_get_random_basic_outputs.rs
+++ b/sdk/examples/client/node_api_indexer/07_get_random_basic_outputs.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/client/offline_signing/0_address_generation.rs
+++ b/sdk/examples/client/offline_signing/0_address_generation.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/offline_signing/0_address_generation.rs
+++ b/sdk/examples/client/offline_signing/0_address_generation.rs
@@ -20,6 +20,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let secret_manager = SecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;
 
     // Generates an address offline.

--- a/sdk/examples/client/offline_signing/0_address_generation.rs
+++ b/sdk/examples/client/offline_signing/0_address_generation.rs
@@ -21,9 +21,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let secret_manager = SecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/client/offline_signing/0_address_generation.rs
+++ b/sdk/examples/client/offline_signing/0_address_generation.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let secret_manager = SecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/client/offline_signing/1_transaction_preparation.rs
+++ b/sdk/examples/client/offline_signing/1_transaction_preparation.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/offline_signing/1_transaction_preparation.rs
+++ b/sdk/examples/client/offline_signing/1_transaction_preparation.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/offline_signing/1_transaction_preparation.rs
+++ b/sdk/examples/client/offline_signing/1_transaction_preparation.rs
@@ -26,6 +26,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Address to which we want to send the amount.

--- a/sdk/examples/client/offline_signing/1_transaction_preparation.rs
+++ b/sdk/examples/client/offline_signing/1_transaction_preparation.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/offline_signing/2_transaction_signing.rs
+++ b/sdk/examples/client/offline_signing/2_transaction_signing.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let secret_manager = SecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/client/offline_signing/2_transaction_signing.rs
+++ b/sdk/examples/client/offline_signing/2_transaction_signing.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let secret_manager = SecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;
 
     let prepared_transaction_data = read_prepared_transaction_from_file(PREPARED_TRANSACTION_FILE_NAME).await?;

--- a/sdk/examples/client/offline_signing/2_transaction_signing.rs
+++ b/sdk/examples/client/offline_signing/2_transaction_signing.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/offline_signing/2_transaction_signing.rs
+++ b/sdk/examples/client/offline_signing/2_transaction_signing.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let secret_manager = SecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/client/offline_signing/3_send_block.rs
+++ b/sdk/examples/client/offline_signing/3_send_block.rs
@@ -28,6 +28,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/offline_signing/3_send_block.rs
+++ b/sdk/examples/client/offline_signing/3_send_block.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/offline_signing/3_send_block.rs
+++ b/sdk/examples/client/offline_signing/3_send_block.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a node client.

--- a/sdk/examples/client/offline_signing/3_send_block.rs
+++ b/sdk/examples/client/offline_signing/3_send_block.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/output/alias.rs
+++ b/sdk/examples/client/output/alias.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/alias.rs
+++ b/sdk/examples/client/output/alias.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/alias.rs
+++ b/sdk/examples/client/output/alias.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/all.rs
+++ b/sdk/examples/client/output/all.rs
@@ -36,6 +36,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/all.rs
+++ b/sdk/examples/client/output/all.rs
@@ -37,9 +37,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/all.rs
+++ b/sdk/examples/client/output/all.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/all_automatic_input_selection.rs
+++ b/sdk/examples/client/output/all_automatic_input_selection.rs
@@ -34,9 +34,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/all_automatic_input_selection.rs
+++ b/sdk/examples/client/output/all_automatic_input_selection.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/all_automatic_input_selection.rs
+++ b/sdk/examples/client/output/all_automatic_input_selection.rs
@@ -33,6 +33,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/basic.rs
+++ b/sdk/examples/client/output/basic.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/basic.rs
+++ b/sdk/examples/client/output/basic.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/basic.rs
+++ b/sdk/examples/client/output/basic.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/build_alias_output.rs
+++ b/sdk/examples/client/output/build_alias_output.rs
@@ -25,6 +25,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/output/build_alias_output.rs
+++ b/sdk/examples/client/output/build_alias_output.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let metadata = std::env::args().nth(1).unwrap_or_else(|| "hello".to_string());

--- a/sdk/examples/client/output/build_alias_output.rs
+++ b/sdk/examples/client/output/build_alias_output.rs
@@ -26,9 +26,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let metadata = std::env::args().nth(1).unwrap_or_else(|| "hello".to_string());

--- a/sdk/examples/client/output/build_alias_output.rs
+++ b/sdk/examples/client/output/build_alias_output.rs
@@ -25,6 +25,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let metadata = std::env::args().nth(1).unwrap_or_else(|| "hello".to_string());
     let metadata = metadata.as_bytes();
 

--- a/sdk/examples/client/output/build_basic_output.rs
+++ b/sdk/examples/client/output/build_basic_output.rs
@@ -30,6 +30,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/build_basic_output.rs
+++ b/sdk/examples/client/output/build_basic_output.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/build_basic_output.rs
+++ b/sdk/examples/client/output/build_basic_output.rs
@@ -31,9 +31,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/build_basic_output.rs
+++ b/sdk/examples/client/output/build_basic_output.rs
@@ -30,6 +30,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/output/build_nft_output.rs
+++ b/sdk/examples/client/output/build_nft_output.rs
@@ -28,6 +28,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/output/build_nft_output.rs
+++ b/sdk/examples/client/output/build_nft_output.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/build_nft_output.rs
+++ b/sdk/examples/client/output/build_nft_output.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/build_nft_output.rs
+++ b/sdk/examples/client/output/build_nft_output.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/expiration.rs
+++ b/sdk/examples/client/output/expiration.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/expiration.rs
+++ b/sdk/examples/client/output/expiration.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/expiration.rs
+++ b/sdk/examples/client/output/expiration.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/foundry.rs
+++ b/sdk/examples/client/output/foundry.rs
@@ -38,6 +38,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/foundry.rs
+++ b/sdk/examples/client/output/foundry.rs
@@ -39,9 +39,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/foundry.rs
+++ b/sdk/examples/client/output/foundry.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/micro_transaction.rs
+++ b/sdk/examples/client/output/micro_transaction.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/micro_transaction.rs
+++ b/sdk/examples/client/output/micro_transaction.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/micro_transaction.rs
+++ b/sdk/examples/client/output/micro_transaction.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/native_tokens.rs
+++ b/sdk/examples/client/output/native_tokens.rs
@@ -26,9 +26,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/native_tokens.rs
+++ b/sdk/examples/client/output/native_tokens.rs
@@ -25,6 +25,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/output/native_tokens.rs
+++ b/sdk/examples/client/output/native_tokens.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/nft.rs
+++ b/sdk/examples/client/output/nft.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/output/nft.rs
+++ b/sdk/examples/client/output/nft.rs
@@ -30,9 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/client/output/nft.rs
+++ b/sdk/examples/client/output/nft.rs
@@ -29,6 +29,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
     let explorer_url = std::env::var("EXPLORER_URL").unwrap();
     let faucet_url = std::env::var("FAUCET_URL").unwrap();

--- a/sdk/examples/client/output/recursive_alias.rs
+++ b/sdk/examples/client/output/recursive_alias.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/recursive_alias.rs
+++ b/sdk/examples/client/output/recursive_alias.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/output/recursive_alias.rs
+++ b/sdk/examples/client/output/recursive_alias.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/participation.rs
+++ b/sdk/examples/client/participation.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/participation.rs
+++ b/sdk/examples/client/participation.rs
@@ -30,9 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/participation.rs
+++ b/sdk/examples/client/participation.rs
@@ -29,6 +29,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/quorum.rs
+++ b/sdk/examples/client/quorum.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_1 = std::env::args().nth(1).expect("missing example argument: NODE 1");

--- a/sdk/examples/client/quorum.rs
+++ b/sdk/examples/client/quorum.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_1 = std::env::args().nth(1).expect("missing example argument: NODE 1");

--- a/sdk/examples/client/quorum.rs
+++ b/sdk/examples/client/quorum.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/quorum.rs
+++ b/sdk/examples/client/quorum.rs
@@ -23,6 +23,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_1 = std::env::args().nth(1).expect("missing example argument: NODE 1");
     let node_2 = std::env::args().nth(2).expect("missing example argument: NODE 2");
     let node_3 = std::env::args().nth(3).expect("missing example argument: NODE 3");

--- a/sdk/examples/client/send_all.rs
+++ b/sdk/examples/client/send_all.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "MNEMONIC_2", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/send_all.rs
+++ b/sdk/examples/client/send_all.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "MNEMONIC_2", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/send_all.rs
+++ b/sdk/examples/client/send_all.rs
@@ -24,6 +24,12 @@ async fn main() -> Result<()> {
     // `NON_SECURE_USE_DEVELOPMENT_MNEMONIC_1` must contain non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "MNEMONIC_2", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/split_funds.rs
+++ b/sdk/examples/client/split_funds.rs
@@ -17,6 +17,12 @@ async fn main() -> Result<()> {
     // `MNEMONIC` must contain non-zero balance.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a node client.
     let client = Client::builder()
         .with_node(&std::env::var("NODE_URL").unwrap())?

--- a/sdk/examples/client/split_funds.rs
+++ b/sdk/examples/client/split_funds.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/split_funds.rs
+++ b/sdk/examples/client/split_funds.rs
@@ -18,9 +18,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "FAUCET_URL", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a node client.

--- a/sdk/examples/client/stronghold.rs
+++ b/sdk/examples/client/stronghold.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let stronghold_secret_manager = StrongholdSecretManager::builder()

--- a/sdk/examples/client/stronghold.rs
+++ b/sdk/examples/client/stronghold.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["MNEMONIC"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/client/stronghold.rs
+++ b/sdk/examples/client/stronghold.rs
@@ -20,12 +20,18 @@ use iota_sdk::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // This example uses secrets in environment variables for simplicity which should not be done in production.
+    dotenvy::dotenv().ok();
+
+    for var in ["MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let stronghold_secret_manager = StrongholdSecretManager::builder()
         .password("some_hopefully_secure_password".to_owned())
         .build("test.stronghold")?;
-
-    // This example uses secrets in environment variables for simplicity which should not be done in production.
-    dotenvy::dotenv().ok();
 
     let mnemonic = Mnemonic::from(std::env::var("MNEMONIC").unwrap());
 

--- a/sdk/examples/client/stronghold.rs
+++ b/sdk/examples/client/stronghold.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let stronghold_secret_manager = StrongholdSecretManager::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/check_balance.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/check_balance.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/check_balance.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/check_balance.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/check_balance.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/check_balance.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
@@ -24,7 +24,9 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/consolidate_outputs.rs
@@ -23,6 +23,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/create_account.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/create_account.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         "NODE_URL",
         "WALLET_DB_PATH",
     ] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/how_tos/accounts_and_addresses/create_account.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/create_account.rs
@@ -24,6 +24,18 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in [
+        "STRONGHOLD_PASSWORD",
+        "STRONGHOLD_SNAPSHOT_PATH",
+        "MNEMONIC",
+        "NODE_URL",
+        "WALLET_DB_PATH",
+    ] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Setup Stronghold secret_manager
     let secret_manager = StrongholdSecretManager::builder()
         .password(std::env::var("STRONGHOLD_PASSWORD").unwrap())

--- a/sdk/examples/how_tos/accounts_and_addresses/create_account.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/create_account.rs
@@ -31,9 +31,7 @@ async fn main() -> Result<()> {
         "NODE_URL",
         "WALLET_DB_PATH",
     ] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/how_tos/accounts_and_addresses/create_address.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/create_address.rs
@@ -21,6 +21,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/create_address.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/create_address.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/create_address.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/create_address.rs
@@ -22,9 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_accounts.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_addresses.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
@@ -15,6 +15,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_outputs.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
@@ -18,6 +18,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
+++ b/sdk/examples/how_tos/accounts_and_addresses/list_transactions.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
@@ -23,6 +23,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create the wallet
     let wallet = Wallet::builder().finish().await?;
 

--- a/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/advanced_transaction.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/advanced_transactions/claim_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/claim_transaction.rs
@@ -17,9 +17,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/advanced_transactions/claim_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/claim_transaction.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/advanced_transactions/claim_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/claim_transaction.rs
@@ -16,6 +16,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["EXPLORER_URL", "STRONGHOLD_PASSWORD"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create the wallet
     let wallet = Wallet::builder().finish().await?;
 

--- a/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
@@ -26,6 +26,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
+++ b/sdk/examples/how_tos/advanced_transactions/send_micro_transaction.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/create.rs
+++ b/sdk/examples/how_tos/alias/create.rs
@@ -19,6 +19,12 @@ async fn main() -> Result<()> {
     //  This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/alias/create.rs
+++ b/sdk/examples/how_tos/alias/create.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/create.rs
+++ b/sdk/examples/how_tos/alias/create.rs
@@ -20,9 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/destroy.rs
+++ b/sdk/examples/how_tos/alias/destroy.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/destroy.rs
+++ b/sdk/examples/how_tos/alias/destroy.rs
@@ -20,9 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/destroy.rs
+++ b/sdk/examples/how_tos/alias/destroy.rs
@@ -19,6 +19,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/alias/governance_transition.rs
+++ b/sdk/examples/how_tos/alias/governance_transition.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/governance_transition.rs
+++ b/sdk/examples/how_tos/alias/governance_transition.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/governance_transition.rs
+++ b/sdk/examples/how_tos/alias/governance_transition.rs
@@ -24,6 +24,12 @@ async fn main() -> Result<()> {
     //  This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/alias/state_transition.rs
+++ b/sdk/examples/how_tos/alias/state_transition.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias/state_transition.rs
+++ b/sdk/examples/how_tos/alias/state_transition.rs
@@ -21,6 +21,12 @@ async fn main() -> Result<()> {
     //  This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/alias/state_transition.rs
+++ b/sdk/examples/how_tos/alias/state_transition.rs
@@ -22,9 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/alias_wallet/request_funds.rs
+++ b/sdk/examples/how_tos/alias_wallet/request_funds.rs
@@ -22,9 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["FAUCET_URL", "WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let faucet_url = std::env::var("FAUCET_URL").unwrap();

--- a/sdk/examples/how_tos/alias_wallet/request_funds.rs
+++ b/sdk/examples/how_tos/alias_wallet/request_funds.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["FAUCET_URL", "WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let faucet_url = std::env::var("FAUCET_URL").unwrap();

--- a/sdk/examples/how_tos/alias_wallet/request_funds.rs
+++ b/sdk/examples/how_tos/alias_wallet/request_funds.rs
@@ -21,6 +21,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["FAUCET_URL", "WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let faucet_url = std::env::var("FAUCET_URL").unwrap();
 
     // Create the wallet

--- a/sdk/examples/how_tos/alias_wallet/transaction.rs
+++ b/sdk/examples/how_tos/alias_wallet/transaction.rs
@@ -22,9 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let sync_options = SyncOptions {

--- a/sdk/examples/how_tos/alias_wallet/transaction.rs
+++ b/sdk/examples/how_tos/alias_wallet/transaction.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let sync_options = SyncOptions {

--- a/sdk/examples/how_tos/alias_wallet/transaction.rs
+++ b/sdk/examples/how_tos/alias_wallet/transaction.rs
@@ -21,6 +21,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let sync_options = SyncOptions {
         alias: AliasSyncOptions {
             basic_outputs: true,
@@ -73,8 +79,10 @@ async fn main() -> Result<()> {
     account
         .retry_transaction_until_included(&transaction.transaction_id, None, None)
         .await?;
+
     println!(
-        "Transaction with custom input: https://explorer.shimmer.network/testnet/transaction/{}",
+        "Transaction with custom input: {}/transaction/{}",
+        std::env::var("EXPLORER_URL").unwrap(),
         transaction.transaction_id
     );
 

--- a/sdk/examples/how_tos/client/get_health.rs
+++ b/sdk/examples/how_tos/client/get_health.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder()

--- a/sdk/examples/how_tos/client/get_info.rs
+++ b/sdk/examples/how_tos/client/get_info.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder()

--- a/sdk/examples/how_tos/client/get_outputs.rs
+++ b/sdk/examples/how_tos/client/get_outputs.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     // Take the node URL from command line argument or use one from env as default.
     let node_url = std::env::args()
         .nth(2)
-        .unwrap_or_else(|| std::env::var("NODE_URL").unwrap());
+        .unwrap_or_else(|| std::env::var("NODE_URL").expect("NODE_URL not set"));
 
     // Create a node client.
     let client = Client::builder().with_node(&node_url)?.finish().await?;

--- a/sdk/examples/how_tos/native_tokens/burn.rs
+++ b/sdk/examples/how_tos/native_tokens/burn.rs
@@ -33,9 +33,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/burn.rs
+++ b/sdk/examples/how_tos/native_tokens/burn.rs
@@ -32,6 +32,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/native_tokens/burn.rs
+++ b/sdk/examples/how_tos/native_tokens/burn.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/create.rs
+++ b/sdk/examples/how_tos/native_tokens/create.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/native_tokens/create.rs
+++ b/sdk/examples/how_tos/native_tokens/create.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/create.rs
+++ b/sdk/examples/how_tos/native_tokens/create.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/destroy_foundry.rs
+++ b/sdk/examples/how_tos/native_tokens/destroy_foundry.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/destroy_foundry.rs
+++ b/sdk/examples/how_tos/native_tokens/destroy_foundry.rs
@@ -20,9 +20,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/destroy_foundry.rs
+++ b/sdk/examples/how_tos/native_tokens/destroy_foundry.rs
@@ -19,6 +19,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/native_tokens/melt.rs
+++ b/sdk/examples/how_tos/native_tokens/melt.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/melt.rs
+++ b/sdk/examples/how_tos/native_tokens/melt.rs
@@ -26,6 +26,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/native_tokens/melt.rs
+++ b/sdk/examples/how_tos/native_tokens/melt.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/mint.rs
+++ b/sdk/examples/how_tos/native_tokens/mint.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/mint.rs
+++ b/sdk/examples/how_tos/native_tokens/mint.rs
@@ -26,6 +26,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/native_tokens/mint.rs
+++ b/sdk/examples/how_tos/native_tokens/mint.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/send.rs
+++ b/sdk/examples/how_tos/native_tokens/send.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/native_tokens/send.rs
+++ b/sdk/examples/how_tos/native_tokens/send.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/native_tokens/send.rs
+++ b/sdk/examples/how_tos/native_tokens/send.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/nft_collection/00_mint_issuer_nft.rs
+++ b/sdk/examples/how_tos/nft_collection/00_mint_issuer_nft.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/nft_collection/00_mint_issuer_nft.rs
+++ b/sdk/examples/how_tos/nft_collection/00_mint_issuer_nft.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/nft_collection/00_mint_issuer_nft.rs
+++ b/sdk/examples/how_tos/nft_collection/00_mint_issuer_nft.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/nft_collection/01_mint_collection_nft.rs
+++ b/sdk/examples/how_tos/nft_collection/01_mint_collection_nft.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let issuer_nft_id = std::env::args()

--- a/sdk/examples/how_tos/nft_collection/01_mint_collection_nft.rs
+++ b/sdk/examples/how_tos/nft_collection/01_mint_collection_nft.rs
@@ -35,9 +35,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let issuer_nft_id = std::env::args()

--- a/sdk/examples/how_tos/nft_collection/01_mint_collection_nft.rs
+++ b/sdk/examples/how_tos/nft_collection/01_mint_collection_nft.rs
@@ -34,6 +34,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let issuer_nft_id = std::env::args()
         .nth(1)
         .expect("missing example argument: ISSUER_NFT_ID")

--- a/sdk/examples/how_tos/nfts/burn_nft.rs
+++ b/sdk/examples/how_tos/nfts/burn_nft.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/nfts/burn_nft.rs
+++ b/sdk/examples/how_tos/nfts/burn_nft.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create the wallet
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())

--- a/sdk/examples/how_tos/nfts/burn_nft.rs
+++ b/sdk/examples/how_tos/nfts/burn_nft.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/nfts/mint_nft.rs
+++ b/sdk/examples/how_tos/nfts/mint_nft.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/nfts/mint_nft.rs
+++ b/sdk/examples/how_tos/nfts/mint_nft.rs
@@ -35,6 +35,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create the wallet
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())

--- a/sdk/examples/how_tos/nfts/mint_nft.rs
+++ b/sdk/examples/how_tos/nfts/mint_nft.rs
@@ -36,9 +36,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/nfts/send_nft.rs
+++ b/sdk/examples/how_tos/nfts/send_nft.rs
@@ -24,6 +24,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create the wallet
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())

--- a/sdk/examples/how_tos/nfts/send_nft.rs
+++ b/sdk/examples/how_tos/nfts/send_nft.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/nfts/send_nft.rs
+++ b/sdk/examples/how_tos/nfts/send_nft.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet

--- a/sdk/examples/how_tos/outputs/features.rs
+++ b/sdk/examples/how_tos/outputs/features.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/how_tos/outputs/features.rs
+++ b/sdk/examples/how_tos/outputs/features.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/how_tos/outputs/features.rs
+++ b/sdk/examples/how_tos/outputs/features.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/how_tos/outputs/features.rs
+++ b/sdk/examples/how_tos/outputs/features.rs
@@ -26,6 +26,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a client instance.

--- a/sdk/examples/how_tos/outputs/unlock_conditions.rs
+++ b/sdk/examples/how_tos/outputs/unlock_conditions.rs
@@ -29,6 +29,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let node_url = std::env::var("NODE_URL").unwrap();
 
     // Create a client instance.

--- a/sdk/examples/how_tos/outputs/unlock_conditions.rs
+++ b/sdk/examples/how_tos/outputs/unlock_conditions.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/how_tos/outputs/unlock_conditions.rs
+++ b/sdk/examples/how_tos/outputs/unlock_conditions.rs
@@ -30,9 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let node_url = std::env::var("NODE_URL").unwrap();

--- a/sdk/examples/how_tos/outputs/unlock_conditions.rs
+++ b/sdk/examples/how_tos/outputs/unlock_conditions.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
+++ b/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["STRONGHOLD_PASSWORD", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
+++ b/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
@@ -30,9 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["STRONGHOLD_PASSWORD", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
+++ b/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
@@ -29,6 +29,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["STRONGHOLD_PASSWORD", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Setup Stronghold secret_manager
     let stronghold = StrongholdSecretManager::builder()
         .password(std::env::var("STRONGHOLD_PASSWORD").unwrap())

--- a/sdk/examples/how_tos/simple_transaction/request_funds.rs
+++ b/sdk/examples/how_tos/simple_transaction/request_funds.rs
@@ -19,9 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "FAUCET_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/simple_transaction/request_funds.rs
+++ b/sdk/examples/how_tos/simple_transaction/request_funds.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "FAUCET_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/simple_transaction/request_funds.rs
+++ b/sdk/examples/how_tos/simple_transaction/request_funds.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "FAUCET_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
+++ b/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
@@ -23,6 +23,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
+++ b/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
+++ b/sdk/examples/how_tos/simple_transaction/simple_transaction.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/wallet/17_check_unlock_conditions.rs
+++ b/sdk/examples/wallet/17_check_unlock_conditions.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/accounts.rs
+++ b/sdk/examples/wallet/accounts.rs
@@ -28,6 +28,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "FAUCET_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
 
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/accounts.rs
+++ b/sdk/examples/wallet/accounts.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "FAUCET_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/accounts.rs
+++ b/sdk/examples/wallet/accounts.rs
@@ -29,9 +29,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "FAUCET_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/background_syncing.rs
+++ b/sdk/examples/wallet/background_syncing.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "FAUCET_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a wallet

--- a/sdk/examples/wallet/background_syncing.rs
+++ b/sdk/examples/wallet/background_syncing.rs
@@ -23,9 +23,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "FAUCET_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create a wallet

--- a/sdk/examples/wallet/background_syncing.rs
+++ b/sdk/examples/wallet/background_syncing.rs
@@ -22,6 +22,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "FAUCET_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create a wallet
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/events.rs
+++ b/sdk/examples/wallet/events.rs
@@ -32,9 +32,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/events.rs
+++ b/sdk/examples/wallet/events.rs
@@ -31,6 +31,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
 
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/events.rs
+++ b/sdk/examples/wallet/events.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/getting_started.rs
+++ b/sdk/examples/wallet/getting_started.rs
@@ -22,6 +22,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/wallet/getting_started.rs
+++ b/sdk/examples/wallet/getting_started.rs
@@ -23,9 +23,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret manager.

--- a/sdk/examples/wallet/getting_started.rs
+++ b/sdk/examples/wallet/getting_started.rs
@@ -19,13 +19,22 @@ use iota_sdk::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // This example uses secrets in environment variables for simplicity which should not be done in production.
+    dotenvy::dotenv().ok();
+
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Setup Stronghold secret manager.
     // WARNING: Never hardcode passwords in production code.
     let secret_manager = StrongholdSecretManager::builder()
         .password("password".to_owned()) // A password to encrypt the stored data.
         .build("vault.stronghold")?; // The path to store the account snapshot.
 
-    let client_options = ClientOptions::new().with_node("https://api.testnet.shimmer.network")?;
+    let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
 
     // Set up and store the wallet.
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/getting_started.rs
+++ b/sdk/examples/wallet/getting_started.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret manager.

--- a/sdk/examples/wallet/ledger_nano.rs
+++ b/sdk/examples/wallet/ledger_nano.rs
@@ -36,6 +36,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "WALLET_DB_PATH", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
     let secret_manager = LedgerSecretManager::new(true);
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/ledger_nano.rs
+++ b/sdk/examples/wallet/ledger_nano.rs
@@ -37,9 +37,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/ledger_nano.rs
+++ b/sdk/examples/wallet/ledger_nano.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/logger.rs
+++ b/sdk/examples/wallet/logger.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Initialize a logger that writes to the specified file

--- a/sdk/examples/wallet/logger.rs
+++ b/sdk/examples/wallet/logger.rs
@@ -24,6 +24,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Initialize a logger that writes to the specified file
     let logger_output_config = fern_logger::LoggerOutputConfigBuilder::new()
         .name("example.log")

--- a/sdk/examples/wallet/logger.rs
+++ b/sdk/examples/wallet/logger.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Initialize a logger that writes to the specified file

--- a/sdk/examples/wallet/offline_signing/0_generate_addresses.rs
+++ b/sdk/examples/wallet/offline_signing/0_generate_addresses.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["STRONGHOLD_PASSWORD", "MNEMONIC"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let offline_client = ClientOptions::new();

--- a/sdk/examples/wallet/offline_signing/0_generate_addresses.rs
+++ b/sdk/examples/wallet/offline_signing/0_generate_addresses.rs
@@ -26,6 +26,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["STRONGHOLD_PASSWORD", "MNEMONIC"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let offline_client = ClientOptions::new();
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/wallet/offline_signing/0_generate_addresses.rs
+++ b/sdk/examples/wallet/offline_signing/0_generate_addresses.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["STRONGHOLD_PASSWORD", "MNEMONIC"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let offline_client = ClientOptions::new();

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let params = [SendParams::new(SEND_AMOUNT, RECV_ADDRESS)?];

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -31,9 +31,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let params = [SendParams::new(SEND_AMOUNT, RECV_ADDRESS)?];

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -30,6 +30,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let params = [SendParams::new(SEND_AMOUNT, RECV_ADDRESS)?];
 
     // Recovers addresses from example `0_address_generation`.

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -30,6 +30,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["NODE_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["STRONGHOLD_PASSWORD"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
@@ -29,6 +29,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["STRONGHOLD_PASSWORD"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Setup Stronghold secret_manager
     let secret_manager = StrongholdSecretManager::builder()
         .password(std::env::var("STRONGHOLD_PASSWORD").unwrap())

--- a/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
@@ -30,9 +30,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["STRONGHOLD_PASSWORD"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Setup Stronghold secret_manager

--- a/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/2_sign_transaction.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["STRONGHOLD_PASSWORD"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/wallet/offline_signing/3_send_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/3_send_transaction.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     #[allow(clippy::single_element_loop)]
     for var in ["EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet with the secret_manager and client options

--- a/sdk/examples/wallet/offline_signing/3_send_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/3_send_transaction.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     // Create the wallet with the secret_manager and client options

--- a/sdk/examples/wallet/offline_signing/3_send_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/3_send_transaction.rs
@@ -27,6 +27,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     // Create the wallet with the secret_manager and client options
     let wallet = Wallet::builder()
         .with_storage_path(ONLINE_WALLET_DB_PATH)

--- a/sdk/examples/wallet/offline_signing/3_send_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/3_send_transaction.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    #[allow(clippy::single_element_loop)]
     for var in ["EXPLORER_URL"] {
         std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }

--- a/sdk/examples/wallet/participation.rs
+++ b/sdk/examples/wallet/participation.rs
@@ -42,9 +42,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/participation.rs
+++ b/sdk/examples/wallet/participation.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = Wallet::builder()

--- a/sdk/examples/wallet/participation.rs
+++ b/sdk/examples/wallet/participation.rs
@@ -41,6 +41,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["WALLET_DB_PATH", "STRONGHOLD_PASSWORD", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = Wallet::builder()
         .with_storage_path(&std::env::var("WALLET_DB_PATH").unwrap())
         .finish()

--- a/sdk/examples/wallet/recover_accounts.rs
+++ b/sdk/examples/wallet/recover_accounts.rs
@@ -24,9 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/recover_accounts.rs
+++ b/sdk/examples/wallet/recover_accounts.rs
@@ -23,6 +23,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
 
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/recover_accounts.rs
+++ b/sdk/examples/wallet/recover_accounts.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "EXPLORER_URL", "FAUCET_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let num_simultaneous_txs = NUM_SIMULTANEOUS_TXS.min(num_cpus::get());

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -33,9 +33,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "EXPLORER_URL", "FAUCET_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let num_simultaneous_txs = NUM_SIMULTANEOUS_TXS.min(num_cpus::get());

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -32,6 +32,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "EXPLORER_URL", "FAUCET_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let num_simultaneous_txs = NUM_SIMULTANEOUS_TXS.min(num_cpus::get());
 
     println!("Spammer set up to issue {num_simultaneous_txs} transactions simultaneously.");

--- a/sdk/examples/wallet/split_funds.rs
+++ b/sdk/examples/wallet/split_funds.rs
@@ -30,6 +30,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
 
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/split_funds.rs
+++ b/sdk/examples/wallet/split_funds.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/split_funds.rs
+++ b/sdk/examples/wallet/split_funds.rs
@@ -31,9 +31,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/storage.rs
+++ b/sdk/examples/wallet/storage.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/storage.rs
+++ b/sdk/examples/wallet/storage.rs
@@ -24,6 +24,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;

--- a/sdk/examples/wallet/storage.rs
+++ b/sdk/examples/wallet/storage.rs
@@ -25,9 +25,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let secret_manager = MnemonicSecretManager::try_from_mnemonic(std::env::var("MNEMONIC").unwrap())?;

--- a/sdk/examples/wallet/wallet.rs
+++ b/sdk/examples/wallet/wallet.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
+        std::env::var(var).unwrap_or_else(|_| panic!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = create_wallet().await?;

--- a/sdk/examples/wallet/wallet.rs
+++ b/sdk/examples/wallet/wallet.rs
@@ -38,9 +38,7 @@ async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
-        if std::env::var(var).is_err() {
-            panic!(".env variable '{}' is undefined, see .env.example", var);
-        }
+        std::env::var(var).expect(&format!(".env variable '{var}' is undefined, see .env.example"));
     }
 
     let wallet = create_wallet().await?;

--- a/sdk/examples/wallet/wallet.rs
+++ b/sdk/examples/wallet/wallet.rs
@@ -37,6 +37,12 @@ async fn main() -> Result<()> {
     // This example uses secrets in environment variables for simplicity which should not be done in production.
     dotenvy::dotenv().ok();
 
+    for var in ["NODE_URL", "MNEMONIC", "WALLET_DB_PATH", "EXPLORER_URL"] {
+        if std::env::var(var).is_err() {
+            panic!(".env variable '{}' is undefined, see .env.example", var);
+        }
+    }
+
     let wallet = create_wallet().await?;
 
     let account = wallet.get_or_create_account("Alice").await?;


### PR DESCRIPTION
# Description of change

Adds env checks to all examples

Ive opted to allow theclipyp warning in single for loop.
there is an RFC in nightly that adds global clippy allows to the cargo.toml:
https://github.com/rust-lang/rfcs/blob/master/text/3389-manifest-lint.md

Although this still doesnt allow disable for a folder, it will function if we allow globally in sdk and deny it again in the sdk/src folder.

Due on stable in dec 28
possible addition then is to change the unwrap_or_else to a panic.
`allow-unwrap-in-tests` exists, but not for examples


## Links to any relevant issues

fixes #1360

## Type of change

- Enhancement (a non-breaking change which adds functionality)