### PR TITLE
Do not clone ledger in balance

### DIFF
--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -28,6 +28,7 @@ where
         let slot_index = self.client().get_slot_index().await?;
 
         let wallet_address = self.address().await;
+        let wallet_ledger = self.ledger().await;
         let network_id = protocol_parameters.network_id();
         let storage_score_params = protocol_parameters.storage_score_parameters();
 
@@ -36,14 +37,10 @@ where
         let mut total_native_tokens = NativeTokensBuilder::default();
 
         #[cfg(feature = "participation")]
-        let voting_output = self.ledger().await.get_voting_output()?;
+        let voting_output = wallet_ledger.get_voting_output()?;
 
-        let claimable_outputs = self.ledger().await.claimable_outputs(
-            &wallet_address,
-            OutputsToClaim::All,
-            slot_index,
-            &protocol_parameters,
-        )?;
+        let claimable_outputs =
+            wallet_ledger.claimable_outputs(&wallet_address, OutputsToClaim::All, slot_index, &protocol_parameters)?;
 
         #[cfg(feature = "participation")]
         {
@@ -54,7 +51,7 @@ where
             }
         }
 
-        for (output_id, output_data) in &self.ledger().await.unspent_outputs {
+        for (output_id, output_data) in &wallet_ledger.unspent_outputs {
             // Check if output is from the network we're currently connected to
             if output_data.network_id != network_id {
                 continue;
@@ -81,7 +78,7 @@ where
 
                     // Add storage deposit
                     balance.required_storage_deposit.account += storage_cost;
-                    if !self.ledger().await.locked_outputs.contains(output_id) {
+                    if !wallet_ledger.locked_outputs.contains(output_id) {
                         total_storage_cost += storage_cost;
                     }
 
@@ -93,7 +90,7 @@ where
                     balance.base_coin.total += foundry.amount();
                     // Add storage deposit
                     balance.required_storage_deposit.foundry += storage_cost;
-                    if !self.ledger().await.locked_outputs.contains(output_id) {
+                    if !wallet_ledger.locked_outputs.contains(output_id) {
                         total_storage_cost += storage_cost;
                     }
 
@@ -113,7 +110,7 @@ where
                     }
                     // Add storage deposit
                     balance.required_storage_deposit.delegation += storage_cost;
-                    if !self.ledger().await.locked_outputs.contains(output_id) {
+                    if !wallet_ledger.locked_outputs.contains(output_id) {
                         total_storage_cost += storage_cost;
                     }
 
@@ -146,14 +143,12 @@ where
                         // Add storage deposit
                         if output.is_basic() {
                             balance.required_storage_deposit.basic += storage_cost;
-                            if output.native_token().is_some()
-                                && !self.ledger().await.locked_outputs.contains(output_id)
-                            {
+                            if output.native_token().is_some() && !wallet_ledger.locked_outputs.contains(output_id) {
                                 total_storage_cost += storage_cost;
                             }
                         } else if output.is_nft() {
                             balance.required_storage_deposit.nft += storage_cost;
-                            if !self.ledger().await.locked_outputs.contains(output_id) {
+                            if !wallet_ledger.locked_outputs.contains(output_id) {
                                 total_storage_cost += storage_cost;
                             }
                         }
@@ -226,13 +221,13 @@ where
                                     // Amount for basic outputs isn't added to total storage cost if there aren't native
                                     // tokens, since we can spend it without burning.
                                     if output.native_token().is_some()
-                                        && !self.ledger().await.locked_outputs.contains(output_id)
+                                        && !wallet_ledger.locked_outputs.contains(output_id)
                                     {
                                         total_storage_cost += storage_cost;
                                     }
                                 } else if output.is_nft() {
                                     balance.required_storage_deposit.nft += storage_cost;
-                                    if !self.ledger().await.locked_outputs.contains(output_id) {
+                                    if !wallet_ledger.locked_outputs.contains(output_id) {
                                         total_storage_cost += storage_cost;
                                     }
                                 }
@@ -266,18 +261,18 @@ where
         }
 
         // for `available` get locked_outputs, sum outputs amount and subtract from total_amount
-        log::debug!("[BALANCE] locked outputs: {:#?}", self.ledger().await.locked_outputs);
+        log::debug!("[BALANCE] locked outputs: {:#?}", wallet_ledger.locked_outputs);
 
         let mut locked_amount = 0;
         let mut locked_mana = DecayedMana::default();
         let mut locked_native_tokens = NativeTokensBuilder::default();
 
-        for locked_output in &self.ledger().await.locked_outputs {
+        for locked_output in &wallet_ledger.locked_outputs {
             // Skip potentially_locked_outputs, as their amounts aren't added to the balance
             if balance.potentially_locked_outputs.contains_key(locked_output) {
                 continue;
             }
-            if let Some(output_data) = self.ledger().await.unspent_outputs.get(locked_output) {
+            if let Some(output_data) = wallet_ledger.unspent_outputs.get(locked_output) {
                 // Only check outputs that are in this network
                 if output_data.network_id == network_id {
                     locked_amount += output_data.output.amount();
@@ -316,9 +311,7 @@ where
                 }
             });
 
-            let metadata = self
-                .ledger()
-                .await
+            let metadata = wallet_ledger
                 .native_token_foundries
                 .get(&FoundryId::from(*native_token.token_id()))
                 .and_then(|foundry| foundry.immutable_features().metadata())

--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -72,7 +72,11 @@ where
                         slot_index,
                     )?;
                     // Add mana rewards
-                    if let Ok(response) = self.client().get_output_mana_rewards(output_id, slot_index).await {
+                    // NOTE: Block here because we really don't want to yield to the executor while we are holding the
+                    // ledger lock
+                    if let Ok(response) = tokio::runtime::Handle::current()
+                        .block_on(self.client().get_output_mana_rewards(output_id, slot_index))
+                    {
                         balance.mana.rewards += response.rewards;
                     }
 
@@ -105,7 +109,11 @@ where
                     // Add amount
                     balance.base_coin.total += delegation.amount();
                     // Add mana rewards
-                    if let Ok(response) = self.client().get_output_mana_rewards(output_id, slot_index).await {
+                    // NOTE: Block here because we really don't want to yield to the executor while we are holding the
+                    // ledger lock
+                    if let Ok(response) = tokio::runtime::Handle::current()
+                        .block_on(self.client().get_output_mana_rewards(output_id, slot_index))
+                    {
                         balance.mana.rewards += response.rewards;
                     }
                     // Add storage deposit


### PR DESCRIPTION
# Description of change

This PR removes the clone from balance, so the read lock is once again held across the balance process. I considered a method without holding the lock but it would still require locking while iterating the outputs, which is most of the process anyway. Instead, I used tokio's `block_on` function to avoid yielding when we are holding that lock.