### PR TITLE
Add strum impls to failure enums

### DIFF
--- a/sdk/src/types/api/core.rs
+++ b/sdk/src/types/api/core.rs
@@ -370,8 +370,20 @@ pub enum TransactionState {
 }
 
 /// Describes the reason of a block failure.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    serde_repr::Serialize_repr,
+    serde_repr::Deserialize_repr,
+    strum::FromRepr,
+    strum::EnumString,
+    strum::AsRefStr,
+)]
 #[serde(rename_all = "camelCase")]
+#[strum(serialize_all = "camelCase")]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum BlockFailureReason {

--- a/sdk/src/types/block/semantic/error.rs
+++ b/sdk/src/types/block/semantic/error.rs
@@ -11,6 +11,7 @@ use crate::types::block::Error;
     Debug, Copy, Clone, Eq, PartialEq, packable::Packable, strum::FromRepr, strum::EnumString, strum::AsRefStr,
 )]
 #[cfg_attr(feature = "serde", derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr))]
+#[strum(serialize_all = "camelCase")]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidTransactionFailureReason)]
 #[non_exhaustive]

--- a/sdk/src/types/block/semantic/error.rs
+++ b/sdk/src/types/block/semantic/error.rs
@@ -7,7 +7,9 @@ use crate::types::block::Error;
 
 /// Describes the reason of a transaction failure.
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, packable::Packable, strum::FromRepr)]
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, packable::Packable, strum::FromRepr, strum::EnumString, strum::AsRefStr,
+)]
 #[cfg_attr(feature = "serde", derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr))]
 #[packable(unpack_error = Error)]
 #[packable(tag_type = u8, with_error = Error::InvalidTransactionFailureReason)]


### PR DESCRIPTION
# Description of change

Adds strum `AsRefStr`, `EnumString`, and `FromRepr` for these rust enums.
