### PR TITLE
Fix TransactionOptions::as_dict() for remainder_value_strategy

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NodeInfoProtocol.belowMaxDepth`;
 - `{NodeInfoProtocol, RentStructure}::as_dict()`;
 
+### Fixed
+
+- `TransactionOptions::as_dict()` for remainder_value_strategy;
+
 ## 1.1.2 - 2023-12-01
 
 ### Added

--- a/bindings/python/iota_sdk/types/transaction_options.py
+++ b/bindings/python/iota_sdk/types/transaction_options.py
@@ -83,4 +83,9 @@ class TransactionOptions():
     def as_dict(self):
         """Converts this object to a dict.
         """
-        return dict(self.__dict__)
+        config = {k: v for k, v in self.__dict__.items() if v is not None}
+
+        if 'remainder_value_strategy' in config:
+            config['remainder_value_strategy'] = config['remainder_value_strategy'].as_dict()
+
+        return config

--- a/bindings/python/iota_sdk/wallet/common.py
+++ b/bindings/python/iota_sdk/wallet/common.py
@@ -21,6 +21,9 @@ def _call_method_routine(func):
                 to_dict_method = getattr(o, "to_dict", None)
                 if callable(to_dict_method):
                     return o.to_dict()
+                as_dict_method = getattr(o, "as_dict", None)
+                if callable(as_dict_method):
+                    return o.as_dict()
                 if isinstance(o, str):
                     return o
                 if isinstance(o, Enum):


### PR DESCRIPTION
# Description of change

Fix TransactionOptions::as_dict() for remainder_value_strategy

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running this example, previously failed with `ValueError: missing field `strategy` at line 1 column 452`
```py
import os

from dotenv import load_dotenv
from dataclasses import dataclass

from iota_sdk import TransactionOptions, Wallet, RemainderValueStrategyCustomAddress, OutputParams

load_dotenv()

wallet = Wallet(os.environ['WALLET_DB_PATH'])

account = wallet.get_account('Alice')

response = account.sync()

if 'STRONGHOLD_PASSWORD' not in os.environ:
    raise Exception(".env STRONGHOLD_PASSWORD is undefined, see .env.example")

wallet.set_stronghold_password(os.environ["STRONGHOLD_PASSWORD"])


@dataclass
class AddressAndAmount:
    address: str
    amount: int


outputs = [
    AddressAndAmount("rms1qqw240yhv2lagc4ra86k6z0xhmlwya6ycgewprft9q2y554asgayw8z2wqe", 1000000)]

hot_wallet_address = "rms1qqw240yhv2lagc4ra86k6z0xhmlwya6ycgewprft9q2y554asgayw8z2wqe"

transaction_options = TransactionOptions(
    remainder_value_strategy=RemainderValueStrategyCustomAddress(
        address=hot_wallet_address, key_index=0, internal=False, used=True
    )
)
transaction = account.send_outputs(
    [account.prepare_output(OutputParams(
        output.address, str(output.amount))) for output in outputs],
    transaction_options,
)
print(f'Block sent: {os.environ["EXPLORER_URL"]}/block/{transaction.blockId}')

```