### PR TITLE
feat(2.0): Log the drop of  `WalletInner`

### DIFF
--- a/sdk/src/wallet/core/mod.rs
+++ b/sdk/src/wallet/core/mod.rs
@@ -525,6 +525,12 @@ impl<S: SecretManage> Drop for Wallet<S> {
     }
 }
 
+impl<S: SecretManage> Drop for WalletInner<S> {
+    fn drop(&mut self) {
+        log::debug!("drop WalletInner");
+    }
+}
+
 /// Dto for the wallet data.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
# Description of change

Currently, logging the drop of `Wallet` is fine, but not always helpful as it is cloned in a few places, so even if you only created one instance, the logs will show multiple drops of the same wallet as `Wallet` is more of a Pointer Wrapper rather than the actual Wallet (`WalletInner`). So, logging the actual drop of the Wallet would be very helpful for debugging purposes.

## Type of change

- Enhancement

## How the change has been tested

In Firefly, but you don't really need it for this

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
