### PR TITLE
Nodejs: fix ImplicitAccountCreationAddress address constructor

### DIFF
--- a/bindings/nodejs/lib/types/block/address.ts
+++ b/bindings/nodejs/lib/types/block/address.ts
@@ -91,11 +91,11 @@ class Ed25519Address extends Address {
     readonly pubKeyHash: HexEncodedString;
 
     /**
-     * @param address An Ed25519 address as hex-encoded string.
+     * @param pubKeyHash BLAKE2b-256 hash of an Ed25519 public key as hex-encoded string.
      */
-    constructor(address: HexEncodedString) {
+    constructor(pubKeyHash: HexEncodedString) {
         super(AddressType.Ed25519);
-        this.pubKeyHash = address;
+        this.pubKeyHash = pubKeyHash;
     }
 
     toString(): string {
@@ -172,11 +172,11 @@ class AnchorAddress extends Address {
 class ImplicitAccountCreationAddress extends Address {
     private pubKeyHash: HexEncodedString;
     /**
-     * @param address An Ed25519 address.
+     * @param pubKeyHash BLAKE2b-256 hash of an Ed25519 public key as hex-encoded string.
      */
-    constructor(address: Ed25519Address) {
+    constructor(pubKeyHash: HexEncodedString) {
         super(AddressType.ImplicitAccountCreation);
-        this.pubKeyHash = address.pubKeyHash;
+        this.pubKeyHash = pubKeyHash;
     }
 
     address(): Ed25519Address {


### PR DESCRIPTION
# Description of change

Fix ImplicitAccountCreationAddress address constructor

## Links to any relevant issues

Fixes #1843 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running an example that lists implicit account creation outputs
