### PR TITLE
Remove OutputData::is_spent and rely on OutputConsumptionMetadata only

### DIFF
--- a/bindings/nodejs/lib/types/wallet/output.ts
+++ b/bindings/nodejs/lib/types/wallet/output.ts
@@ -26,8 +26,6 @@ export class OutputData {
         discriminator: OutputDiscriminator,
     })
     output!: Output;
-    /** If an output is spent */
-    isSpent!: boolean;
     /** Associated account address */
     @Type(() => Address, {
         discriminator: AddressDiscriminator,

--- a/bindings/python/iota_sdk/types/output_data.py
+++ b/bindings/python/iota_sdk/types/output_data.py
@@ -20,7 +20,6 @@ class OutputData():
         output_id: With the output data corresponding output ID.
         metadata: With the output corresponding metadata.
         output: The output object itself.
-        is_spent: Whether the output is spent.
         address: The address associated with the output.
         network_id: The network ID the output belongs to.
         remainder: Whether the output represents a remainder amount.
@@ -29,7 +28,6 @@ class OutputData():
     output_id: HexStr
     metadata: OutputMetadata
     output: Output
-    is_spent: bool
     address: Address
     network_id: str
     remainder: bool

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -888,7 +888,7 @@ pub async fn send_nft_command(
     address: impl ConvertTo<Bech32Address>,
     nft_id: NftId,
 ) -> Result<(), Error> {
-    let outputs = [SendNftParams::new(address.convert()?, &nft_id)?];
+    let outputs = [SendNftParams::new(address.convert()?, nft_id)?];
     let transaction = wallet.send_nft(outputs, None).await?;
 
     println_log_info!(
@@ -1358,7 +1358,11 @@ fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), Error>
                 i,
                 &output_data.output_id,
                 kind_str,
-                if output_data.is_spent { "Spent" } else { "Unspent" },
+                if output_data.metadata.is_spent() {
+                    "Spent"
+                } else {
+                    "Unspent"
+                },
             );
         }
     }

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -1358,11 +1358,7 @@ fn print_outputs(mut outputs: Vec<OutputData>, title: &str) -> Result<(), Error>
                 i,
                 &output_data.output_id,
                 kind_str,
-                if output_data.metadata.is_spent() {
-                    "Spent"
-                } else {
-                    "Unspent"
-                },
+                if output_data.is_spent() { "Spent" } else { "Unspent" },
             );
         }
     }

--- a/sdk/src/types/block/output/metadata.rs
+++ b/sdk/src/types/block/output/metadata.rs
@@ -100,7 +100,7 @@ pub struct OutputMetadata {
     included: OutputInclusionMetadata,
     // Metadata of the output if it is marked as spent in the ledger.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
-    spent: Option<OutputConsumptionMetadata>,
+    pub(crate) spent: Option<OutputConsumptionMetadata>,
     /// Latest commitment ID of the node.
     latest_commitment_id: SlotCommitmentId,
 }

--- a/sdk/src/wallet/operations/participation/mod.rs
+++ b/sdk/src/wallet/operations/participation/mod.rs
@@ -96,7 +96,7 @@ where
     //                         entry.get_mut().push(output_data.output_id);
     //                     }
     //                 }
-    //                 if output_data.metadata.is_spent() {
+    //                 if output_data.is_spent() {
     //                     spent_outputs.insert(output_data.output_id);
     //                 }
     //             }

--- a/sdk/src/wallet/operations/participation/mod.rs
+++ b/sdk/src/wallet/operations/participation/mod.rs
@@ -96,7 +96,7 @@ where
     //                         entry.get_mut().push(output_data.output_id);
     //                     }
     //                 }
-    //                 if output_data.is_spent {
+    //                 if output_data.metadata.is_spent() {
     //                     spent_outputs.insert(output_data.output_id);
     //                 }
     //             }

--- a/sdk/src/wallet/operations/syncing/outputs.rs
+++ b/sdk/src/wallet/operations/syncing/outputs.rs
@@ -47,7 +47,6 @@ where
                     metadata: *output_with_meta.metadata(),
                     output: output_with_meta.output().clone(),
                     output_id_proof: output_with_meta.output_id_proof().clone(),
-                    is_spent: output_with_meta.metadata().is_spent(),
                     network_id,
                     remainder,
                 }
@@ -72,7 +71,8 @@ where
             match wallet_data.outputs.get_mut(&output_id) {
                 // set unspent
                 Some(output_data) => {
-                    output_data.is_spent = false;
+                    log::warn!("Removing spent output metadata for {output_id}, because it's still unspent");
+                    output_data.metadata.spent = None;
                     unspent_outputs.push((output_id, output_data.clone()));
                     outputs.push(OutputWithMetadata::new(
                         output_data.output.clone(),

--- a/sdk/src/wallet/operations/syncing/transactions.rs
+++ b/sdk/src/wallet/operations/syncing/transactions.rs
@@ -249,7 +249,7 @@ fn process_transaction_with_unknown_state(
     for input in transaction.payload.transaction().inputs() {
         let Input::Utxo(input) = input;
         if let Some(output_data) = wallet_data.outputs.get(input.output_id()) {
-            if !output_data.metadata.is_spent() {
+            if !output_data.is_spent() {
                 // unspent output needs to be made available again
                 output_ids_to_unlock.push(*input.output_id());
                 all_inputs_spent = false;

--- a/sdk/src/wallet/operations/syncing/transactions.rs
+++ b/sdk/src/wallet/operations/syncing/transactions.rs
@@ -92,7 +92,7 @@ where
             for input in transaction.payload.transaction().inputs() {
                 let Input::Utxo(input) = input;
                 if let Some(input) = wallet_data.outputs.get(input.output_id()) {
-                    if input.is_spent {
+                    if input.metadata.is_spent() {
                         input_got_spent = true;
                     }
                 }

--- a/sdk/src/wallet/types/mod.rs
+++ b/sdk/src/wallet/types/mod.rs
@@ -42,8 +42,6 @@ pub struct OutputData {
     pub output: Output,
     /// The output ID proof
     pub output_id_proof: OutputIdProof,
-    /// If an output is spent
-    pub is_spent: bool,
     /// Network ID
     pub network_id: u64,
     pub remainder: bool,

--- a/sdk/src/wallet/types/mod.rs
+++ b/sdk/src/wallet/types/mod.rs
@@ -48,6 +48,11 @@ pub struct OutputData {
 }
 
 impl OutputData {
+    /// Returns whether the [`OutputMetadata`] is spent or not.
+    pub fn is_spent(&self) -> bool {
+        self.metadata.is_spent()
+    }
+
     pub fn input_signing_data(
         &self,
         wallet_data: &WalletData,

--- a/sdk/src/wallet/update.rs
+++ b/sdk/src/wallet/update.rs
@@ -69,7 +69,7 @@ where
                     wallet_data.unspent_outputs.remove(&output_id);
                     // Update spent data fields
                     if let Some(output_data) = wallet_data.outputs.get_mut(&output_id) {
-                        if !output_data.metadata.is_spent() {
+                        if !output_data.is_spent() {
                             log::warn!(
                                 "[SYNC] Setting output {} as spent without having the OutputConsumptionMetadata",
                                 output_id
@@ -124,7 +124,7 @@ where
                     .await;
                 }
             };
-            if !output_data.metadata.is_spent() {
+            if !output_data.is_spent() {
                 wallet_data.unspent_outputs.insert(output_data.output_id, output_data);
             }
         }
@@ -175,7 +175,7 @@ where
 
         for output_to_unlock in &spent_output_ids {
             if let Some(output_data) = wallet_data.outputs.get_mut(output_to_unlock) {
-                if !output_data.metadata.is_spent() {
+                if !output_data.is_spent() {
                     log::warn!(
                         "[SYNC] Setting output {} as spent without having the OutputConsumptionMetadata",
                         output_data.output_id

--- a/sdk/src/wallet/update.rs
+++ b/sdk/src/wallet/update.rs
@@ -71,7 +71,7 @@ where
                     if let Some(output_data) = wallet_data.outputs.get_mut(&output_id) {
                         if !output_data.metadata.is_spent() {
                             log::warn!(
-                                "[SYNC] Setting output as spent {} without having the OutputConsumptionMetadata",
+                                "[SYNC] Setting output {} as spent without having the OutputConsumptionMetadata",
                                 output_id
                             );
                             // Set 0 values because we don't have the actual metadata and also couldn't get it, probably
@@ -177,7 +177,7 @@ where
             if let Some(output_data) = wallet_data.outputs.get_mut(output_to_unlock) {
                 if !output_data.metadata.is_spent() {
                     log::warn!(
-                        "[SYNC] Setting output as spent {} without having the OutputConsumptionMetadata",
+                        "[SYNC] Setting output {} as spent without having the OutputConsumptionMetadata",
                         output_data.output_id
                     );
                     // Set 0 values because we don't have the actual metadata and also couldn't get it, probably because

--- a/sdk/src/wallet/update.rs
+++ b/sdk/src/wallet/update.rs
@@ -5,7 +5,10 @@ use std::collections::HashMap;
 
 use crate::{
     client::secret::SecretManage,
-    types::block::output::{OutputId, OutputMetadata},
+    types::block::{
+        output::{OutputConsumptionMetadata, OutputId, OutputMetadata},
+        payload::signed_transaction::TransactionId,
+    },
     wallet::{
         types::{InclusionState, OutputData, TransactionWithMetadata},
         Wallet,
@@ -66,9 +69,20 @@ where
                     wallet_data.unspent_outputs.remove(&output_id);
                     // Update spent data fields
                     if let Some(output_data) = wallet_data.outputs.get_mut(&output_id) {
-                        // TODO https://github.com/iotaledger/iota-sdk/issues/1718
-                        // output_data.metadata.set_spent(true);
-                        output_data.is_spent = true;
+                        if !output_data.metadata.is_spent() {
+                            log::warn!(
+                                "[SYNC] Setting output as spent {} without having the OutputConsumptionMetadata",
+                                output_id
+                            );
+                            // Set 0 values because we don't have the actual metadata and also couldn't get it, probably
+                            // because it got pruned.
+                            output_data.metadata.spent = Some(OutputConsumptionMetadata::new(
+                                0.into(),
+                                TransactionId::new([0u8; TransactionId::LENGTH]),
+                                None,
+                            ));
+                        }
+
                         #[cfg(feature = "events")]
                         {
                             self.emit(WalletEvent::SpentOutput(Box::new(SpentOutputEvent {
@@ -110,7 +124,7 @@ where
                     .await;
                 }
             };
-            if !output_data.is_spent {
+            if !output_data.metadata.is_spent() {
                 wallet_data.unspent_outputs.insert(output_data.output_id, output_data);
             }
         }
@@ -160,8 +174,20 @@ where
         }
 
         for output_to_unlock in &spent_output_ids {
-            if let Some(output) = wallet_data.outputs.get_mut(output_to_unlock) {
-                output.is_spent = true;
+            if let Some(output_data) = wallet_data.outputs.get_mut(output_to_unlock) {
+                if !output_data.metadata.is_spent() {
+                    log::warn!(
+                        "[SYNC] Setting output as spent {} without having the OutputConsumptionMetadata",
+                        output_data.output_id
+                    );
+                    // Set 0 values because we don't have the actual metadata and also couldn't get it, probably because
+                    // it got pruned.
+                    output_data.metadata.spent = Some(OutputConsumptionMetadata::new(
+                        0.into(),
+                        TransactionId::new([0u8; TransactionId::LENGTH]),
+                        None,
+                    ));
+                }
             }
             wallet_data.locked_outputs.remove(output_to_unlock);
             wallet_data.unspent_outputs.remove(output_to_unlock);

--- a/sdk/tests/wallet/events.rs
+++ b/sdk/tests/wallet/events.rs
@@ -59,7 +59,6 @@ fn wallet_events_serde() {
                 hash: [0u8; 32],
             }),
         },
-        is_spent: false,
         network_id: 42,
         remainder: true,
     };


### PR DESCRIPTION
# Description of change

Remove OutputData::is_spent and rely on OutputConsumptionMetadata only so we don't have multiple fields to update which could get out of sync

## Links to any relevant issues

Closes #1718 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
