### PR TITLE
Fix `needs_blind_signing()` for non Ed25519 addresses

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Display of `WalletError::InsufficientFunds`;
 
+### Fixed
+
+- `needs_blind_signing()` for non Ed25519 addresses;
+
 ## 1.1.2 - 2023-10-26
 
 ### Added

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -426,11 +426,9 @@ impl SecretManagerConfig for LedgerSecretManager {
 pub fn needs_blind_signing(prepared_transaction: &PreparedTransactionData, buffer_size: usize) -> bool {
     let TransactionEssence::Regular(essence) = &prepared_transaction.essence;
 
-    if !essence
-        .outputs()
-        .iter()
-        .all(|output| matches!(output, Output::Basic(o) if o.simple_deposit_address().is_some()))
-    {
+    if !essence.outputs().iter().all(
+        |output| matches!(output, Output::Basic(o) if o.simple_deposit_address().is_some() && o.address().is_ed25519()),
+    ) {
         return true;
     }
 


### PR DESCRIPTION
# Description of change

Fix `needs_blind_signing()` for non Ed25519 addresses, because these are not allowed.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Simulated in a biological neuronal network :trollface:
