### PR TITLE
Fix bindings types

### DIFF
--- a/bindings/nodejs/lib/types/wallet/transaction-options.ts
+++ b/bindings/nodejs/lib/types/wallet/transaction-options.ts
@@ -4,6 +4,7 @@
 import {
     AccountAddress,
     AccountId,
+    Address,
     Bech32Address,
     ContextInput,
     OutputId,
@@ -11,7 +12,6 @@ import {
 import { TaggedDataPayload } from '../block/payload/tagged';
 import { Burn } from '../client';
 import { u256, HexEncodedString, NumericString, u64 } from '../utils';
-import { Bip44Address } from './address';
 
 /** Options for creating a transaction. */
 export interface TransactionOptions {
@@ -56,7 +56,7 @@ export type ReuseAddress = {
 export type CustomAddress = {
     /** The name of the strategy. */
     strategy: 'CustomAddress';
-    value: Bip44Address;
+    value: Address;
 };
 
 /** Options for creating Native Tokens. */

--- a/bindings/python/iota_sdk/types/balance.py
+++ b/bindings/python/iota_sdk/types/balance.py
@@ -18,7 +18,7 @@ class BaseCoinBalance:
     Attributes:
         total: The total balance.
         available: The available amount of the total balance.
-        voting_power: The voting power of the wallet.
+        # voting_power: The voting power of the wallet.
     """
     total: int = field(metadata=config(
         encoder=str
@@ -26,9 +26,10 @@ class BaseCoinBalance:
     available: int = field(metadata=config(
         encoder=str
     ))
-    voting_power: int = field(metadata=config(
-        encoder=str
-    ))
+    # TODO https://github.com/iotaledger/iota-sdk/issues/1822
+    # voting_power: int = field(metadata=config(
+    # encoder=str
+    # ))
 
 
 @json
@@ -39,9 +40,13 @@ class ManaBalance:
     Attributes:
         total: The total balance.
         available: The available amount of the total balance.
+        rewards: Mana rewards of account and delegation outputs.
     """
     total: DecayedMana
     available: DecayedMana
+    rewards: int = field(metadata=config(
+        encoder=str
+    ))
 
 
 @json

--- a/bindings/python/iota_sdk/types/transaction_options.py
+++ b/bindings/python/iota_sdk/types/transaction_options.py
@@ -3,7 +3,8 @@
 
 from enum import Enum
 from typing import Optional, List, Union
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from iota_sdk.types.address import Address
 from iota_sdk.types.burn import Burn
 from iota_sdk.types.common import HexStr, json
 from iota_sdk.types.context_input import ContextInput
@@ -17,30 +18,10 @@ class RemainderValueStrategyCustomAddress:
     """Remainder value strategy for custom addresses.
 
     Attributes:
-        address: An address to move the remainder value to.
-        key_index: The address key index.
-        internal: Determines if an address is a public or an internal (change) address.
-        used: Indicates whether an address has been used already.
+        value: An address to move the remainder value to.
     """
-
-    address: str
-    key_index: int
-    internal: bool
-    used: bool
-
-    def to_dict(self) -> dict:
-        """Custom dict conversion.
-        """
-
-        return {
-            'strategy': 'CustomAddress',
-            'value': {
-                'address': self.address,
-                'keyIndex': self.key_index,
-                'internal': self.internal,
-                'used': self.used
-            }
-        }
+    strategy: str = field(default_factory=lambda: 'CustomAddress', init=False)
+    value: Address
 
 
 class RemainderValueStrategy(Enum):
@@ -57,7 +38,6 @@ class RemainderValueStrategy(Enum):
 
         return {
             'strategy': self.name,
-            'value': self.value[0]
         }
 
 
@@ -79,28 +59,15 @@ class TransactionOptions:
         mana_allotments: Mana allotments for the transaction.
         issuer_id: Optional block issuer to which the transaction will have required mana allotted.
     """
-
-    def __init__(self, remainder_value_strategy: Optional[Union[RemainderValueStrategy, RemainderValueStrategyCustomAddress]] = None,
-                 tagged_data_payload: Optional[TaggedDataPayload] = None,
-                 context_inputs: Optional[List[ContextInput]] = None,
-                 required_inputs: Optional[List[OutputId]] = None,
-                 burn: Optional[Burn] = None,
-                 note: Optional[str] = None,
-                 allow_micro_amount: Optional[bool] = None,
-                 allow_additional_input_selection: Optional[bool] = None,
-                 capabilities: Optional[HexStr] = None,
-                 mana_allotments: Optional[dict[HexStr, int]] = None,
-                 issuer_id: Optional[HexStr] = None):
-        """Initialize transaction options.
-        """
-        self.remainder_value_strategy = remainder_value_strategy
-        self.tagged_data_payload = tagged_data_payload
-        self.context_inputs = context_inputs
-        self.required_inputs = required_inputs
-        self.burn = burn
-        self.note = note
-        self.allow_micro_amount = allow_micro_amount
-        self.allow_additional_input_selection = allow_additional_input_selection
-        self.capabilities = capabilities
-        self.mana_allotments = mana_allotments
-        self.issuer_id = issuer_id
+    remainder_value_strategy: Optional[Union[RemainderValueStrategy,
+                                             RemainderValueStrategyCustomAddress]] = None
+    tagged_data_payload: Optional[TaggedDataPayload] = None
+    context_inputs: Optional[List[ContextInput]] = None
+    required_inputs: Optional[List[OutputId]] = None
+    burn: Optional[Burn] = None
+    note: Optional[str] = None
+    allow_micro_amount: Optional[bool] = None
+    allow_additional_input_selection: Optional[bool] = None
+    capabilities: Optional[HexStr] = None
+    mana_allotments: Optional[dict[HexStr, int]] = None
+    issuer_id: Optional[HexStr] = None


### PR DESCRIPTION
# Description of change

Fix RemainderValueStrategy in bindings, fix balance in Python

## Links to any relevant issues

 Fixes https://github.com/iotaledger/iota-sdk/issues/1975 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running examples
```
transaction = wallet.send_with_params(params, TransactionOptions(
    remainder_value_strategy=RemainderValueStrategy.ReuseAddress))

transaction = wallet.send_with_params(params, TransactionOptions(remainder_value_strategy=RemainderValueStrategyCustomAddress(
    Utils.parse_bech32_address("rms1qpszqzadsym6wpppd6z037dvlejmjuke7s24hm95s9fg9vpua7vluaw60xu"))))


const response = await wallet.send(amount, address, { remainderValueStrategy: { strategy: 'ReuseAddress' } as ReuseAddress });
const response = await wallet.send(amount, address, { remainderValueStrategy: { strategy: 'CustomAddress', value: Utils.parseBech32Address('rms1qrrv7flg6lz5cssvzv2lsdt8c673khad060l4quev6q09tkm9mgtupgf0h0') } });

```