### PR TITLE
Python: change `BlockState` and `TransactionState` enums to hold `str` variants

### DIFF
--- a/bindings/python/iota_sdk/types/block/metadata.py
+++ b/bindings/python/iota_sdk/types/block/metadata.py
@@ -1,33 +1,7 @@
 # Copyright 2023 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 from enum import Enum, IntEnum
-from dataclasses import dataclass
-from typing import Optional
-
-from iota_sdk.types.common import json
-from iota_sdk.types.block.id import BlockId
-from iota_sdk.types.transaction_metadata import TransactionFailureReason, TransactionState
-
-
-@json
-@dataclass
-class BlockMetadata:
-    """Represents the metadata of a block.
-    Response of GET /api/core/v3/blocks/{blockId}/metadata.
-
-    Attributes:
-        block_state: The block state.
-        transaction_state: The transaction state.
-        block_failure_reason: The block failure reason.
-        transaction_failure_reason: The transaction failure reason.
-    """
-    block_id: BlockId
-    block_state: BlockState
-    transaction_state: Optional[TransactionState] = None
-    block_failure_reason: Optional[BlockFailureReason] = None
-    transaction_failure_reason: Optional[TransactionFailureReason] = None
 
 
 class BlockState(str, Enum):

--- a/bindings/python/iota_sdk/types/block/metadata.py
+++ b/bindings/python/iota_sdk/types/block/metadata.py
@@ -30,7 +30,7 @@ class BlockMetadata:
     transaction_failure_reason: Optional[TransactionFailureReason] = None
 
 
-class BlockState(Enum):
+class BlockState(str, Enum):
     """Describes the state of a block.
 
     Attributes:
@@ -41,12 +41,12 @@ class BlockState(Enum):
         Rejected: Rejected by the node, and user should reissue payload if it contains one.
         Failed: Not successfully issued due to failure reason.
     """
-    Pending = 0
-    Accepted = 1
-    Confirmed = 2
-    Finalized = 3
-    Rejected = 4
-    Failed = 5
+    Pending = 'pending'
+    Accepted = 'accepted'
+    Confirmed = 'confirmed'
+    Finalized = 'finalized'
+    Rejected = 'rejected'
+    Failed = 'failed'
 
 
 class BlockFailureReason(IntEnum):

--- a/bindings/python/iota_sdk/types/transaction_metadata.py
+++ b/bindings/python/iota_sdk/types/transaction_metadata.py
@@ -4,7 +4,7 @@
 from enum import Enum
 
 
-class TransactionState(Enum):
+class TransactionState(str, Enum):
     """Describes the state of a transaction.
 
     Attributes:
@@ -14,11 +14,11 @@ class TransactionState(Enum):
         Finalized: Included, its included block is finalized and cannot be reverted anymore.
         Failed: Not successfully issued due to failure reason.
     """
-    Pending = 0
-    Accepted = 1
-    Confirmed = 2
-    Finalized = 3
-    Failed = 4
+    Pending = 'pending'
+    Accepted = 'accepted'
+    Confirmed = 'confirmed'
+    Finalized = 'finalized'
+    Failed = 'failed'
 
 
 class TransactionFailureReason(Enum):

--- a/bindings/python/tests/test_api_responses.py
+++ b/bindings/python/tests/test_api_responses.py
@@ -3,7 +3,7 @@
 
 from typing import Generic, TypeVar
 from json import load, loads, dumps
-from iota_sdk import RoutesResponse, CongestionResponse, ManaRewardsResponse, ValidatorResponse, CommitteeResponse, IssuanceBlockHeaderResponse, Block, OutputMetadata, OutputResponse, SlotCommitment, UtxoChangesResponse, UtxoChangesFullResponse
+from iota_sdk import RoutesResponse, CongestionResponse, ManaRewardsResponse, ValidatorResponse, CommitteeResponse, IssuanceBlockHeaderResponse, Block, BlockMetadataResponse, BlockWithMetadataResponse, OutputMetadata, OutputResponse, TransactionMetadataResponse, SlotCommitment, UtxoChangesResponse, UtxoChangesFullResponse
 
 
 base_path = '../../sdk/tests/types/api/fixtures/'
@@ -51,20 +51,19 @@ def test_api_responses():
     test_api_response(
         Block, "get-block-by-id-validation-response-example.json")
     # GET /api/core/v3/blocks/{blockId}/metadata
-    # TODO enable when Block and Tx State enums are fixed https://github.com/iotaledger/iota-sdk/issues/2019
-    # test_api_response(BlockMetadataResponse,
-    #                   "get-block-by-id-response-example-new-transaction.json")
-    # test_api_response(BlockMetadataResponse,
-    #                   "get-block-by-id-response-example-new.json")
-    # test_api_response(BlockMetadataResponse,
-    #                   "get-block-by-id-response-example-confirmed-transaction.json")
-    # test_api_response(BlockMetadataResponse,
-    #                   "get-block-by-id-response-example-confirmed.json")
-    # test_api_response(BlockMetadataResponse,
-    #                   "get-block-by-id-response-example-conflicting-transaction.json")
-    # # GET /api/core/v3/blocks/{blockId}/full
-    # test_api_response(BlockWithMetadataResponse,
-    #                   "get-full-block-by-id-tagged-data-response-example.json")
+    test_api_response(BlockMetadataResponse,
+                      "get-block-by-id-response-example-new-transaction.json")
+    test_api_response(BlockMetadataResponse,
+                      "get-block-by-id-response-example-new.json")
+    test_api_response(BlockMetadataResponse,
+                      "get-block-by-id-response-example-confirmed-transaction.json")
+    test_api_response(BlockMetadataResponse,
+                      "get-block-by-id-response-example-confirmed.json")
+    test_api_response(BlockMetadataResponse,
+                      "get-block-by-id-response-example-conflicting-transaction.json")
+    # GET /api/core/v3/blocks/{blockId}/full
+    test_api_response(BlockWithMetadataResponse,
+                      "get-full-block-by-id-tagged-data-response-example.json")
     # GET /api/core/v3/outputs/{outputId}
     test_api_response(
         OutputResponse, "get-outputs-by-id-response-example.json")
@@ -78,9 +77,8 @@ def test_api_responses():
     # test_api_response(OutputWithMetadata,
     #                   "get-full-output-metadata-example.json")
     # GET /api/core/v3/transactions/{transactionId}/metadata
-    # TODO enable when Tx State enum is fixed https://github.com/iotaledger/iota-sdk/issues/2019
-    # test_api_response(TransactionMetadataResponse,
-    #                   "get-transaction-metadata-by-id-response-example.json")
+    test_api_response(TransactionMetadataResponse,
+                      "get-transaction-metadata-by-id-response-example.json")
     # GET /api/core/v3/commitments/{commitmentId}
     test_api_response(SlotCommitment, "get-commitment-response-example.json")
     # GET /api/core/v3/commitments/{commitmentId}/utxo-changes


### PR DESCRIPTION
# Description of change

Changes `BlockState` and `TransactionState` enum variants from `int`egers to `str`ings.

## Links to any relevant issues

Closed #2019 

## Open questions

Should we still add methods to convert from/to `int`s?
