### PR TITLE
Use stored wallet data in builder

### DIFF
--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -259,7 +259,7 @@ where
             #[cfg(feature = "storage")]
             storage_manager: tokio::sync::RwLock::new(storage_manager),
         };
-        let wallet_data = WalletData::new(self.bip_path, address, self.alias.clone());
+        let wallet_data = wallet_data.unwrap_or_else(|| WalletData::new(self.bip_path, address, self.alias.clone()));
         let wallet = Wallet {
             inner: Arc::new(wallet_inner),
             data: Arc::new(RwLock::new(wallet_data)),

--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -259,7 +259,10 @@ where
             #[cfg(feature = "storage")]
             storage_manager: tokio::sync::RwLock::new(storage_manager),
         };
+        #[cfg(feature = "storage")]
         let wallet_data = wallet_data.unwrap_or_else(|| WalletData::new(self.bip_path, address, self.alias.clone()));
+        #[cfg(not(feature = "storage"))]
+        let wallet_data = WalletData::new(self.bip_path, address, self.alias.clone());
         let wallet = Wallet {
             inner: Arc::new(wallet_inner),
             data: Arc::new(RwLock::new(wallet_data)),


### PR DESCRIPTION
# Description of change

Use stored wallet data in builder, so the previous data is kept

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Using the cli wallet, after building the wallet a second time the bech32 was still set to something else than default.