### PR TITLE
Remove ChangeAddress RemainderValueStrategy from bindings

### DIFF
--- a/bindings/nodejs/lib/types/wallet/transaction-options.ts
+++ b/bindings/nodejs/lib/types/wallet/transaction-options.ts
@@ -30,20 +30,7 @@ export interface TransactionOptions {
 }
 
 /** The possible remainder value strategies. */
-export type RemainderValueStrategy =
-    | ChangeAddress
-    | ReuseAddress
-    | CustomAddress;
-
-/**
- * Allows to move the remainder value to a change address.
- */
-export type ChangeAddress = {
-    /** The name of the strategy. */
-    strategy: 'ChangeAddress';
-    /** Only required for `CustomAddress`. */
-    value: null;
-};
+export type RemainderValueStrategy = ReuseAddress | CustomAddress;
 
 /**
  * Allows to keep the remainder value on the source address.

--- a/bindings/python/iota_sdk/types/transaction_options.py
+++ b/bindings/python/iota_sdk/types/transaction_options.py
@@ -46,10 +46,8 @@ class RemainderValueStrategy(Enum):
     """Remainder value strategy variants.
 
     Attributes:
-        ChangeAddress: Allows to move the remainder value to a change address.
         ReuseAddress: Allows to keep the remainder value on the source address.
     """
-    ChangeAddress = None
     ReuseAddress = None
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
We removed it in Rust already, but didn't update the bindings
