### PR TITLE
Allow using account mana for allotments, fix semantic validation

### DIFF
--- a/sdk/src/client/api/block_builder/input_selection/mod.rs
+++ b/sdk/src/client/api/block_builder/input_selection/mod.rs
@@ -51,7 +51,9 @@ pub struct InputSelection {
     requirements: Vec<Requirement>,
     automatically_transitioned: HashSet<ChainId>,
     auto_mana_allotment: Option<AutoManaAllotment>,
-    mana_allotments: BTreeMap<AccountId, u64>,
+    // first u64 is the actual allotment amount, the second value specifies the amount that was added by reducing
+    // amounts of automatically transitioned chains
+    mana_allotments: BTreeMap<AccountId, (u64, u64)>,
     mana_rewards: HashMap<OutputId, u64>,
     payload: Option<TaggedDataPayload>,
     allow_additional_input_selection: bool,
@@ -263,7 +265,7 @@ impl InputSelection {
             mana_allotments: self
                 .mana_allotments
                 .into_iter()
-                .map(|(account_id, mana)| ManaAllotment::new(account_id, mana))
+                .map(|(account_id, mana)| ManaAllotment::new(account_id, mana.0))
                 .collect::<Result<_, _>>()?,
         })
     }
@@ -316,7 +318,7 @@ impl InputSelection {
 
     /// Sets the mana allotments of an [`InputSelection`].
     pub fn with_mana_allotments(mut self, mana_allotments: impl IntoIterator<Item = (AccountId, u64)>) -> Self {
-        self.mana_allotments = mana_allotments.into_iter().collect();
+        self.mana_allotments = mana_allotments.into_iter().map(|a| (a.0, (a.1, 0))).collect();
         self
     }
 

--- a/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
@@ -35,8 +35,18 @@ impl InputSelection {
     }
 
     pub(crate) fn mana_sums(&self) -> Result<(u64, u64), Error> {
-        let required_mana =
-            self.outputs.iter().map(|o| o.mana()).sum::<u64>() + self.mana_allotments.values().sum::<u64>();
+        let required_mana = self.outputs.iter().map(|o| o.mana()).sum::<u64>()
+            + self.mana_allotments.values().map(|v| v.0 - v.1).sum::<u64>();
+        let mut selected_mana = 0;
+
+        for input in &self.selected_inputs {
+            selected_mana += self.total_mana(input)?;
+        }
+        Ok((selected_mana, required_mana))
+    }
+
+    pub(crate) fn mana_sums_without_allotments(&self) -> Result<(u64, u64), Error> {
+        let required_mana = self.outputs.iter().map(|o| o.mana()).sum::<u64>();
         let mut selected_mana = 0;
 
         for input in &self.selected_inputs {

--- a/sdk/src/client/api/block_builder/input_selection/transition.rs
+++ b/sdk/src/client/api/block_builder/input_selection/transition.rs
@@ -61,7 +61,6 @@ impl InputSelection {
             .with_features(features);
 
         if input.is_block_issuer() {
-            // TODO https://github.com/iotaledger/iota-sdk/issues/1918
             builder = builder.with_mana(Output::from(input.clone()).available_mana(
                 &self.protocol_parameters,
                 output_id.transaction_id().slot_index(),

--- a/sdk/src/types/block/semantic/mod.rs
+++ b/sdk/src/types/block/semantic/mod.rs
@@ -221,6 +221,14 @@ impl<'a> SemanticValidationContext<'a> {
             }
         }
 
+        // Add allotted mana
+        for mana_allotment in self.transaction.allotments() {
+            self.output_mana = self
+                .output_mana
+                .checked_add(mana_allotment.mana())
+                .ok_or(Error::CreatedManaOverflow)?;
+        }
+
         // Validation of outputs.
         for created_output in self.transaction.outputs() {
             let (amount, mana, created_native_token, features) = match created_output {
@@ -260,14 +268,6 @@ impl<'a> SemanticValidationContext<'a> {
 
             // Add stored mana
             self.output_mana = self.output_mana.checked_add(mana).ok_or(Error::CreatedManaOverflow)?;
-
-            // Add allotted mana
-            for mana_allotment in self.transaction.allotments() {
-                self.output_mana = self
-                    .output_mana
-                    .checked_add(mana_allotment.mana())
-                    .ok_or(Error::CreatedManaOverflow)?;
-            }
 
             if let Some(created_native_token) = created_native_token {
                 let native_token_amount = self

--- a/sdk/tests/client/input_selection/account_outputs.rs
+++ b/sdk/tests/client/input_selection/account_outputs.rs
@@ -4,11 +4,16 @@
 use std::str::FromStr;
 
 use iota_sdk::{
-    client::api::input_selection::{Burn, Error, InputSelection, Requirement},
+    client::{
+        api::input_selection::{Burn, Error, InputSelection, Requirement},
+        secret::types::InputSigningData,
+    },
     types::block::{
         address::Address,
-        output::{AccountId, AccountOutputBuilder, Output},
+        mana::ManaAllotment,
+        output::{unlock_condition::AddressUnlockCondition, AccountId, AccountOutputBuilder, Output},
         protocol::protocol_parameters,
+        rand::output::{rand_output_id_with_slot_index, rand_output_metadata_with_id},
     },
 };
 use pretty_assertions::{assert_eq, assert_ne};
@@ -1701,4 +1706,60 @@ fn remainder_address_in_state_controller() {
             ));
         }
     });
+}
+
+#[test]
+fn automatic_allot_account_mana() {
+    let protocol_parameters = protocol_parameters();
+    let account_id_1 = AccountId::from_str(ACCOUNT_ID_1).unwrap();
+
+    let mut inputs = Vec::new();
+    let mana_input_amount = 1_000_000;
+
+    let account_output = AccountOutputBuilder::new_with_amount(2_000_000, account_id_1)
+        .add_unlock_condition(AddressUnlockCondition::new(
+            Address::try_from_bech32(BECH32_ADDRESS_ED25519_0).unwrap(),
+        ))
+        .with_mana(mana_input_amount)
+        .finish_output()
+        .unwrap();
+    inputs.push(InputSigningData {
+        output: account_output,
+        output_metadata: rand_output_metadata_with_id(rand_output_id_with_slot_index(SLOT_INDEX)),
+        chain: None,
+    });
+
+    let outputs = build_outputs([Basic {
+        amount: 1_000_000,
+        address: Address::try_from_bech32(BECH32_ADDRESS_ED25519_0).unwrap(),
+        native_token: None,
+        sender: Some(Address::try_from_bech32(BECH32_ADDRESS_ED25519_0).unwrap()),
+        sdruc: None,
+        timelock: None,
+        expiration: None,
+    }]);
+
+    let selected = InputSelection::new(
+        inputs.clone(),
+        None,
+        outputs.clone(),
+        [Address::try_from_bech32(BECH32_ADDRESS_ED25519_0).unwrap()],
+        SLOT_INDEX,
+        SLOT_COMMITMENT_ID,
+        protocol_parameters,
+    )
+    .with_auto_mana_allotment(account_id_1, 500)
+    .select()
+    .unwrap();
+
+    assert!(unsorted_eq(&selected.inputs, &inputs));
+    assert_eq!(selected.outputs.len(), 2);
+    assert!(selected.outputs.contains(&outputs[0]));
+    assert_eq!(selected.mana_allotments.len(), 1);
+    let mana_cost = 230_000;
+    assert_eq!(
+        selected.mana_allotments[0],
+        ManaAllotment::new(account_id_1, mana_cost).unwrap()
+    );
+    assert_eq!(selected.outputs[1].as_account().mana(), mana_input_amount - mana_cost);
 }


### PR DESCRIPTION
# Description of change

Allow using account Mana for allotments, fix semantic validation (only add allotments Mana to output Mana once)

## Links to any relevant issues

#1918 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Sending a transaction with only accounts as inputs