### PR TITLE
Use `try_from_dto` instead of `try_from_dto_with_params`

### DIFF
--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -214,10 +214,7 @@ impl ClientInner {
 
         let dto = self.get_request::<BlockDto>(path, None, false, true).await?;
 
-        Ok(Block::try_from_dto_with_params(
-            dto,
-            self.get_protocol_parameters().await?,
-        )?)
+        Ok(Block::try_from_dto(dto)?)
     }
 
     /// Finds a block by its BlockId. This method returns the given block raw data.
@@ -303,10 +300,7 @@ impl ClientInner {
 
         let dto = self.get_request::<BlockDto>(path, None, true, true).await?;
 
-        Ok(Block::try_from_dto_with_params(
-            dto,
-            self.get_protocol_parameters().await?,
-        )?)
+        Ok(Block::try_from_dto(dto)?)
     }
 
     /// Returns the block, as raw bytes, that was included in the ledger for a given TransactionId.
@@ -334,10 +328,7 @@ impl ClientInner {
 
         let dto = self.get_request::<MilestonePayloadDto>(path, None, false, true).await?;
 
-        Ok(MilestonePayload::try_from_dto_with_params(
-            dto,
-            self.get_protocol_parameters().await?,
-        )?)
+        Ok(MilestonePayload::try_from_dto(dto)?)
     }
 
     /// Gets the milestone by the given milestone id.
@@ -363,10 +354,7 @@ impl ClientInner {
 
         let dto = self.get_request::<MilestonePayloadDto>(path, None, false, true).await?;
 
-        Ok(MilestonePayload::try_from_dto_with_params(
-            dto,
-            self.get_protocol_parameters().await?,
-        )?)
+        Ok(MilestonePayload::try_from_dto(dto)?)
     }
 
     /// Gets the milestone by the given milestone index.


### PR DESCRIPTION
# Description of change

As @Thoralf-M suggested we can just use `Block::try_from_dto` instead of `Block::try_from_dto_with_params` because if the block doesn't belong to that network (that the user provided protocol parameters for) then it will return a "not found" error anyway, so we can make the life easier for the user by not having to provide correct protocol parameters for the network he/she intends to query a block for.

CURRENTLY IN DISCUSSION with @msarcev 

## Links to any relevant issues

Closes #1808 
