### PR TITLE
feat(2.0 nodejs) Add `clearStrongholdPassword` to  `SecretManager`

### DIFF
--- a/bindings/core/src/method/secret_manager.rs
+++ b/bindings/core/src/method/secret_manager.rs
@@ -87,6 +87,14 @@ pub enum SecretManagerMethod {
         #[derivative(Debug(format_with = "OmittedDebug::omitted_fmt"))]
         password: String,
     },
+    /// Change the stronghold password.
+    /// Expected response: [`Ok`](crate::Response::Ok)
+    #[cfg(feature = "stronghold")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
+    ChangeStrongholdPassword {
+        #[derivative(Debug(format_with = "OmittedDebug::omitted_fmt"))]
+        password: String,
+    },
 }
 
 #[cfg(test)]

--- a/bindings/core/src/method/secret_manager.rs
+++ b/bindings/core/src/method/secret_manager.rs
@@ -95,6 +95,11 @@ pub enum SecretManagerMethod {
         #[derivative(Debug(format_with = "OmittedDebug::omitted_fmt"))]
         password: String,
     },
+    /// Clear the stronghold password.
+    /// Expected response: [`Ok`](crate::Response::Ok)
+    #[cfg(feature = "stronghold")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "stronghold")))]
+    ClearStrongholdPassword
 }
 
 #[cfg(test)]

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -159,6 +159,18 @@ where
             stronghold.change_password(password).await?;
             Response::Ok
         }
+        #[cfg(feature = "stronghold")]
+        SecretManagerMethod::ClearStrongholdPassword => {
+            let stronghold = if let Some(secret_manager) = secret_manager.downcast::<StrongholdSecretManager>() {
+                secret_manager
+            } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
+                secret_manager
+            } else {
+                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+            };
+            stronghold.clear_key().await;
+            Response::Ok
+        }
     };
     Ok(response)
 }

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -147,6 +147,18 @@ where
             stronghold.set_password(password).await?;
             Response::Ok
         }
+        #[cfg(feature = "stronghold")]
+        SecretManagerMethod::ChangeStrongholdPassword { password } => {
+            let stronghold = if let Some(secret_manager) = secret_manager.downcast::<StrongholdSecretManager>() {
+                secret_manager
+            } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
+                secret_manager
+            } else {
+                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+            };
+            stronghold.change_password(password).await?;
+            Response::Ok
+        }
     };
     Ok(response)
 }

--- a/bindings/nodejs/lib/secret_manager/secret-manager.ts
+++ b/bindings/nodejs/lib/secret_manager/secret-manager.ts
@@ -236,4 +236,13 @@ export class SecretManager {
             data: { password },
         });
     }
+
+    /**
+     * Clear the Stronghold password.
+     */
+    async clearStrongholdPassword(): Promise<void> {
+        await this.methodHandler.callMethod({
+            name: 'clearStrongholdPassword',
+        });
+    }
 }

--- a/bindings/nodejs/lib/secret_manager/secret-manager.ts
+++ b/bindings/nodejs/lib/secret_manager/secret-manager.ts
@@ -226,4 +226,14 @@ export class SecretManager {
             data: { password },
         });
     }
+
+    /**
+     * Change the Stronghold password.
+     */
+    async changeStrongholdPassword(password: string): Promise<void> {
+        await this.methodHandler.callMethod({
+            name: 'changeStrongholdPassword',
+            data: { password },
+        });
+    }
 }

--- a/bindings/nodejs/lib/types/secret_manager/bridge/index.ts
+++ b/bindings/nodejs/lib/types/secret_manager/bridge/index.ts
@@ -9,6 +9,7 @@ import type {
     __SignEd25519Method__,
     __SignSecp256k1EcdsaMethod__,
     __SetStrongholdPasswordMethod__,
+    __ChangeStrongholdPasswordMethod__,
 } from './secret-manager';
 
 export type __SecretManagerMethods__ =
@@ -21,4 +22,5 @@ export type __SecretManagerMethods__ =
     | __StoreMnemonicMethod__
     | __SignEd25519Method__
     | __SignSecp256k1EcdsaMethod__
-    | __SetStrongholdPasswordMethod__;
+    | __SetStrongholdPasswordMethod__
+    | __ChangeStrongholdPasswordMethod__;

--- a/bindings/nodejs/lib/types/secret_manager/bridge/index.ts
+++ b/bindings/nodejs/lib/types/secret_manager/bridge/index.ts
@@ -10,6 +10,7 @@ import type {
     __SignSecp256k1EcdsaMethod__,
     __SetStrongholdPasswordMethod__,
     __ChangeStrongholdPasswordMethod__,
+    __ClearStrongholdPasswordMethod__,
 } from './secret-manager';
 
 export type __SecretManagerMethods__ =
@@ -23,4 +24,5 @@ export type __SecretManagerMethods__ =
     | __SignEd25519Method__
     | __SignSecp256k1EcdsaMethod__
     | __SetStrongholdPasswordMethod__
-    | __ChangeStrongholdPasswordMethod__;
+    | __ChangeStrongholdPasswordMethod__
+    | __ClearStrongholdPasswordMethod__;

--- a/bindings/nodejs/lib/types/secret_manager/bridge/secret-manager.ts
+++ b/bindings/nodejs/lib/types/secret_manager/bridge/secret-manager.ts
@@ -80,3 +80,7 @@ export interface __ChangeStrongholdPasswordMethod__ {
     name: 'changeStrongholdPassword';
     data: { password: string };
 }
+
+export interface __ClearStrongholdPasswordMethod__ {
+    name: 'clearStrongholdPassword';
+}

--- a/bindings/nodejs/lib/types/secret_manager/bridge/secret-manager.ts
+++ b/bindings/nodejs/lib/types/secret_manager/bridge/secret-manager.ts
@@ -75,3 +75,8 @@ export interface __SetStrongholdPasswordMethod__ {
     name: 'setStrongholdPassword';
     data: { password: string };
 }
+
+export interface __ChangeStrongholdPasswordMethod__ {
+    name: 'changeStrongholdPassword';
+    data: { password: string };
+}


### PR DESCRIPTION
Depends on https://github.com/iotaledger/iota-sdk/pull/1829

# Description of change

Enables support for `clearStrongholdPassword` in Nodejs's `SecretManager`

## Type of change

- Enhancement

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
