### PR TITLE
Use bytes for Ed25519Signature public key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "628a8f9bd1e24b4e0db2b4bc2d000b001e7dd032d54afa60a68836aeec5aa54a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -225,9 +225,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -279,9 +279,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitvec"
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -561,15 +561,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -627,12 +627,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -1165,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1263,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
 dependencies = [
  "bytes",
  "fnv",
@@ -1505,15 +1502,15 @@ dependencies = [
 
 [[package]]
 name = "iota-crypto"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d5a986d972c3a703d48ced24fdc0bf16fb2d02959ff4b152fa77b9132f6fb0"
+checksum = "a5db0e2d85e258d6d0db66f4a6bf1e8bdf5b10c3353aa87d98b168778d13fdc1"
 dependencies = [
  "aead",
  "aes",
  "aes-gcm",
  "autocfg",
- "base64 0.21.5",
+ "base64 0.21.7",
  "blake2",
  "chacha20poly1305",
  "cipher",
@@ -1560,7 +1557,7 @@ dependencies = [
  "anymap",
  "async-trait",
  "bech32",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bs58",
  "bytemuck",
  "derive_more",
@@ -1734,18 +1731,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -1799,7 +1796,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall",
 ]
@@ -1833,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2001,7 +1998,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
 ]
@@ -2534,7 +2531,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2664,11 +2661,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2705,7 +2702,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2724,7 +2721,7 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -2990,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
 
 [[package]]
 name = "socket2"
@@ -3528,9 +3525,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3540,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -3555,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3567,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3577,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3590,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-logger"
@@ -3607,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3685,15 +3682,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3708,21 +3696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3757,12 +3730,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3778,12 +3745,6 @@ name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3805,12 +3766,6 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -3826,12 +3781,6 @@ name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3853,12 +3802,6 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -3868,12 +3811,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3895,12 +3832,6 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -3913,9 +3844,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.33"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]
@@ -3938,7 +3869,7 @@ checksum = "e283cc794a890f5bdc01e358ad7c34535025f79ba83c1b5c7e01e5d6c60b336d"
 dependencies = [
  "async-tungstenite",
  "async_io_stream",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "futures-core",
  "futures-io",
  "futures-sink",

--- a/bindings/core/Cargo.toml
+++ b/bindings/core/Cargo.toml
@@ -18,7 +18,7 @@ backtrace = { version = "0.3.69", default-features = false, features = ["std"] }
 derivative = { version = "2.2.0", default-features = false }
 fern-logger = { version = "0.5.0", default-features = false }
 futures = { version = "0.3.30", default-features = false }
-iota-crypto = { version = "0.23.0", default-features = false, features = [
+iota-crypto = { version = "0.23.1", default-features = false, features = [
     "slip10",
     "bip44",
 ] }

--- a/bindings/core/src/method_handler/utils.rs
+++ b/bindings/core/src/method_handler/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crypto::keys::bip39::Mnemonic;
@@ -97,7 +97,7 @@ pub(crate) fn call_utils_method_internal(method: UtilsMethod) -> Result<Response
             use iota_sdk::types::block::Error;
             let signature = Ed25519Signature::try_from(signature)?;
             let message: Vec<u8> = prefix_hex::decode(message)?;
-            Response::Bool(signature.verify(&message).map_err(Error::from)?)
+            Response::Bool(signature.try_verify(&message).map_err(Error::from)?)
         }
         UtilsMethod::VerifySecp256k1EcdsaSignature {
             public_key,

--- a/bindings/core/src/method_handler/utils.rs
+++ b/bindings/core/src/method_handler/utils.rs
@@ -94,9 +94,10 @@ pub(crate) fn call_utils_method_internal(method: UtilsMethod) -> Result<Response
             Response::Ok
         }
         UtilsMethod::VerifyEd25519Signature { signature, message } => {
+            use iota_sdk::types::block::Error;
             let signature = Ed25519Signature::try_from(signature)?;
             let message: Vec<u8> = prefix_hex::decode(message)?;
-            Response::Bool(signature.verify(&message))
+            Response::Bool(signature.verify(&message).map_err(Error::from)?)
         }
         UtilsMethod::VerifySecp256k1EcdsaSignature {
             public_key,

--- a/bindings/core/src/method_handler/utils.rs
+++ b/bindings/core/src/method_handler/utils.rs
@@ -14,7 +14,7 @@ use iota_sdk::{
             output::{AliasId, FoundryId, InputsCommitment, NftId, Output, OutputId, Rent, TokenId},
             payload::{transaction::TransactionEssence, MilestonePayload, TransactionPayload},
             signature::Ed25519Signature,
-            Block,
+            Block, Error,
         },
         TryFromDto,
     },
@@ -94,7 +94,6 @@ pub(crate) fn call_utils_method_internal(method: UtilsMethod) -> Result<Response
             Response::Ok
         }
         UtilsMethod::VerifyEd25519Signature { signature, message } => {
-            use iota_sdk::types::block::Error;
             let signature = Ed25519Signature::try_from(signature)?;
             let message: Vec<u8> = prefix_hex::decode(message)?;
             Response::Bool(signature.try_verify(&message).map_err(Error::from)?)
@@ -105,7 +104,6 @@ pub(crate) fn call_utils_method_internal(method: UtilsMethod) -> Result<Response
             message,
         } => {
             use crypto::signatures::secp256k1_ecdsa;
-            use iota_sdk::types::block::Error;
             let public_key = prefix_hex::decode(public_key)?;
             let public_key = secp256k1_ecdsa::PublicKey::try_from_bytes(&public_key).map_err(Error::from)?;
             let signature = prefix_hex::decode(signature)?;

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 1.1.4 - 2024-MM-DD
+
+### Added
+
+- `Ed25519Signature` methods `new_from_bytes`, `public_key_bytes`, `from_bytes`, `try_verify`;
+
+### Changed
+
+- Deprecated `Ed25519Signature` methods `public_key`, `try_from_bytes`, `verify`;
+
+### Fixed
+
+- `Ed25519Signature` type no longer requires validated public key bytes to construct;
+
 ## 1.1.3 - 2023-12-07
 
 ### Added

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Ed25519Signature` methods `new_from_bytes`, `public_key_bytes`, `from_bytes`, `try_verify`;
 
-### Changed
+### Deprecated
 
-- Deprecated `Ed25519Signature` methods `public_key`, `try_from_bytes`, `verify`;
+- `Ed25519Signature` methods `public_key`, `try_from_bytes`, `verify`;
 
 ### Fixed
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -34,7 +34,7 @@ hashbrown = { version = "0.14.3", default-features = false, features = [
     "inline-more",
 ] }
 hex = { version = "0.4.3", default-features = false }
-iota-crypto = { version = "0.23.0", default-features = false, features = [
+iota-crypto = { version = "0.23.1", default-features = false, features = [
     "blake2b",
     "ed25519",
     "secp256k1",

--- a/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
+++ b/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! In this example we will sign with Ed25519.
@@ -53,12 +53,13 @@ async fn main() -> Result<()> {
         .await?;
     println!(
         "Public key: {}\nSignature: {}",
-        prefix_hex::encode(signature.public_key()),
+        prefix_hex::encode(signature.public_key_bytes().as_ref()),
         prefix_hex::encode(signature.signature().to_bytes()),
     );
 
     // Hash the public key to get the address
-    let bech32_address = hex_public_key_to_bech32_address(&prefix_hex::encode(signature.public_key()), "rms")?;
+    let bech32_address =
+        hex_public_key_to_bech32_address(&prefix_hex::encode(signature.public_key_bytes().as_ref()), "rms")?;
     println!("Address: {bech32_address}");
 
     Ok(())

--- a/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
+++ b/sdk/examples/how_tos/sign_and_verify_ed25519/sign_ed25519.rs
@@ -53,12 +53,12 @@ async fn main() -> Result<()> {
         .await?;
     println!(
         "Public key: {}\nSignature: {}",
-        prefix_hex::encode(signature.public_key().as_ref()),
+        prefix_hex::encode(signature.public_key()),
         prefix_hex::encode(signature.signature().to_bytes()),
     );
 
     // Hash the public key to get the address
-    let bech32_address = hex_public_key_to_bech32_address(&prefix_hex::encode(signature.public_key().as_ref()), "rms")?;
+    let bech32_address = hex_public_key_to_bech32_address(&prefix_hex::encode(signature.public_key()), "rms")?;
     println!("Address: {bech32_address}");
 
     Ok(())

--- a/sdk/src/types/block/payload/milestone/mod.rs
+++ b/sdk/src/types/block/payload/milestone/mod.rs
@@ -126,7 +126,10 @@ impl MilestonePayload {
                 )));
             }
 
-            if !signature.verify(&essence_hash) {
+            if !signature
+                .verify(&essence_hash)
+                .map_err(|e| MilestoneValidationError::Crypto(e))?
+            {
                 return Err(MilestoneValidationError::InvalidSignature(
                     index,
                     prefix_hex::encode(signature.public_key().as_ref()),

--- a/sdk/src/types/block/payload/milestone/mod.rs
+++ b/sdk/src/types/block/payload/milestone/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module describing the milestone payload.
@@ -120,19 +120,19 @@ impl MilestonePayload {
         for (index, signature) in self.signatures().iter().enumerate() {
             let Signature::Ed25519(signature) = signature;
 
-            if !applicable_public_keys.contains(&hex::encode(signature.public_key())) {
+            if !applicable_public_keys.contains(&hex::encode(signature.public_key_bytes())) {
                 return Err(MilestoneValidationError::UnapplicablePublicKey(prefix_hex::encode(
-                    signature.public_key().as_ref(),
+                    signature.public_key_bytes().as_ref(),
                 )));
             }
 
             if !signature
-                .verify(&essence_hash)
+                .try_verify(&essence_hash)
                 .map_err(|e| MilestoneValidationError::Crypto(e))?
             {
                 return Err(MilestoneValidationError::InvalidSignature(
                     index,
-                    prefix_hex::encode(signature.public_key().as_ref()),
+                    prefix_hex::encode(signature.public_key_bytes().as_ref()),
                 ));
             }
         }
@@ -145,7 +145,7 @@ fn verify_signatures<const VERIFY: bool>(signatures: &[Signature]) -> Result<(),
     if VERIFY
         && !is_unique_sorted(signatures.iter().map(|signature| {
             let Signature::Ed25519(signature) = signature;
-            signature.public_key()
+            signature.public_key_bytes()
         }))
     {
         Err(Error::MilestoneSignaturesNotUniqueSorted)

--- a/sdk/src/types/block/payload/milestone/mod.rs
+++ b/sdk/src/types/block/payload/milestone/mod.rs
@@ -128,7 +128,7 @@ impl MilestonePayload {
 
             if !signature
                 .try_verify(&essence_hash)
-                .map_err(|e| MilestoneValidationError::Crypto(e))?
+                .map_err(MilestoneValidationError::Crypto)?
             {
                 return Err(MilestoneValidationError::InvalidSignature(
                     index,

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -67,7 +67,7 @@ impl Ed25519Signature {
         panic!("deprecated method: use Ed25519Signature::public_key_bytes instead")
     }
 
-    /// Returns the public key of an [`Ed25519Signature`].
+    /// Returns the unvalidated public key bytes of an [`Ed25519Signature`].
     pub fn public_key_bytes(&self) -> &PublicKeyBytes {
         &self.public_key
     }

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -85,7 +85,7 @@ impl Ed25519Signature {
 
     /// Verify a message using the signature.
     pub fn try_verify(&self, message: &[u8]) -> Result<bool, crypto::Error> {
-        Ok(self.public_key.verify(&self.signature, message)?)
+        self.public_key.verify(&self.signature, message)
     }
 
     /// Verifies the [`Ed25519Signature`] for a message against an [`Ed25519Address`].

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 /// The module with the AccountBuilder.

--- a/sdk/src/wallet/account/mod.rs
+++ b/sdk/src/wallet/account/mod.rs
@@ -651,7 +651,7 @@ mod test {
 
         let pub_key_bytes = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
         let sig_bytes = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-        let signature = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+        let signature = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
         let sig_unlock = Unlock::Signature(SignatureUnlock::from(Signature::from(signature)));
         let ref_unlock = Unlock::Reference(ReferenceUnlock::new(0).unwrap());
         let unlocks = Unlocks::new([sig_unlock, ref_unlock]).unwrap();

--- a/sdk/tests/types/ed25519_signature.rs
+++ b/sdk/tests/types/ed25519_signature.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::types::block::signature::Ed25519Signature;

--- a/sdk/tests/types/ed25519_signature.rs
+++ b/sdk/tests/types/ed25519_signature.rs
@@ -17,7 +17,7 @@ fn kind() {
 fn packed_len() {
     let pub_key_bytes: [u8; 32] = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes: [u8; 64] = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let sig = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let sig = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
 
     assert_eq!(sig.packed_len(), 32 + 64);
     assert_eq!(sig.pack_to_vec().len(), 32 + 64);
@@ -27,7 +27,7 @@ fn packed_len() {
 fn pack_unpack_valid() {
     let pub_key_bytes: [u8; 32] = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes: [u8; 64] = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let sig = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let sig = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
     let sig_packed = sig.pack_to_vec();
 
     assert_eq!(sig, PackableExt::unpack_verified(sig_packed.as_slice(), &()).unwrap());

--- a/sdk/tests/types/payload.rs
+++ b/sdk/tests/types/payload.rs
@@ -56,7 +56,7 @@ fn transaction() {
 
     let pub_key_bytes = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let signature = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let signature = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
     let sig_unlock = Unlock::Signature(SignatureUnlock::from(Signature::from(signature)));
     let ref_unlock = Unlock::Reference(ReferenceUnlock::new(0).unwrap());
     let unlocks = Unlocks::new(vec![sig_unlock, ref_unlock]).unwrap();
@@ -93,9 +93,7 @@ fn milestone() {
             MilestoneOptions::from_vec(vec![]).unwrap(),
         )
         .unwrap(),
-        vec![Signature::from(
-            Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap(),
-        )],
+        vec![Signature::from(Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes))],
     )
     .unwrap()
     .into();

--- a/sdk/tests/types/payload.rs
+++ b/sdk/tests/types/payload.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use core::str::FromStr;

--- a/sdk/tests/types/transaction_payload.rs
+++ b/sdk/tests/types/transaction_payload.rs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 IOTA Stiftung
+// Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::types::block::{

--- a/sdk/tests/types/transaction_payload.rs
+++ b/sdk/tests/types/transaction_payload.rs
@@ -53,7 +53,7 @@ fn builder_no_essence_too_few_unlocks() {
     // Construct a list with a single unlock, whereas we have 2 tx inputs.
     let pub_key_bytes = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let signature = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let signature = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
     let sig_unlock = Unlock::Signature(SignatureUnlock::from(Signature::from(signature)));
     let unlocks = Unlocks::new([sig_unlock]).unwrap();
 
@@ -90,7 +90,7 @@ fn builder_no_essence_too_many_unlocks() {
     // Construct a list of two unlocks, whereas we only have 1 tx input.
     let pub_key_bytes = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let signature = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let signature = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
     let sig_unlock = Unlock::Signature(SignatureUnlock::from(Signature::from(signature)));
     let ref_unlock = Unlock::Reference(ReferenceUnlock::new(0).unwrap());
 
@@ -130,7 +130,7 @@ fn pack_unpack_valid() {
     // Construct a list of two unlocks, whereas we only have 1 tx input.
     let pub_key_bytes = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let signature = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let signature = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
     let sig_unlock = Unlock::Signature(SignatureUnlock::from(Signature::from(signature)));
     let ref_unlock = Unlock::Reference(ReferenceUnlock::new(0).unwrap());
     let unlocks = Unlocks::new([sig_unlock, ref_unlock]).unwrap();
@@ -172,7 +172,7 @@ fn getters() {
     // Construct a list of two unlocks, whereas we only have 1 tx input.
     let pub_key_bytes = prefix_hex::decode(ED25519_PUBLIC_KEY).unwrap();
     let sig_bytes = prefix_hex::decode(ED25519_SIGNATURE).unwrap();
-    let signature = Ed25519Signature::try_from_bytes(pub_key_bytes, sig_bytes).unwrap();
+    let signature = Ed25519Signature::from_bytes(pub_key_bytes, sig_bytes);
     let sig_unlock = Unlock::Signature(SignatureUnlock::from(Signature::from(signature)));
     let ref_unlock = Unlock::Reference(ReferenceUnlock::new(0).unwrap());
     let unlocks = Unlocks::new([sig_unlock, ref_unlock]).unwrap();


### PR DESCRIPTION
# Description of change

Looks like using the `PublicKey` type here was a mistake, as the validation is not intended to be at the syntactic level. Unfortunately this is a breaking change, and there's no way to avoid that.

## Links to any relevant issues

https://github.com/iotaledger/inx-chronicle/issues/1308

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
