### PR TITLE
chore: Use GitHub PAT to publish bindings

### DIFF
--- a/.github/workflows/bindings-nodejs-publish.yml
+++ b/.github/workflows/bindings-nodejs-publish.yml
@@ -253,7 +253,8 @@ jobs:
       - name: Upload prebuild to Github release
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Token expires Jan 25, 2025
+          token: ${{ secrets.GH_RELEASE_PUBLISH_PAT }}
           body: https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md
           files: bindings/nodejs/prebuilds/@iota/*
           tag_name: ${{ steps.prepare_release.outputs.tag_name }}

--- a/.github/workflows/bindings-python-publish.yml
+++ b/.github/workflows/bindings-python-publish.yml
@@ -161,7 +161,8 @@ jobs:
       - name: Upload Wheels to Github release
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Token expires Jan 25, 2025
+          token: ${{ secrets.GH_RELEASE_PUBLISH_PAT }}
           body: https://github.com/iotaledger/iota-sdk/blob/develop/bindings/python/CHANGELOG.md
           files: wheels/*
           tag_name: ${{ steps.tagname.outputs.TAG_NAME }}

--- a/.github/workflows/bindings-wasm-publish.yml
+++ b/.github/workflows/bindings-wasm-publish.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Upload package to Github release
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Token expires Jan 25, 2025
+          token: ${{ secrets.GH_RELEASE_PUBLISH_PAT }}
           body: "https://github.com/iotaledger/iota-sdk/blob/develop/bindings/wasm/CHANGELOG.md \n https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md"
           files: bindings/wasm/*.tgz
           tag_name: ${{ steps.prepare_release.outputs.tag_name }}


### PR DESCRIPTION
# Description of change

As @Dr-Electron mentioned in Slack, the it seems that the reason the "Build and upload API docs" workflow isn't triggered by a new the SDK bindings release is because the publisher is GitHub Actions under the default `GITHUB_TOKEN`. 
From the [docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):
> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur. For more information, see "[Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)."


Publishing a release of the CLI wallet, however, triggers the docs workflow because the release is originally created by `GITHUB_TOKEN` as a draft and then published by a human. To make this work for the SDK bindings, we need to make it look like a human published the release. We created a PAT under the `iota-ci` account in order to do this. This PAT expires in 1 year (Jan 25, 2025).

## Links to any relevant issues

N/A

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Chore

## How the change has been tested

Has not been tested yet

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas