### PR TITLE
Use ALL_FLAGS length instead of manually set associated constant

### DIFF
--- a/sdk/src/types/block/output/feature/mod.rs
+++ b/sdk/src/types/block/output/feature/mod.rs
@@ -149,7 +149,7 @@ crate::create_bitflags!(
     ]
 );
 
-pub(crate) type FeatureCount = BoundedU8<0, { Features::COUNT_MAX }>;
+pub(crate) type FeatureCount = BoundedU8<0, { FeatureFlags::ALL_FLAGS.len() as u8 }>;
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, Packable)]
@@ -184,9 +184,6 @@ impl IntoIterator for Features {
 }
 
 impl Features {
-    ///
-    pub const COUNT_MAX: u8 = 5;
-
     /// Creates a new [`Features`] from a vec.
     pub fn from_vec(features: Vec<Feature>) -> Result<Self, Error> {
         let mut features = BoxedSlicePrefix::<Feature, FeatureCount>::try_from(features.into_boxed_slice())

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -152,7 +152,7 @@ crate::create_bitflags!(
     ]
 );
 
-pub(crate) type UnlockConditionCount = BoundedU8<0, { UnlockConditions::COUNT_MAX }>;
+pub(crate) type UnlockConditionCount = BoundedU8<0, { UnlockConditionFlags::ALL_FLAGS.len() as u8 }>;
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, Packable)]
@@ -190,9 +190,6 @@ impl IntoIterator for UnlockConditions {
 }
 
 impl UnlockConditions {
-    ///
-    pub const COUNT_MAX: u8 = 7;
-
     /// Creates a new [`UnlockConditions`] from a vec.
     pub fn from_vec(unlock_conditions: Vec<UnlockCondition>) -> Result<Self, Error> {
         let mut unlock_conditions =


### PR DESCRIPTION
The constant needs to be set manually and is very easily out of sync (as currently is), potentially making random tests to fail. Instead we can use `*Flags::ALL_FLAGS.len()` because `*Flags` has to always be in sync with the enum as it wouldn't compile otherwise.
Alternative would be https://doc.rust-lang.org/std/mem/fn.variant_count.html but it's unstable.