### PR TITLE
Add issuing_time check

### DIFF
--- a/sdk/src/client/api/block_builder/mod.rs
+++ b/sdk/src/client/api/block_builder/mod.rs
@@ -6,7 +6,7 @@ pub mod transaction;
 
 pub use self::transaction::verify_semantic;
 use crate::{
-    client::{ClientInner, Result},
+    client::{constants::FIVE_MINUTES_IN_NANOSECONDS, ClientInner, Error, Result},
     types::block::{
         core::{BlockHeader, UnsignedBlock},
         output::AccountId,
@@ -19,7 +19,6 @@ impl ClientInner {
     pub async fn build_basic_block(&self, issuer_id: AccountId, payload: Option<Payload>) -> Result<UnsignedBlock> {
         let issuance = self.get_issuance().await?;
 
-        // TODO https://github.com/iotaledger/iota-sdk/issues/1753
         let issuing_time = {
             #[cfg(feature = "std")]
             let issuing_time = std::time::SystemTime::now()
@@ -30,7 +29,20 @@ impl ClientInner {
             // https://github.com/iotaledger/iota-sdk/issues/647
             #[cfg(not(feature = "std"))]
             let issuing_time = 0;
-            issuing_time
+
+            // Check that the issuing_time is in the range of +-5 minutes of the node to prevent potential issues
+            if !(issuance.latest_parent_block_issuing_time - FIVE_MINUTES_IN_NANOSECONDS
+                ..issuance.latest_parent_block_issuing_time + FIVE_MINUTES_IN_NANOSECONDS)
+                .contains(&issuing_time)
+            {
+                return Err(Error::TimeNotSynced {
+                    current_time: issuing_time,
+                    tangle_time: issuance.latest_parent_block_issuing_time,
+                });
+            }
+            // If timestamp is below latest_parent_block_issuing_time, just increase it to that +1 so the block doesn't
+            // get rejected
+            issuing_time.max(issuance.latest_parent_block_issuing_time + 1)
         };
 
         let protocol_params = self.get_protocol_parameters().await?;


### PR DESCRIPTION
# Description of change

Add issuing_time check to prevent issues with wrong local times and make sure to have issuing_time >= latest_parent_block_issuing_time +1 to prevent rejection because of a lower timestamp

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-sdk/issues/1753

## Type of change

- Enhancement (a non-breaking change which adds functionality)