### PR TITLE
Fix signing with implicit account creation and ed25519 addresses

### DIFF
--- a/sdk/src/client/secret/mod.rs
+++ b/sdk/src/client/secret/mod.rs
@@ -569,8 +569,8 @@ where
 
         // Convert restricted and implicit addresses to Ed25519 address, so they're the same entry in `block_indexes`.
         let required_address = match required_address {
-            Address::Restricted(restricted) => restricted.address().clone(),
             Address::ImplicitAccountCreation(implicit) => Address::Ed25519(*implicit.ed25519_address()),
+            Address::Restricted(restricted) => restricted.address().clone(),
             _ => required_address,
         };
 

--- a/sdk/src/client/secret/mod.rs
+++ b/sdk/src/client/secret/mod.rs
@@ -567,14 +567,15 @@ where
             .required_address(slot_index, protocol_parameters.committable_age_range())?
             .ok_or(crate::client::Error::ExpirationDeadzone)?;
 
-        let required_address = if let Address::Restricted(restricted) = &required_address {
-            restricted.address()
-        } else {
-            &required_address
+        // Convert restricted and implicit addresses to Ed25519 address, so they're the same entry in `block_indexes`.
+        let required_address = match required_address {
+            Address::Restricted(restricted) => restricted.address().clone(),
+            Address::ImplicitAccountCreation(implicit) => Address::Ed25519(*implicit.ed25519_address()),
+            _ => required_address,
         };
 
         // Check if we already added an [Unlock] for this address
-        match block_indexes.get(required_address) {
+        match block_indexes.get(&required_address) {
             // If we already have an [Unlock] for this address, add a [Unlock] based on the address type
             Some(block_index) => match required_address {
                 Address::Ed25519(_) | Address::ImplicitAccountCreation(_) => {


### PR DESCRIPTION
# Description of change

Fix signing with implicit account creation and ed25519 addresses, without this change it would add a second signature unlock with the same signature, which is not allowed.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Signed a tx with inputs that have both address types and the same backed Ed25519 address