### PR TITLE
Fix InvalidTransactionNativeTokensCount error for multiple entries

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `needs_blind_signing()` for non Ed25519 addresses;
+- InvalidTransactionNativeTokensCount error for multiple entries with the same native token;
 
 ## 1.1.2 - 2023-10-26
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `needs_blind_signing()` for non Ed25519 addresses;
-- InvalidTransactionNativeTokensCount error for multiple entries with the same native token;
+- `InvalidTransactionNativeTokensCount` error for multiple entries with the same native token;
 
 ## 1.1.2 - 2023-10-26
 

--- a/sdk/src/types/block/payload/transaction/essence/regular.rs
+++ b/sdk/src/types/block/payload/transaction/essence/regular.rs
@@ -219,7 +219,7 @@ fn verify_inputs_packable<const VERIFY: bool>(inputs: &[Input], _visitor: &Proto
 fn verify_outputs<const VERIFY: bool>(outputs: &[Output], visitor: &ProtocolParameters) -> Result<(), Error> {
     if VERIFY {
         let mut amount_sum: u64 = 0;
-        let mut total_native_tokens: HashSet<TokenId> = HashSet::new();
+        let mut total_native_tokens = HashSet::<TokenId>::new();
         let mut chain_ids = HashSet::new();
 
         for output in outputs.iter() {

--- a/sdk/tests/types/transaction_regular_essence.rs
+++ b/sdk/tests/types/transaction_regular_essence.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use core::str::FromStr;
+
 use iota_sdk::types::block::{
     address::{Address, AliasAddress, Ed25519Address},
     input::{Input, TreasuryInput, UtxoInput},
@@ -43,8 +45,7 @@ fn build_valid() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -67,8 +68,7 @@ fn build_valid_with_payload() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -92,8 +92,7 @@ fn build_valid_add_inputs_outputs() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -116,8 +115,7 @@ fn build_invalid_payload_kind() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -138,8 +136,7 @@ fn build_invalid_payload_kind() {
 #[test]
 fn build_invalid_input_count_low() {
     let protocol_parameters = protocol_parameters();
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -163,8 +160,7 @@ fn build_invalid_input_count_high() {
     let protocol_parameters = protocol_parameters();
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -205,8 +201,7 @@ fn build_invalid_output_count_high() {
     let protocol_parameters = protocol_parameters();
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -231,8 +226,7 @@ fn build_invalid_duplicate_utxo() {
     let protocol_parameters = protocol_parameters();
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -253,8 +247,7 @@ fn build_invalid_duplicate_utxo() {
 fn build_invalid_input_kind() {
     let protocol_parameters = protocol_parameters();
     let input = Input::Treasury(TreasuryInput::new(MilestoneId::new(rand_bytes_array())));
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let output = Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -327,8 +320,7 @@ fn getters() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let outputs = [Output::Basic(
         BasicOutput::build_with_amount(amount)
@@ -355,14 +347,13 @@ fn duplicate_output_nft() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let basic = BasicOutput::build_with_amount(amount)
         .add_unlock_condition(AddressUnlockCondition::new(address))
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
-    let nft_id = NftId::from(bytes);
+    let nft_id = NftId::from_str(ED25519_ADDRESS_1).unwrap();
     let nft = NftOutput::build_with_amount(1_000_000, nft_id)
         .add_unlock_condition(AddressUnlockCondition::new(address))
         .finish_output(protocol_parameters.token_supply())
@@ -385,8 +376,7 @@ fn duplicate_output_nft_null() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let basic = BasicOutput::build_with_amount(amount)
         .add_unlock_condition(AddressUnlockCondition::new(address))
@@ -412,14 +402,13 @@ fn duplicate_output_alias() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let basic = BasicOutput::build_with_amount(amount)
         .add_unlock_condition(AddressUnlockCondition::new(address))
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
-    let alias_id = AliasId::from(bytes);
+    let alias_id = AliasId::from_str(ED25519_ADDRESS_1).unwrap();
     let alias = AliasOutput::build_with_amount(1_000_000, alias_id)
         .add_unlock_condition(StateControllerAddressUnlockCondition::new(address))
         .add_unlock_condition(GovernorAddressUnlockCondition::new(address))
@@ -443,14 +432,13 @@ fn duplicate_output_foundry() {
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input1 = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
     let input2 = Input::Utxo(UtxoInput::new(transaction_id, 1).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
     let basic = BasicOutput::build_with_amount(amount)
         .add_unlock_condition(AddressUnlockCondition::new(address))
         .finish_output(protocol_parameters.token_supply())
         .unwrap();
-    let alias_id = AliasId::from(bytes);
+    let alias_id = AliasId::from_str(ED25519_ADDRESS_1).unwrap();
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(70, 0, 100).unwrap());
     let foundry_id = FoundryId::build(&AliasAddress::from(alias_id), 1, token_scheme.kind());
     let token_id = TokenId::from(foundry_id);
@@ -476,10 +464,9 @@ fn more_than_64_same_native_tokens() {
     let protocol_parameters = protocol_parameters();
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
-    let alias_id = AliasId::from(bytes);
+    let alias_id = AliasId::from_str(ED25519_ADDRESS_1).unwrap();
     let token_scheme = TokenScheme::Simple(SimpleTokenScheme::new(70, 0, 100).unwrap());
     let foundry_id = FoundryId::build(&AliasAddress::from(alias_id), 1, token_scheme.kind());
     let token_id = TokenId::from(foundry_id);
@@ -502,8 +489,7 @@ fn more_than_64_distinctive_native_tokens() {
     let protocol_parameters = protocol_parameters();
     let transaction_id = TransactionId::new(prefix_hex::decode(TRANSACTION_ID).unwrap());
     let input = Input::Utxo(UtxoInput::new(transaction_id, 0).unwrap());
-    let bytes: [u8; 32] = prefix_hex::decode(ED25519_ADDRESS_1).unwrap();
-    let address = Address::from(Ed25519Address::new(bytes));
+    let address = Address::from(Ed25519Address::from_str(ED25519_ADDRESS_1).unwrap());
     let amount = 1_000_000;
 
     let mut outputs = Vec::new();


### PR DESCRIPTION
# Description of change

Fix InvalidTransactionNativeTokensCount error for multiple entries with the same native token

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added tests and getting this block https://api.shimmer.network/api/core/v2/blocks/0x8ff7d61fae6687303aac3c2a47b1d6599b35428d2ca2296ebc25e5856ae90f4b with an example
