### PR TITLE
Allotment touchups

### DIFF
--- a/bindings/core/src/method/wallet.rs
+++ b/bindings/core/src/method/wallet.rs
@@ -357,11 +357,17 @@ pub enum WalletMethod {
     PrepareExtendStaking {
         account_id: AccountId,
         additional_epochs: u32,
+        #[serde(default)]
+        options: Option<TransactionOptions>,
     },
     /// Prepare to end staking.
     /// Expected response: [`PreparedTransaction`](crate::Response::PreparedTransaction)
     #[serde(rename_all = "camelCase")]
-    PrepareEndStaking { account_id: AccountId },
+    PrepareEndStaking {
+        account_id: AccountId,
+        #[serde(default)]
+        options: Option<TransactionOptions>,
+    },
     /// Announce candidacy for an account.
     /// Expected response: [`BlockId`](crate::Response::BlockId)
     #[serde(rename_all = "camelCase")]

--- a/bindings/core/src/method_handler/wallet.rs
+++ b/bindings/core/src/method_handler/wallet.rs
@@ -343,12 +343,15 @@ pub(crate) async fn call_wallet_method_internal(wallet: &Wallet, method: WalletM
         WalletMethod::PrepareExtendStaking {
             account_id,
             additional_epochs,
+            options,
         } => {
-            let data = wallet.prepare_extend_staking(account_id, additional_epochs).await?;
+            let data = wallet
+                .prepare_extend_staking(account_id, additional_epochs, options)
+                .await?;
             Response::PreparedTransaction(data)
         }
-        WalletMethod::PrepareEndStaking { account_id } => {
-            let data = wallet.prepare_end_staking(account_id).await?;
+        WalletMethod::PrepareEndStaking { account_id, options } => {
+            let data = wallet.prepare_end_staking(account_id, options).await?;
             Response::PreparedTransaction(data)
         }
         WalletMethod::AnnounceCandidacy { account_id } => {

--- a/bindings/nodejs/lib/types/wallet/transaction-options.ts
+++ b/bindings/nodejs/lib/types/wallet/transaction-options.ts
@@ -31,6 +31,11 @@ export interface TransactionOptions {
     allowMicroAmount?: boolean;
     /** Whether to allow the selection of additional inputs for this transaction. */
     allowAdditionalInputSelection?: boolean;
+    /**
+     * Whether to allow allotting automatically calculated mana from the issuer account.
+     * If this flag is disabled, additional inputs will be selected to cover the amount.
+     */
+    allowAllottingFromAccountMana?: boolean;
     /** Transaction capabilities. */
     capabilities?: HexEncodedString;
     /** Mana allotments for the transaction. */

--- a/bindings/python/iota_sdk/types/transaction_options.py
+++ b/bindings/python/iota_sdk/types/transaction_options.py
@@ -62,15 +62,15 @@ class TransactionOptions:
         issuer_id: Optional block issuer to which the transaction will have required mana allotted.
     """
     remainder_value_strategy: Optional[Union[RemainderValueStrategy,
-                                             RemainderValueStrategyCustomAddress]] = None,
-    tagged_data_payload: Optional[TaggedDataPayload] = None,
-    context_inputs: Optional[List[ContextInput]] = None,
-    required_inputs: Optional[List[OutputId]] = None,
-    burn: Optional[Burn] = None,
-    note: Optional[str] = None,
-    allow_micro_amount: Optional[bool] = None,
-    allow_additional_input_selection: Optional[bool] = None,
-    allow_allotting_from_account_mana: Optional[bool] = None,
-    capabilities: Optional[HexStr] = None,
-    mana_allotments: Optional[dict[HexStr, int]] = None,
+                                             RemainderValueStrategyCustomAddress]] = None
+    tagged_data_payload: Optional[TaggedDataPayload] = None
+    context_inputs: Optional[List[ContextInput]] = None
+    required_inputs: Optional[List[OutputId]] = None
+    burn: Optional[Burn] = None
+    note: Optional[str] = None
+    allow_micro_amount: Optional[bool] = None
+    allow_additional_input_selection: Optional[bool] = None
+    allow_allotting_from_account_mana: Optional[bool] = None
+    capabilities: Optional[HexStr] = None
+    mana_allotments: Optional[dict[HexStr, int]] = None
     issuer_id: Optional[HexStr] = None

--- a/bindings/python/iota_sdk/types/transaction_options.py
+++ b/bindings/python/iota_sdk/types/transaction_options.py
@@ -75,6 +75,8 @@ class TransactionOptions:
         note: A string attached to the transaction.
         allow_micro_amount: Whether to allow sending a micro amount.
         allow_additional_input_selection: Whether to allow the selection of additional inputs for this transaction.
+        allow_allotting_from_account_mana: Whether to allow allotting automatically calculated mana from the issuer account.
+            If this flag is disabled, additional inputs will be selected to cover the amount.
         capabilities: Transaction capabilities.
         mana_allotments: Mana allotments for the transaction.
         issuer_id: Optional block issuer to which the transaction will have required mana allotted.
@@ -88,6 +90,7 @@ class TransactionOptions:
                  note: Optional[str] = None,
                  allow_micro_amount: Optional[bool] = None,
                  allow_additional_input_selection: Optional[bool] = None,
+                 allow_allotting_from_account_mana: Optional[bool] = None,
                  capabilities: Optional[HexStr] = None,
                  mana_allotments: Optional[dict[HexStr, int]] = None,
                  issuer_id: Optional[HexStr] = None):
@@ -101,6 +104,7 @@ class TransactionOptions:
         self.note = note
         self.allow_micro_amount = allow_micro_amount
         self.allow_additional_input_selection = allow_additional_input_selection
+        self.allow_allotting_from_account_mana = allow_allotting_from_account_mana
         self.capabilities = capabilities
         self.mana_allotments = mana_allotments
         self.issuer_id = issuer_id

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -80,6 +80,7 @@ pub enum WalletCommand {
         /// The staking period (in epochs). Will default to the staking unbonding period.
         staking_period: Option<u32>,
         /// Whether to allot mana from the account output.
+        #[arg(long, default_value_t = true)]
         allot_from_account: bool,
     },
     /// Burn an amount of native token.
@@ -167,6 +168,7 @@ pub enum WalletCommand {
         /// The Account ID of the staking account.
         account_id: AccountId,
         /// Whether to allot mana from the account output.
+        #[arg(long, default_value_t = true)]
         allot_from_account: bool,
     },
     /// Exit the CLI wallet.
@@ -178,6 +180,7 @@ pub enum WalletCommand {
         /// The number of additional epochs to add to the staking period.
         additional_epochs: u32,
         /// Whether to allot mana from the account output.
+        #[arg(long, default_value_t = true)]
         allot_from_account: bool,
     },
     /// Request funds from the faucet.

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -79,6 +79,8 @@ pub enum WalletCommand {
         fixed_cost: u64,
         /// The staking period (in epochs). Will default to the staking unbonding period.
         staking_period: Option<u32>,
+        /// Whether to allot mana from the account output.
+        allot_from_account: bool,
     },
     /// Burn an amount of native token.
     BurnNativeToken {
@@ -164,6 +166,8 @@ pub enum WalletCommand {
     EndStaking {
         /// The Account ID of the staking account.
         account_id: AccountId,
+        /// Whether to allot mana from the account output.
+        allot_from_account: bool,
     },
     /// Exit the CLI wallet.
     Exit,
@@ -173,6 +177,8 @@ pub enum WalletCommand {
         account_id: AccountId,
         /// The number of additional epochs to add to the staking period.
         additional_epochs: u32,
+        /// Whether to allot mana from the account output.
+        allot_from_account: bool,
     },
     /// Request funds from the faucet.
     Faucet {
@@ -472,6 +478,7 @@ pub async fn begin_staking_command(
     staked_amount: u64,
     fixed_cost: u64,
     staking_period: Option<u32>,
+    allot_from_account: bool,
 ) -> Result<(), Error> {
     println_log_info!("Begin staking for {account_id}.");
 
@@ -483,7 +490,10 @@ pub async fn begin_staking_command(
                 fixed_cost,
                 staking_period,
             },
-            None,
+            TransactionOptions {
+                allow_allotting_from_account_mana: allot_from_account,
+                ..Default::default()
+            },
         )
         .await?;
 
@@ -793,10 +803,22 @@ pub async fn destroy_foundry_command(wallet: &Wallet, foundry_id: FoundryId) -> 
 }
 
 // `end-staking` command
-pub async fn end_staking_command(wallet: &Wallet, account_id: AccountId) -> Result<(), Error> {
+pub async fn end_staking_command(
+    wallet: &Wallet,
+    account_id: AccountId,
+    allot_from_account: bool,
+) -> Result<(), Error> {
     println_log_info!("Ending staking for {account_id}.");
 
-    let transaction = wallet.end_staking(account_id).await?;
+    let transaction = wallet
+        .end_staking(
+            account_id,
+            TransactionOptions {
+                allow_allotting_from_account_mana: allot_from_account,
+                ..Default::default()
+            },
+        )
+        .await?;
 
     println_log_info!(
         "End staking transaction sent:\n{:?}\n{:?}",
@@ -812,10 +834,20 @@ pub async fn extend_staking_command(
     wallet: &Wallet,
     account_id: AccountId,
     additional_epochs: u32,
+    allot_from_account: bool,
 ) -> Result<(), Error> {
     println_log_info!("Extending staking for {account_id} by {additional_epochs} epochs.");
 
-    let transaction = wallet.extend_staking(account_id, additional_epochs).await?;
+    let transaction = wallet
+        .extend_staking(
+            account_id,
+            additional_epochs,
+            TransactionOptions {
+                allow_allotting_from_account_mana: allot_from_account,
+                ..Default::default()
+            },
+        )
+        .await?;
 
     println_log_info!(
         "Extend staking transaction sent:\n{:?}\n{:?}",
@@ -1404,9 +1436,18 @@ pub async fn prompt_internal(
                             staked_amount,
                             fixed_cost,
                             staking_period,
+                            allot_from_account,
                         } => {
                             ensure_password(wallet).await?;
-                            begin_staking_command(wallet, account_id, staked_amount, fixed_cost, staking_period).await
+                            begin_staking_command(
+                                wallet,
+                                account_id,
+                                staked_amount,
+                                fixed_cost,
+                                staking_period,
+                                allot_from_account,
+                            )
+                            .await
                         }
                         WalletCommand::BurnNativeToken { token_id, amount } => {
                             ensure_password(wallet).await?;
@@ -1478,9 +1519,12 @@ pub async fn prompt_internal(
                             ensure_password(wallet).await?;
                             destroy_foundry_command(wallet, foundry_id).await
                         }
-                        WalletCommand::EndStaking { account_id } => {
+                        WalletCommand::EndStaking {
+                            account_id,
+                            allot_from_account,
+                        } => {
                             ensure_password(wallet).await?;
-                            end_staking_command(wallet, account_id).await
+                            end_staking_command(wallet, account_id, allot_from_account).await
                         }
                         WalletCommand::Exit => {
                             return Ok(PromptResponse::Done);
@@ -1488,9 +1532,10 @@ pub async fn prompt_internal(
                         WalletCommand::ExtendStaking {
                             account_id,
                             additional_epochs,
+                            allot_from_account,
                         } => {
                             ensure_password(wallet).await?;
-                            extend_staking_command(wallet, account_id, additional_epochs).await
+                            extend_staking_command(wallet, account_id, additional_epochs, allot_from_account).await
                         }
                         WalletCommand::Faucet { address, url } => faucet_command(wallet, address, url).await,
                         WalletCommand::ImplicitAccountCreationAddress => {

--- a/sdk/src/client/api/block_builder/input_selection/mod.rs
+++ b/sdk/src/client/api/block_builder/input_selection/mod.rs
@@ -234,6 +234,15 @@ impl InputSelection {
             }
         }
 
+        let (input_mana, output_mana) = self.mana_sums(false)?;
+
+        if input_mana < output_mana {
+            return Err(Error::InsufficientMana {
+                found: input_mana,
+                required: output_mana,
+            });
+        }
+
         // If there is no min allotment calculation, then we should update the remainders as the last step
         if self.min_mana_allotment.is_none() {
             self.update_remainders()?;

--- a/sdk/src/client/api/block_builder/input_selection/mod.rs
+++ b/sdk/src/client/api/block_builder/input_selection/mod.rs
@@ -69,6 +69,7 @@ pub struct InputSelection {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct MinManaAllotment {
     issuer_id: AccountId,
+    allow_allotting_from_account_mana: bool,
     reference_mana_cost: u64,
     allotment_debt: u64,
 }
@@ -180,7 +181,7 @@ impl InputSelection {
                     let input = self.available_inputs.swap_remove(index);
 
                     // Selects required input.
-                    self.select_input(input)?
+                    self.select_input(input)?;
                 }
                 None => return Err(Error::RequiredInputIsNotAvailable(required_input)),
             }
@@ -202,8 +203,8 @@ impl InputSelection {
         if !OUTPUT_COUNT_RANGE.contains(&(self.provided_outputs.len() as u16)) {
             // If burn or mana allotments are provided, outputs will be added later, in the other cases it will just
             // create remainder outputs.
-            if !(self.provided_outputs.is_empty()
-                && (self.burn.is_some() || !self.mana_allotments.is_empty() || !self.required_inputs.is_empty()))
+            if !self.provided_outputs.is_empty()
+                || (self.burn.is_none() && self.mana_allotments.is_empty() && self.required_inputs.is_empty())
             {
                 return Err(Error::InvalidOutputCount(self.provided_outputs.len()));
             }
@@ -324,9 +325,10 @@ impl InputSelection {
         })
     }
 
-    fn select_input(&mut self, input: InputSigningData) -> Result<(), Error> {
+    fn select_input(&mut self, input: InputSigningData) -> Result<Option<&Output>, Error> {
         log::debug!("Selecting input {:?}", input.output_id());
 
+        let mut added_output = None;
         if let Some(output) = self.transition_input(&input)? {
             // No need to check for `outputs_requirements` because
             // - the sender feature doesn't need to be verified as it has been removed
@@ -334,6 +336,7 @@ impl InputSelection {
             // - input doesn't need to be checked for as we just transitioned it
             // - foundry account requirement should have been met already by a prior `required_account_nft_addresses`
             self.added_outputs.push(output);
+            added_output = self.added_outputs.last();
         }
 
         if let Some(requirement) = self.required_account_nft_addresses(&input)? {
@@ -348,7 +351,7 @@ impl InputSelection {
             self.requirements.push(Requirement::ContextInputs);
         }
 
-        Ok(())
+        Ok(added_output)
     }
 
     /// Sets the required inputs of an [`InputSelection`].
@@ -406,9 +409,15 @@ impl InputSelection {
     }
 
     /// Specifies an account to which the minimum required mana allotment will be added.
-    pub fn with_min_mana_allotment(mut self, account_id: AccountId, reference_mana_cost: u64) -> Self {
+    pub fn with_min_mana_allotment(
+        mut self,
+        account_id: AccountId,
+        reference_mana_cost: u64,
+        allow_allotting_from_account_mana: bool,
+    ) -> Self {
         self.min_mana_allotment.replace(MinManaAllotment {
             issuer_id: account_id,
+            allow_allotting_from_account_mana,
             reference_mana_cost,
             allotment_debt: 0,
         });
@@ -431,13 +440,19 @@ impl InputSelection {
     }
 
     pub(crate) fn all_outputs(&self) -> impl Iterator<Item = &Output> {
-        self.non_remainder_outputs()
-            .chain(self.remainders.data.iter().map(|r| &r.output))
-            .chain(&self.remainders.storage_deposit_returns)
+        self.non_remainder_outputs().chain(self.remainder_outputs())
     }
 
     pub(crate) fn non_remainder_outputs(&self) -> impl Iterator<Item = &Output> {
         self.provided_outputs.iter().chain(&self.added_outputs)
+    }
+
+    pub(crate) fn remainder_outputs(&self) -> impl Iterator<Item = &Output> {
+        self.remainders
+            .data
+            .iter()
+            .map(|r| &r.output)
+            .chain(&self.remainders.storage_deposit_returns)
     }
 
     fn required_account_nft_addresses(&self, input: &InputSigningData) -> Result<Option<Requirement>, Error> {

--- a/sdk/src/client/api/block_builder/input_selection/remainder.rs
+++ b/sdk/src/client/api/block_builder/input_selection/remainder.rs
@@ -142,15 +142,13 @@ impl InputSelection {
             .ok_or(Error::MissingInputWithEd25519Address)?;
 
         // If there is a mana remainder, try to fit it in an existing output
-        if input_mana > output_mana {
-            if self.output_for_added_mana_exists(&remainder_address) {
-                log::debug!("Allocating {mana_diff} excess input mana for output with address {remainder_address}");
-                self.remainders.added_mana = std::mem::take(&mut mana_diff);
-                // If we have no other remainders, we are done
-                if input_amount == output_amount && native_tokens_diff.is_none() {
-                    log::debug!("No more remainder required");
-                    return Ok((storage_deposit_returns, Vec::new()));
-                }
+        if input_mana > output_mana && self.output_for_added_mana_exists(&remainder_address) {
+            log::debug!("Allocating {mana_diff} excess input mana for output with address {remainder_address}");
+            self.remainders.added_mana = std::mem::take(&mut mana_diff);
+            // If we have no other remainders, we are done
+            if input_amount == output_amount && native_tokens_diff.is_none() {
+                log::debug!("No more remainder required");
+                return Ok((storage_deposit_returns, Vec::new()));
             }
         }
 

--- a/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
@@ -268,6 +268,8 @@ impl InputSelection {
         let mut required_mana =
             self.non_remainder_outputs().map(|o| o.mana()).sum::<u64>() + self.mana_allotments.values().sum::<u64>();
         if include_remainders {
+            // Add the remainder outputs mana as well as the excess mana we've allocated to add to existing outputs
+            // later.
             required_mana += self.remainder_outputs().map(|o| o.mana()).sum::<u64>() + self.remainders.added_mana;
         }
 

--- a/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
@@ -80,6 +80,7 @@ impl InputSelection {
             let MinManaAllotment {
                 issuer_id,
                 allotment_debt,
+                allow_allotting_from_account_mana,
                 ..
             } = self
                 .min_mana_allotment
@@ -89,7 +90,7 @@ impl InputSelection {
             // Add the required allotment to the issuing allotment
             if required_allotment_mana > self.mana_allotments[issuer_id] {
                 log::debug!("Allotting at least {required_allotment_mana} mana to account ID {issuer_id}");
-                let additional_allotment = required_allotment_mana - self.mana_allotments[&issuer_id];
+                let additional_allotment = required_allotment_mana - self.mana_allotments[issuer_id];
                 log::debug!("{additional_allotment} additional mana required to meet minimum allotment");
                 // Unwrap: safe because we always add the record above
                 *self.mana_allotments.get_mut(issuer_id).unwrap() = required_allotment_mana;
@@ -100,11 +101,11 @@ impl InputSelection {
                 *allotment_debt = self.mana_allotments[issuer_id];
             }
 
-            self.reduce_account_output()?;
-        } else {
-            if !self.requirements.contains(&Requirement::Mana) {
-                self.requirements.push(Requirement::Mana);
+            if *allow_allotting_from_account_mana {
+                self.reduce_account_output()?;
             }
+        } else if !self.requirements.contains(&Requirement::Mana) {
+            self.requirements.push(Requirement::Mana);
         }
 
         // Remainders can only be calculated when the input mana is >= the output mana
@@ -126,7 +127,7 @@ impl InputSelection {
         Ok(Vec::new())
     }
 
-    pub(crate) fn reduce_account_output(&mut self) -> Result<(), Error> {
+    fn reduce_account_output(&mut self) -> Result<(), Error> {
         let MinManaAllotment {
             issuer_id,
             allotment_debt,
@@ -236,20 +237,22 @@ impl InputSelection {
     }
 
     pub(crate) fn get_inputs_for_mana_balance(&mut self) -> Result<Vec<InputSigningData>, Error> {
-        let (mut selected_mana, required_mana) = self.mana_sums(true)?;
+        let (mut selected_mana, mut required_mana) = self.mana_sums(true)?;
 
         log::debug!("Mana requirement selected mana: {selected_mana}, required mana: {required_mana}");
 
         if selected_mana >= required_mana {
             log::debug!("Mana requirement already fulfilled");
-            Ok(Vec::new())
         } else {
-            let mut inputs = Vec::new();
-
+            if !self.allow_additional_input_selection {
+                return Err(Error::AdditionalInputsRequired(Requirement::Mana));
+            }
             // TODO we should do as for the amount and have preferences on which inputs to pick.
             while let Some(input) = self.available_inputs.pop() {
                 selected_mana += self.total_mana(&input)?;
-                inputs.push(input);
+                if let Some(output) = self.select_input(input)? {
+                    required_mana += output.mana();
+                }
 
                 if selected_mana >= required_mana {
                     break;
@@ -261,17 +264,17 @@ impl InputSelection {
                     required: required_mana,
                 });
             }
-
-            Ok(inputs)
         }
+        Ok(Vec::new())
     }
 
     pub(crate) fn mana_sums(&self, include_remainders: bool) -> Result<(u64, u64), Error> {
-        let required_mana = if include_remainders {
-            self.all_outputs().map(|o| o.mana()).sum::<u64>() + self.remainders.added_mana
-        } else {
-            self.non_remainder_outputs().map(|o| o.mana()).sum::<u64>()
-        } + self.mana_allotments.values().sum::<u64>();
+        let mut required_mana =
+            self.non_remainder_outputs().map(|o| o.mana()).sum::<u64>() + self.mana_allotments.values().sum::<u64>();
+        if include_remainders {
+            required_mana += self.remainder_outputs().map(|o| o.mana()).sum::<u64>() + self.remainders.added_mana;
+        }
+
         let mut selected_mana = 0;
 
         for input in &self.selected_inputs {

--- a/sdk/src/client/api/block_builder/input_selection/transition.rs
+++ b/sdk/src/client/api/block_builder/input_selection/transition.rs
@@ -60,7 +60,7 @@ impl InputSelection {
             .with_features(features);
 
         if input.is_block_issuer() {
-            builder = builder.with_mana(Output::from(input.clone()).available_mana(
+            builder = builder.with_mana(input.available_mana(
                 &self.protocol_parameters,
                 output_id.transaction_id().slot_index(),
                 self.creation_slot,

--- a/sdk/src/types/block/output/account.rs
+++ b/sdk/src/types/block/output/account.rs
@@ -19,10 +19,12 @@ use crate::types::block::{
             verify_allowed_unlock_conditions, verify_restricted_addresses, UnlockCondition, UnlockConditionFlags,
             UnlockConditions,
         },
-        ChainId, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore, StorageScoreParameters,
+        ChainId, DecayedMana, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore,
+        StorageScoreParameters,
     },
     protocol::{ProtocolParameters, WorkScore, WorkScoreParameters},
     semantic::TransactionFailureReason,
+    slot::SlotIndex,
     Error,
 };
 
@@ -393,6 +395,40 @@ impl AccountOutput {
     /// Returns whether the output can claim rewards based on its current and next state in a transaction.
     pub fn can_claim_rewards(&self, next_state: Option<&Self>) -> bool {
         self.features().staking().is_some() && next_state.map_or(true, |o| o.features().staking().is_none())
+    }
+
+    /// Returns all the mana held by the output, which is potential + stored, all decayed.
+    pub fn available_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<u64, Error> {
+        let decayed_mana = self.decayed_mana(protocol_parameters, creation_index, target_index)?;
+
+        decayed_mana
+            .stored
+            .checked_add(decayed_mana.potential)
+            .ok_or(Error::ConsumedManaOverflow)
+    }
+
+    /// Returns the decayed stored and potential mana of the output.
+    pub fn decayed_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<DecayedMana, Error> {
+        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
+        let generation_amount = self.amount().saturating_sub(min_deposit);
+        let stored_mana = protocol_parameters.mana_with_decay(self.mana(), creation_index, target_index)?;
+        let potential_mana =
+            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
+
+        Ok(DecayedMana {
+            stored: stored_mana,
+            potential: potential_mana,
+        })
     }
 
     // Transition, just without full SemanticValidationContext

--- a/sdk/src/types/block/output/anchor.rs
+++ b/sdk/src/types/block/output/anchor.rs
@@ -19,10 +19,12 @@ use crate::types::block::{
             verify_allowed_unlock_conditions, verify_restricted_addresses, UnlockCondition, UnlockConditionFlags,
             UnlockConditions,
         },
-        ChainId, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore, StorageScoreParameters,
+        ChainId, DecayedMana, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore,
+        StorageScoreParameters,
     },
     protocol::{ProtocolParameters, WorkScore, WorkScoreParameters},
     semantic::{SemanticValidationContext, TransactionFailureReason},
+    slot::SlotIndex,
     unlock::Unlock,
     Error,
 };
@@ -449,6 +451,40 @@ impl AnchorOutput {
         };
 
         Ok(())
+    }
+
+    /// Returns all the mana held by the output, which is potential + stored, all decayed.
+    pub fn available_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<u64, Error> {
+        let decayed_mana = self.decayed_mana(protocol_parameters, creation_index, target_index)?;
+
+        decayed_mana
+            .stored
+            .checked_add(decayed_mana.potential)
+            .ok_or(Error::ConsumedManaOverflow)
+    }
+
+    /// Returns the decayed stored and potential mana of the output.
+    pub fn decayed_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<DecayedMana, Error> {
+        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
+        let generation_amount = self.amount().saturating_sub(min_deposit);
+        let stored_mana = protocol_parameters.mana_with_decay(self.mana(), creation_index, target_index)?;
+        let potential_mana =
+            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
+
+        Ok(DecayedMana {
+            stored: stored_mana,
+            potential: potential_mana,
+        })
     }
 
     // Transition, just without full ValidationContext

--- a/sdk/src/types/block/output/basic.rs
+++ b/sdk/src/types/block/output/basic.rs
@@ -13,9 +13,11 @@ use crate::types::block::{
             verify_allowed_unlock_conditions, verify_restricted_addresses, AddressUnlockCondition,
             StorageDepositReturnUnlockCondition, UnlockCondition, UnlockConditionFlags, UnlockConditions,
         },
-        MinimumOutputAmount, NativeToken, Output, OutputBuilderAmount, StorageScore, StorageScoreParameters,
+        DecayedMana, MinimumOutputAmount, NativeToken, Output, OutputBuilderAmount, StorageScore,
+        StorageScoreParameters,
     },
     protocol::{ProtocolParameters, WorkScore, WorkScoreParameters},
+    slot::SlotIndex,
     Error,
 };
 
@@ -347,6 +349,40 @@ impl BasicOutput {
             .finish()
             .unwrap()
             .amount()
+    }
+
+    /// Returns all the mana held by the output, which is potential + stored, all decayed.
+    pub fn available_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<u64, Error> {
+        let decayed_mana = self.decayed_mana(protocol_parameters, creation_index, target_index)?;
+
+        decayed_mana
+            .stored
+            .checked_add(decayed_mana.potential)
+            .ok_or(Error::ConsumedManaOverflow)
+    }
+
+    /// Returns the decayed stored and potential mana of the output.
+    pub fn decayed_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<DecayedMana, Error> {
+        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
+        let generation_amount = self.amount().saturating_sub(min_deposit);
+        let stored_mana = protocol_parameters.mana_with_decay(self.mana(), creation_index, target_index)?;
+        let potential_mana =
+            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
+
+        Ok(DecayedMana {
+            stored: stored_mana,
+            potential: potential_mana,
+        })
     }
 }
 

--- a/sdk/src/types/block/output/delegation.rs
+++ b/sdk/src/types/block/output/delegation.rs
@@ -13,11 +13,11 @@ use crate::types::block::{
             verify_allowed_unlock_conditions, verify_restricted_addresses, UnlockCondition, UnlockConditionFlags,
             UnlockConditions,
         },
-        MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore, StorageScoreParameters,
+        DecayedMana, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore, StorageScoreParameters,
     },
     protocol::{ProtocolParameters, WorkScore, WorkScoreParameters},
     semantic::TransactionFailureReason,
-    slot::EpochIndex,
+    slot::{EpochIndex, SlotIndex},
     Error,
 };
 
@@ -329,6 +329,39 @@ impl DelegationOutput {
     #[inline(always)]
     pub fn chain_id(&self) -> ChainId {
         ChainId::Delegation(self.delegation_id)
+    }
+
+    /// Returns all the mana held by the output, which is potential + stored, all decayed.
+    pub fn available_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<u64, Error> {
+        let decayed_mana = self.decayed_mana(protocol_parameters, creation_index, target_index)?;
+
+        decayed_mana
+            .stored
+            .checked_add(decayed_mana.potential)
+            .ok_or(Error::ConsumedManaOverflow)
+    }
+
+    /// Returns the decayed stored and potential mana of the output.
+    pub fn decayed_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<DecayedMana, Error> {
+        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
+        let generation_amount = self.amount().saturating_sub(min_deposit);
+        let potential_mana =
+            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
+
+        Ok(DecayedMana {
+            stored: 0,
+            potential: potential_mana,
+        })
     }
 
     // Transition, just without full SemanticValidationContext.

--- a/sdk/src/types/block/output/foundry.rs
+++ b/sdk/src/types/block/output/foundry.rs
@@ -18,12 +18,13 @@ use crate::types::block::{
         account::AccountId,
         feature::{verify_allowed_features, Feature, FeatureFlags, Features, NativeTokenFeature},
         unlock_condition::{verify_allowed_unlock_conditions, UnlockCondition, UnlockConditionFlags, UnlockConditions},
-        ChainId, MinimumOutputAmount, NativeToken, Output, OutputBuilderAmount, StorageScore, StorageScoreParameters,
-        TokenId, TokenScheme,
+        ChainId, DecayedMana, MinimumOutputAmount, NativeToken, Output, OutputBuilderAmount, StorageScore,
+        StorageScoreParameters, TokenId, TokenScheme,
     },
     payload::signed_transaction::{TransactionCapabilities, TransactionCapabilityFlag},
     protocol::{ProtocolParameters, WorkScore, WorkScoreParameters},
     semantic::TransactionFailureReason,
+    slot::SlotIndex,
     Error,
 };
 
@@ -399,6 +400,39 @@ impl FoundryOutput {
     #[inline(always)]
     pub fn chain_id(&self) -> ChainId {
         ChainId::Foundry(self.id())
+    }
+
+    /// Returns all the mana held by the output, which is potential + stored, all decayed.
+    pub fn available_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<u64, Error> {
+        let decayed_mana = self.decayed_mana(protocol_parameters, creation_index, target_index)?;
+
+        decayed_mana
+            .stored
+            .checked_add(decayed_mana.potential)
+            .ok_or(Error::ConsumedManaOverflow)
+    }
+
+    /// Returns the decayed stored and potential mana of the output.
+    pub fn decayed_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<DecayedMana, Error> {
+        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
+        let generation_amount = self.amount().saturating_sub(min_deposit);
+        let potential_mana =
+            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
+
+        Ok(DecayedMana {
+            stored: 0,
+            potential: potential_mana,
+        })
     }
 
     // Transition, just without full SemanticValidationContext

--- a/sdk/src/types/block/output/mod.rs
+++ b/sdk/src/types/block/output/mod.rs
@@ -242,25 +242,14 @@ impl Output {
         creation_index: SlotIndex,
         target_index: SlotIndex,
     ) -> Result<DecayedMana, Error> {
-        let (amount, mana) = match self {
-            Self::Basic(output) => (output.amount(), output.mana()),
-            Self::Account(output) => (output.amount(), output.mana()),
-            Self::Anchor(output) => (output.amount(), output.mana()),
-            Self::Foundry(output) => (output.amount(), 0),
-            Self::Nft(output) => (output.amount(), output.mana()),
-            Self::Delegation(output) => (output.amount(), 0),
-        };
-
-        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
-        let generation_amount = amount.saturating_sub(min_deposit);
-        let stored_mana = protocol_parameters.mana_with_decay(mana, creation_index, target_index)?;
-        let potential_mana =
-            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
-
-        Ok(DecayedMana {
-            stored: stored_mana,
-            potential: potential_mana,
-        })
+        match self {
+            Self::Basic(output) => output.decayed_mana(protocol_parameters, creation_index, target_index),
+            Self::Account(output) => output.decayed_mana(protocol_parameters, creation_index, target_index),
+            Self::Anchor(output) => output.decayed_mana(protocol_parameters, creation_index, target_index),
+            Self::Foundry(output) => output.decayed_mana(protocol_parameters, creation_index, target_index),
+            Self::Nft(output) => output.decayed_mana(protocol_parameters, creation_index, target_index),
+            Self::Delegation(output) => output.decayed_mana(protocol_parameters, creation_index, target_index),
+        }
     }
 
     /// Returns the unlock conditions of an [`Output`], if any.

--- a/sdk/src/types/block/output/nft.rs
+++ b/sdk/src/types/block/output/nft.rs
@@ -18,11 +18,12 @@ use crate::types::block::{
             verify_allowed_unlock_conditions, verify_restricted_addresses, AddressUnlockCondition,
             StorageDepositReturnUnlockCondition, UnlockCondition, UnlockConditionFlags, UnlockConditions,
         },
-        BasicOutputBuilder, ChainId, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId, StorageScore,
-        StorageScoreParameters,
+        BasicOutputBuilder, ChainId, DecayedMana, MinimumOutputAmount, Output, OutputBuilderAmount, OutputId,
+        StorageScore, StorageScoreParameters,
     },
     protocol::{ProtocolParameters, WorkScore, WorkScoreParameters},
     semantic::TransactionFailureReason,
+    slot::SlotIndex,
     Error,
 };
 
@@ -404,6 +405,40 @@ impl NftOutput {
     /// Returns the nft address for this output.
     pub fn nft_address(&self, output_id: &OutputId) -> NftAddress {
         NftAddress::new(self.nft_id_non_null(output_id))
+    }
+
+    /// Returns all the mana held by the output, which is potential + stored, all decayed.
+    pub fn available_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<u64, Error> {
+        let decayed_mana = self.decayed_mana(protocol_parameters, creation_index, target_index)?;
+
+        decayed_mana
+            .stored
+            .checked_add(decayed_mana.potential)
+            .ok_or(Error::ConsumedManaOverflow)
+    }
+
+    /// Returns the decayed stored and potential mana of the output.
+    pub fn decayed_mana(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        creation_index: SlotIndex,
+        target_index: SlotIndex,
+    ) -> Result<DecayedMana, Error> {
+        let min_deposit = self.minimum_amount(protocol_parameters.storage_score_parameters());
+        let generation_amount = self.amount().saturating_sub(min_deposit);
+        let stored_mana = protocol_parameters.mana_with_decay(self.mana(), creation_index, target_index)?;
+        let potential_mana =
+            protocol_parameters.generate_mana_with_decay(generation_amount, creation_index, target_index)?;
+
+        Ok(DecayedMana {
+            stored: stored_mana,
+            potential: potential_mana,
+        })
     }
 
     // Transition, just without full SemanticValidationContext

--- a/sdk/src/wallet/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/minting/mint_native_token.rs
@@ -5,9 +5,7 @@ use primitive_types::U256;
 
 use crate::{
     client::{api::PreparedTransactionData, secret::SecretManage},
-    types::block::output::{
-        AccountOutputBuilder, FoundryOutputBuilder, Output, SimpleTokenScheme, TokenId, TokenScheme,
-    },
+    types::block::output::{FoundryOutputBuilder, Output, SimpleTokenScheme, TokenId, TokenScheme},
     wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Error, Wallet},
 };
 
@@ -96,19 +94,17 @@ where
 
         drop(wallet_data);
 
-        let account_output = if let Output::Account(account_output) = existing_account_output.output {
-            account_output
-        } else {
-            unreachable!("We checked if it's an account output before")
-        };
-        let foundry_output = if let Output::Foundry(foundry_output) = existing_foundry_output.output {
-            foundry_output
-        } else {
-            unreachable!("We checked if it's an foundry output before")
-        };
+        let foundry_output = existing_foundry_output.output.as_foundry();
 
-        // Create the next account output with the same data.
-        let new_account_output_builder = AccountOutputBuilder::from(&account_output);
+        let mut options = options.into();
+        if let Some(options) = options.as_mut() {
+            options.required_inputs.insert(existing_account_output.output_id);
+        } else {
+            options.replace(TransactionOptions {
+                required_inputs: [existing_account_output.output_id].into(),
+                ..Default::default()
+            });
+        }
 
         // Create next foundry output with minted native tokens
 
@@ -121,10 +117,9 @@ where
         )?);
 
         let new_foundry_output_builder =
-            FoundryOutputBuilder::from(&foundry_output).with_token_scheme(updated_token_scheme);
+            FoundryOutputBuilder::from(foundry_output).with_token_scheme(updated_token_scheme);
 
         let outputs = [
-            new_account_output_builder.finish_output()?,
             new_foundry_output_builder.finish_output()?,
             // Native Tokens will be added automatically in the remainder output in try_select_inputs()
         ];

--- a/sdk/src/wallet/operations/transaction/high_level/staking/end.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/staking/end.rs
@@ -12,14 +12,23 @@ where
     crate::wallet::Error: From<S::Error>,
     crate::client::Error: From<S::Error>,
 {
-    pub async fn end_staking(&self, account_id: AccountId) -> crate::wallet::Result<TransactionWithMetadata> {
-        let prepared = self.prepare_end_staking(account_id).await?;
+    pub async fn end_staking(
+        &self,
+        account_id: AccountId,
+        options: impl Into<Option<TransactionOptions>> + Send,
+    ) -> crate::wallet::Result<TransactionWithMetadata> {
+        let options = options.into();
+        let prepared = self.prepare_end_staking(account_id, options.clone()).await?;
 
-        self.sign_and_submit_transaction(prepared, None).await
+        self.sign_and_submit_transaction(prepared, options).await
     }
 
     /// Prepares the transaction for [Wallet::end_staking()].
-    pub async fn prepare_end_staking(&self, account_id: AccountId) -> crate::wallet::Result<PreparedTransactionData> {
+    pub async fn prepare_end_staking(
+        &self,
+        account_id: AccountId,
+        options: impl Into<Option<TransactionOptions>> + Send,
+    ) -> crate::wallet::Result<PreparedTransactionData> {
         log::debug!("[TRANSACTION] prepare_end_staking");
 
         let account_output_data = self
@@ -61,11 +70,6 @@ where
             .with_account_id(account_id)
             .with_features(features)
             .finish_output()?;
-
-        let options = TransactionOptions {
-            required_inputs: [account_output_data.output_id].into(),
-            ..Default::default()
-        };
 
         let transaction = self.prepare_transaction([output], options).await?;
 

--- a/sdk/src/wallet/operations/transaction/high_level/staking/extend.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/staking/extend.rs
@@ -16,10 +16,14 @@ where
         &self,
         account_id: AccountId,
         additional_epochs: u32,
+        options: impl Into<Option<TransactionOptions>> + Send,
     ) -> crate::wallet::Result<TransactionWithMetadata> {
-        let prepared = self.prepare_extend_staking(account_id, additional_epochs).await?;
+        let options = options.into();
+        let prepared = self
+            .prepare_extend_staking(account_id, additional_epochs, options.clone())
+            .await?;
 
-        self.sign_and_submit_transaction(prepared, None).await
+        self.sign_and_submit_transaction(prepared, options).await
     }
 
     /// Prepares the transaction for [Wallet::extend_staking()].
@@ -27,6 +31,7 @@ where
         &self,
         account_id: AccountId,
         additional_epochs: u32,
+        options: impl Into<Option<TransactionOptions>> + Send,
     ) -> crate::wallet::Result<PreparedTransactionData> {
         log::debug!("[TRANSACTION] prepare_extend_staking");
 
@@ -53,8 +58,6 @@ where
         let mut output_builder =
             AccountOutputBuilder::from(account_output_data.output.as_account()).with_account_id(account_id);
 
-        let mut options = TransactionOptions::default();
-
         // Just extend the end epoch if it's still possible
         if future_bounded_epoch <= staking_feature.end_epoch() {
             output_builder = output_builder.replace_feature(StakingFeature::new(
@@ -80,7 +83,6 @@ where
                 past_bounded_epoch,
                 end_epoch,
             ));
-            options.required_inputs = [account_output_data.output_id].into();
         }
 
         let output = output_builder.finish_output()?;

--- a/sdk/src/wallet/operations/transaction/input_selection.rs
+++ b/sdk/src/wallet/operations/transaction/input_selection.rs
@@ -147,7 +147,11 @@ where
         .with_burn(options.burn);
 
         if let (Some(account_id), Some(reference_mana_cost)) = (options.issuer_id, reference_mana_cost) {
-            input_selection = input_selection.with_min_mana_allotment(account_id, reference_mana_cost);
+            input_selection = input_selection.with_min_mana_allotment(
+                account_id,
+                reference_mana_cost,
+                options.allow_allotting_from_account_mana,
+            );
         }
 
         if !options.allow_additional_input_selection {

--- a/sdk/src/wallet/operations/transaction/options.rs
+++ b/sdk/src/wallet/operations/transaction/options.rs
@@ -36,6 +36,9 @@ pub struct TransactionOptions {
     pub allow_micro_amount: bool,
     /// Whether to allow the selection of additional inputs for this transaction.
     pub allow_additional_input_selection: bool,
+    /// Whether to allow allotting automatically calculated mana from the issuer account.
+    /// If this flag is disabled, additional inputs will be selected to cover the amount.
+    pub allow_allotting_from_account_mana: bool,
     /// Transaction capabilities.
     pub capabilities: Option<TransactionCapabilities>,
     /// Mana allotments for the transaction.
@@ -55,6 +58,7 @@ impl Default for TransactionOptions {
             note: Default::default(),
             allow_micro_amount: false,
             allow_additional_input_selection: true,
+            allow_allotting_from_account_mana: false,
             capabilities: Default::default(),
             mana_allotments: Default::default(),
             issuer_id: Default::default(),

--- a/sdk/tests/client/input_selection/outputs.rs
+++ b/sdk/tests/client/input_selection/outputs.rs
@@ -431,7 +431,7 @@ fn consolidate_with_min_allotment() {
         SLOT_COMMITMENT_ID,
         protocol_parameters,
     )
-    .with_min_mana_allotment(account_id_1, 10)
+    .with_min_mana_allotment(account_id_1, 10, true)
     .with_required_inputs(inputs.iter().map(|i| *i.output_id()))
     .select()
     .unwrap();


### PR DESCRIPTION
# Description of change

In order to provide more fine-grained control over ISA, I have added a new flag to the transaction options to control whether ISA can use account mana for allotments. It will only remove mana for the minimum allotment and only from an account output with the `account_id == issuer_id`. This extends to the CLI, so that for staking operations users can now set this flag.

I also reworked the way that the mana requirement selects inputs so that it can also add the output mana to the equation. This means that the calculation will be the same regardless of whether the inputs are passed in or added later.