### PR TITLE
Python: fix input_range params and export init_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk-python"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "futures",
  "iota-sdk-bindings-core",

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Utils:verify_transaction_semantic()`;
 - `Account::prepare_claim_outputs()` method;
 
+### Fixed
+
+- Missing `init_logger` export;
+- `Client::build_and_post_block()` with custom input range;
+
 ## 1.1.1 - 2023-10-31
 
 ### Added

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 1.1.2 - 2023-MM-DD
+## 1.1.2 - 2023-12-01
 
 ### Added
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-sdk-python"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "Python bindings for the IOTA SDK library"

--- a/bindings/python/iota_sdk/client/client.py
+++ b/bindings/python/iota_sdk/client/client.py
@@ -410,11 +410,12 @@ class Client(NodeCoreAPI, NodeIndexerAPI, HighLevelAPI, ClientUtils):
         is_start_set = 'input_range_start' in options
         is_end_set = 'input_range_end' in options
         if is_start_set or is_end_set:
-            options['range'] = {}
+            options['input_range'] = {}
             if is_start_set:
-                options['range']['start'] = options.pop('start')
+                options['input_range']['start'] = options.pop(
+                    'input_range_start')
             if is_end_set:
-                options['range']['end'] = options.pop('end')
+                options['input_range']['end'] = options.pop('input_range_end')
 
         options = humps.camelize(options)
 

--- a/bindings/python/iota_sdk/external.py
+++ b/bindings/python/iota_sdk/external.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=import-error, unused-import
-from .iota_sdk import call_utils_method, call_secret_manager_method, create_secret_manager, destroy_wallet, create_client, create_wallet, listen_wallet, get_client_from_wallet, get_secret_manager_from_wallet, call_wallet_method, call_client_method, listen_mqtt
+from .iota_sdk import call_utils_method, call_secret_manager_method, create_secret_manager, destroy_wallet, create_client, create_wallet, listen_wallet, get_client_from_wallet, get_secret_manager_from_wallet, call_wallet_method, call_client_method, init_logger, listen_mqtt

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -22,7 +22,7 @@ def get_py_version_cfgs():
 
 setup(
     name="iota_sdk",
-    version="1.1.1",
+    version="1.1.2",
     classifiers=[
         "License :: SPDX-License-Identifier ::  Apache-2.0",
         "Intended Audience :: Developers",


### PR DESCRIPTION
# Description of change

Python: fix input_range params and export init_logger

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running this
```Python
# pylint: disable=no-name-in-module
from iota_sdk import (init_logger)
import json
import os

from dotenv import load_dotenv

from iota_sdk import AddressAndAmount, Client, MnemonicSecretManager, CoinType, SecretManager

load_dotenv()


load_dotenv()
log_config = {
    'name': 'client.log',
    'levelFilter': 'debug',
    'targetExclusions': ["h2", "hyper", "rustls"]
}

log_config_str = json.dumps(log_config)

init_logger(log_config_str)

node_url = os.environ.get('NODE_URL', 'https://api.testnet.shimmer.network')

# Create a Client instance
client = Client(nodes=[node_url])

if 'MNEMONIC' not in os.environ:
    raise Exception(".env MNEMONIC is undefined, see .env.example")

secret_manager = MnemonicSecretManager(
    os.environ['MNEMONIC'])

amount = 1000000
address_and_amount = AddressAndAmount(
    amount,
    'rms1qzgkhdwhe0z9ntgv4wcpys2zy4xv0fht87famu90g0wsp73qghz7vm3j8j0',
)


index = 200
addresses = SecretManager(secret_manager).generate_ed25519_addresses(
    coin_type=CoinType.IOTA,
    account_index=0,
    start=index,
    end=index + 1,
    internal=False,
    bech32_hrp='rms')

print(addresses)

inputs = client.find_inputs(addresses, amount)
print(inputs)

# Create and post a block with a transaction
block = client.build_and_post_block(secret_manager,
                                    account_index=0,
                                    coin_type=CoinType.IOTA,
                                    output=address_and_amount,
                                    inputs=inputs,
                                    input_range_start=index,
                                    input_range_end=index+1,
                                    )
print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{block[0]}')
```