### PR TITLE
Improve ISA with many native tokens in inputs

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Ed25519Signature` type no longer requires validated public key bytes to construct;
+- Input selection for > max native tokens;
 
 ## 1.1.3 - 2023-12-07
 

--- a/sdk/src/client/api/block_builder/input_selection/core/requirement/amount.rs
+++ b/sdk/src/client/api/block_builder/input_selection/core/requirement/amount.rs
@@ -161,6 +161,7 @@ impl AmountSelection {
 
             if let Some(nt) = input.output.native_tokens() {
                 let mut selected_native_tokens = self.selected_native_tokens.clone();
+                
                 selected_native_tokens.extend(nt.iter().map(|t| t.token_id()));
                 // Don't select input if the tx would end up with more than allowed native tokens.
                 if selected_native_tokens.len() > NativeTokens::COUNT_MAX.into() {

--- a/sdk/src/client/api/block_builder/input_selection/core/requirement/amount.rs
+++ b/sdk/src/client/api/block_builder/input_selection/core/requirement/amount.rs
@@ -161,7 +161,7 @@ impl AmountSelection {
 
             if let Some(nt) = input.output.native_tokens() {
                 let mut selected_native_tokens = self.selected_native_tokens.clone();
-                
+
                 selected_native_tokens.extend(nt.iter().map(|t| t.token_id()));
                 // Don't select input if the tx would end up with more than allowed native tokens.
                 if selected_native_tokens.len() > NativeTokens::COUNT_MAX.into() {

--- a/sdk/tests/client/input_selection/native_tokens.rs
+++ b/sdk/tests/client/input_selection/native_tokens.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use iota_sdk::{
     client::api::input_selection::{Burn, Error, InputSelection},
-    types::block::{output::TokenId, protocol::protocol_parameters},
+    types::block::{output::TokenId, protocol::protocol_parameters, rand::bytes::rand_bytes_array},
 };
 use pretty_assertions::assert_eq;
 use primitive_types::U256;
@@ -1465,6 +1465,73 @@ fn two_basic_outputs_native_tokens_not_needed() {
         500_000,
         BECH32_ADDRESS_ED25519_0,
         None,
+    ));
+}
+
+#[test]
+fn higher_nts_count_but_below_max_native_tokens() {
+    let protocol_parameters = protocol_parameters();
+
+    let mut input_native_tokens_0 = Vec::new();
+    for _ in 0..10 {
+        input_native_tokens_0.push((TokenId::from(rand_bytes_array()).to_string(), 10));
+    }
+    let mut input_native_tokens_1 = Vec::new();
+    for _ in 0..64 {
+        input_native_tokens_1.push((TokenId::from(rand_bytes_array()).to_string(), 10));
+    }
+
+    let inputs = build_inputs([
+        Basic(
+            3_000_000,
+            BECH32_ADDRESS_ED25519_0,
+            Some(input_native_tokens_0.iter().map(|(t, a)| (t.as_str(), *a)).collect()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        Basic(
+            10_000_000,
+            BECH32_ADDRESS_ED25519_0,
+            Some(input_native_tokens_1.iter().map(|(t, a)| (t.as_str(), *a)).collect()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    ]);
+    let outputs = build_outputs([Basic(
+        5_000_000,
+        BECH32_ADDRESS_ED25519_0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )]);
+
+    let selected = InputSelection::new(
+        inputs.clone(),
+        outputs.clone(),
+        addresses([BECH32_ADDRESS_ED25519_0]),
+        protocol_parameters,
+    )
+    .select()
+    .unwrap();
+
+    assert_eq!(selected.inputs.len(), 1);
+    assert!(selected.inputs.contains(&inputs[1]));
+    assert_eq!(selected.outputs.len(), 2);
+    assert!(selected.outputs.contains(&outputs[0]));
+    assert!(is_remainder_or_return(
+        &selected.outputs[1],
+        5_000_000,
+        BECH32_ADDRESS_ED25519_0,
+        Some(input_native_tokens_1.iter().map(|(t, a)| (t.as_str(), *a)).collect()),
     ));
 }
 


### PR DESCRIPTION
# Description of change

Improve ISA with many native tokens in inputs by using the inputs in reversed order if ordering from low to high didn't work and inputs have more than max native tokens.

## Links to any relevant issues

https://github.com/iotaledger/iota-sdk/issues/1704

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added test
