### PR TITLE
Fix error serialization and use strum for variant names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "strum",
  "thiserror",
  "time",
  "tokio",
@@ -1669,6 +1670,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_json",
+ "strum",
  "thiserror",
  "tokio",
  "url",
@@ -2774,6 +2776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "rustyline"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3140,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "subtle"

--- a/bindings/core/Cargo.toml
+++ b/bindings/core/Cargo.toml
@@ -28,6 +28,7 @@ prefix-hex = { version = "0.7.1", default-features = false }
 primitive-types = { version = "0.12.2", default-features = false }
 serde = { version = "1.0.195", default-features = false }
 serde_json = { version = "1.0.111", default-features = false }
+strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.56", default-features = false }
 tokio = { version = "1.35.1", default-features = false }
 url = { version = "2.4.1", default-features = false, features = ["serde"] }

--- a/bindings/core/src/error.rs
+++ b/bindings/core/src/error.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use packable::error::UnexpectedEOF;
-use serde::{ser::SerializeMap, Serialize, Serializer};
+use serde::{Serialize, Serializer};
 
 /// Result type of the bindings core crate.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Error type for the bindings core crate.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, strum::AsRefStr)]
+#[strum(serialize_all = "camelCase")]
 #[non_exhaustive]
 pub enum Error {
     /// Block errors.
@@ -51,23 +52,22 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_map(Some(2))?;
-        let mut kind_dbg = format!("{self:?}");
-        // Convert first char to lowercase
-        if let Some(r) = kind_dbg.get_mut(0..1) {
-            r.make_ascii_lowercase();
+        #[derive(Serialize)]
+        struct ErrorDto {
+            #[serde(rename = "type")]
+            kind: String,
+            error: serde_json::Value,
         }
-        // Split by whitespace for struct variants and split by `(` for tuple variants
-        // Safe to unwrap because kind_dbg is never an empty string
-        let kind = kind_dbg.split([' ', '(']).next().unwrap();
-        seq.serialize_entry("type", &kind)?;
-        let value: serde_json::Value = match &self {
-            // Only Client and wallet have a proper serde impl
-            Self::Client(e) => serde_json::from_str(&serde_json::to_string(&e).expect("json to string error")).unwrap(),
-            Self::Wallet(e) => serde_json::from_str(&serde_json::to_string(&e).expect("json to string error")).unwrap(),
-            _ => self.to_string().into()
-        };
-        seq.serialize_entry("error", &value)?;
-        seq.end()
+
+        ErrorDto {
+            kind: self.as_ref().to_owned(),
+            error: match &self {
+                // Only Client and wallet have a proper serde impl
+                Self::Client(e) => serde_json::to_value(e).map_err(|e| serde::ser::Error::custom(e))?,
+                Self::Wallet(e) => serde_json::to_value(e).map_err(|e| serde::ser::Error::custom(e))?,
+                _ => serde_json::Value::String(self.to_string()),
+            },
+        }
+        .serialize(serializer)
     }
 }

--- a/bindings/core/tests/serialize_error.rs
+++ b/bindings/core/tests/serialize_error.rs
@@ -14,15 +14,27 @@ fn custom_error_serialization() {
     // testing a unit-type-like error
     let error = Error::Client(ClientError::HealthyNodePoolEmpty);
     assert_eq!(
-        serde_json::to_string(&error).unwrap(),
-        "{\"type\":\"client\",\"error\":\"no healthy node available\"}"
+        serde_json::to_value(&error).unwrap(),
+        serde_json::json!({
+            "type": "client",
+            "error": {
+                "type": "healthyNodePoolEmpty",
+                "error": "no healthy node available"
+            }
+        })
     );
 
     // testing a tuple-like error
     let error = Error::Wallet(WalletError::InvalidMnemonic("nilly willy".to_string()));
     assert_eq!(
-        serde_json::to_string(&error).unwrap(),
-        "{\"type\":\"wallet\",\"error\":\"invalid mnemonic: nilly willy\"}"
+        serde_json::to_value(&error).unwrap(),
+        serde_json::json!({
+            "type": "wallet",
+            "error": {
+                "type": "invalidMnemonic",
+                "error": "invalid mnemonic: nilly willy"
+            }
+        })
     );
 
     // testing a struct-like error
@@ -31,7 +43,13 @@ fn custom_error_serialization() {
         new_bip_path: Some(Bip44::new(SHIMMER_COIN_TYPE)),
     });
     assert_eq!(
-        serde_json::to_string(&error).unwrap(),
-        "{\"type\":\"wallet\",\"error\":\"BIP44 mismatch: Some(Bip44 { coin_type: 4219, account: 0, change: 0, address_index: 0 }), existing bip path is: None\"}"
+        serde_json::to_value(&error).unwrap(),
+        serde_json::json!({
+            "type": "wallet",
+            "error": {
+                "type": "bipPathMismatch",
+                "error": "BIP44 mismatch: Some(Bip44 { coin_type: 4219, account: 0, change: 0, address_index: 0 }), existing bip path is: None"
+            }
+        })
     );
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -58,6 +58,7 @@ serde = { version = "1.0.195", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.111", default-features = false, features = [
     "alloc",
 ] }
+strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 
 # Optional dependencies
 anymap = { version = "0.12.1", default-features = false, optional = true }
@@ -168,6 +169,7 @@ std = [
     "primitive-types/std",
     "bech32/std",
     "bitflags/std",
+    "strum/std",
     "rand?/std_rng",
     "regex?/std",
     "iota_stronghold?/std",

--- a/sdk/src/wallet/error.rs
+++ b/sdk/src/wallet/error.rs
@@ -4,15 +4,13 @@
 use std::fmt::Debug;
 
 use crypto::keys::bip44::Bip44;
-use serde::{
-    ser::{SerializeMap, Serializer},
-    Serialize,
-};
+use serde::{ser::Serializer, Serialize};
 
 use crate::types::block::{address::Bech32Address, payload::signed_transaction::TransactionId};
 
 /// The wallet error type.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, strum::AsRefStr)]
+#[strum(serialize_all = "camelCase")]
 #[non_exhaustive]
 pub enum Error {
     /// Errors during backup creation or restoring
@@ -141,18 +139,18 @@ impl Serialize for Error {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_map(Some(2))?;
-        let mut kind_dbg = format!("{self:?}");
-        // Convert first char to lowercase
-        if let Some(r) = kind_dbg.get_mut(0..1) {
-            r.make_ascii_lowercase();
+        #[derive(Serialize)]
+        struct ErrorDto {
+            #[serde(rename = "type")]
+            kind: String,
+            error: String,
         }
-        // Split by whitespace for struct variants and split by `(` for tuple variants
-        // Safe to unwrap because kind_dbg is never an empty string
-        let kind = kind_dbg.split([' ', '(']).next().unwrap();
-        seq.serialize_entry("type", &kind)?;
-        seq.serialize_entry("error", &self.to_string())?;
-        seq.end()
+
+        ErrorDto {
+            kind: self.as_ref().to_owned(),
+            error: self.to_string(),
+        }
+        .serialize(serializer)
     }
 }
 


### PR DESCRIPTION
# Description of change

Fixes the serialization of the error enums and the test. Uses `strum` for deriving string variant names.
