### PR TITLE
Restore default sync options

### DIFF
--- a/sdk/src/wallet/storage/manager.rs
+++ b/sdk/src/wallet/storage/manager.rs
@@ -49,6 +49,11 @@ impl StorageManager {
         Ok(storage_manager)
     }
 
+    pub(crate) async fn save_wallet_ledger(&self, wallet_ledger: &WalletLedgerDto) -> crate::wallet::Result<()> {
+        self.set(WALLET_LEDGER_KEY, wallet_ledger).await?;
+        Ok(())
+    }
+
     pub(crate) async fn load_wallet_ledger(&self) -> crate::wallet::Result<Option<WalletLedger>> {
         if let Some(dto) = self.get::<WalletLedgerDto>(WALLET_LEDGER_KEY).await? {
             Ok(Some(WalletLedger::try_from_dto(dto)?))
@@ -57,18 +62,11 @@ impl StorageManager {
         }
     }
 
-    pub(crate) async fn save_wallet_ledger(&self, wallet_ledger: &WalletLedgerDto) -> crate::wallet::Result<()> {
-        self.set(WALLET_LEDGER_KEY, wallet_ledger).await?;
-        Ok(())
-    }
-
     pub(crate) async fn set_default_sync_options(&self, sync_options: &SyncOptions) -> crate::wallet::Result<()> {
         let key = format!("{WALLET_LEDGER_KEY}-{WALLET_SYNC_OPTIONS}");
         self.set(&key, &sync_options).await
     }
 
-    // TODO: call this method in wallet builder: https://github.com/iotaledger/iota-sdk/issues/2022
-    #[allow(dead_code)]
     pub(crate) async fn get_default_sync_options(&self) -> crate::wallet::Result<Option<SyncOptions>> {
         let key = format!("{WALLET_LEDGER_KEY}-{WALLET_SYNC_OPTIONS}");
         self.get(&key).await
@@ -144,12 +142,10 @@ mod tests {
     #[tokio::test]
     async fn save_load_wallet_builder() {
         let storage_manager = StorageManager::new(Memory::default(), None).await.unwrap();
-        assert!(
-            WalletBuilder::<SecretManager>::load(&storage_manager)
-                .await
-                .unwrap()
-                .is_none()
-        );
+        assert!(WalletBuilder::<SecretManager>::load(&storage_manager)
+            .await
+            .unwrap()
+            .is_none());
 
         let wallet_address = Bech32Address::new("rms".parse().unwrap(), Ed25519Address::null());
         let wallet_bip_path = Bip44::new(SHIMMER_COIN_TYPE);

--- a/sdk/src/wallet/storage/manager.rs
+++ b/sdk/src/wallet/storage/manager.rs
@@ -142,10 +142,12 @@ mod tests {
     #[tokio::test]
     async fn save_load_wallet_builder() {
         let storage_manager = StorageManager::new(Memory::default(), None).await.unwrap();
-        assert!(WalletBuilder::<SecretManager>::load(&storage_manager)
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            WalletBuilder::<SecretManager>::load(&storage_manager)
+                .await
+                .unwrap()
+                .is_none()
+        );
 
         let wallet_address = Bech32Address::new("rms".parse().unwrap(), Ed25519Address::null());
         let wallet_bip_path = Bip44::new(SHIMMER_COIN_TYPE);


### PR DESCRIPTION
# Description of change

Tries to restore default sync options from storage if available, otherwise uses `SyncOptions::default()`.

## Links to any relevant issues

Closes #2022 
