### PR TITLE
Split Python CI

### DIFF
--- a/.github/workflows/bindings-python.yml
+++ b/.github/workflows/bindings-python.yml
@@ -39,13 +39,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  format:
     name: Python PEP8 format
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
+
+    steps:
+      - name: Checkout the Source Code
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }} and Pip Cache
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: bindings/python/requirements-dev.txt
+
+      - name: Install Dependencies for Python Binding Format
+        run: |
+          python3 -m pip install --upgrade setuptools pip wheel
+          python3 -m pip install tox-gh-actions
+
+      - name: Run tox format check
+        working-directory: bindings/python
+        run: tox -e format
+
+  lint:
+    name: Python lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
 
     steps:
       - name: Checkout the Source Code
@@ -63,14 +91,25 @@ jobs:
           python3 -m pip install --upgrade setuptools pip wheel
           python3 -m pip install tox-gh-actions
 
-      - name: Run tox format check
-        working-directory: bindings/python
-        run: tox -e format
+      - name: Install required packages (Ubuntu)
+        run: |
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
 
+      - name: Run linter for iota_sdk
+        working-directory: bindings/python
+        run: tox -e lint-sdk
+
+      - name: Run linter for examples
+        working-directory: bindings/python
+        run: tox -e lint-examples
+
+      - name: Run linter for tests
+        working-directory: bindings/python
+        run: tox -e lint-tests
 
   test:
-    name: Linter & Tests
-    needs: lint
+    name: Tests
+    needs: format
     if: ${{ ! github.event.schedule }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -78,7 +117,7 @@ jobs:
       matrix:
         # os: [windows-latest, macos-latest, ubuntu-latest]
         os: [windows-latest, ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout the Source Code
@@ -111,21 +150,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
-
-      - name: Run linter for iota_sdk
-        if: ${{ startsWith(matrix.os, 'ubuntu-latest') }}
-        working-directory: bindings/python
-        run: tox -e lint-sdk
-
-      - name: Run linter for examples
-        if: ${{ startsWith(matrix.os, 'ubuntu-latest') }}
-        working-directory: bindings/python
-        run: tox -e lint-examples
-
-      - name: Run linter for tests
-        if: ${{ startsWith(matrix.os, 'ubuntu-latest') }}
-        working-directory: bindings/python
-        run: tox -e lint-tests
 
       - name: Run tests
         working-directory: bindings/python

--- a/bindings/python/tox.ini
+++ b/bindings/python/tox.ini
@@ -29,7 +29,6 @@ deps =
     -r requirements-dev.txt
     pylint
 commands =
-    pip install .
     pylint --rcfile=.pylintrc iota_sdk/**/*.py
 
 [testenv:lint-examples]


### PR DESCRIPTION
# Description of change

Split Python CI so it's faster and cleaner

Unfortunately, the linting can only be faster for the main package (finishes in 25 seconds) and not for the examples and tests, as these require the installation of the package first. (I haven't found a clean way to install it without compiling)

## Links to any relevant issues

Closes #1779 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

CI