### PR TITLE
Remove Bip44Address, AddressWithUnspentOutputs::{key_index, internal}

### DIFF
--- a/bindings/nodejs/lib/types/wallet/address.ts
+++ b/bindings/nodejs/lib/types/wallet/address.ts
@@ -5,16 +5,6 @@ import { SlotIndex } from '../block/slot';
 import { Bech32Address, NftId, TokenId } from '../block';
 import { NumericString, u256, u64 } from '../utils';
 
-/** A Bip44 address */
-export interface Bip44Address {
-    /** The Bech32 address. */
-    address: Bech32Address;
-    /** The address key index. */
-    keyIndex: number;
-    /** Whether the address is a public or an internal (change) address. */
-    internal: boolean;
-}
-
 /** Address with a base token amount */
 export interface SendParams {
     /** The Bech32 address to send the amount to. */

--- a/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
+++ b/sdk/examples/wallet/offline_signing/1_prepare_transaction.rs
@@ -11,7 +11,8 @@
 use iota_sdk::{
     client::{api::PreparedTransactionDataDto, constants::SHIMMER_COIN_TYPE, secret::SecretManager},
     crypto::keys::bip44::Bip44,
-    wallet::{types::Bip44Address, ClientOptions, Result, SendParams, Wallet},
+    types::block::address::Bech32Address,
+    wallet::{ClientOptions, Result, SendParams, Wallet},
 };
 
 const ONLINE_WALLET_DB_PATH: &str = "./examples/wallet/offline_signing/example-online-walletdb";
@@ -35,7 +36,7 @@ async fn main() -> Result<()> {
     let params = [SendParams::new(SEND_AMOUNT, RECV_ADDRESS)?];
 
     // Recovers addresses from example `0_address_generation`.
-    let address = read_address_from_file().await?.into_bech32();
+    let address = read_address_from_file().await?;
 
     let client_options = ClientOptions::new().with_node(&std::env::var("NODE_URL").unwrap())?;
 
@@ -71,7 +72,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn read_address_from_file() -> Result<Bip44Address> {
+async fn read_address_from_file() -> Result<Bech32Address> {
     use tokio::io::AsyncReadExt;
 
     let mut file = tokio::io::BufReader::new(tokio::fs::File::open(ADDRESS_FILE_PATH).await?);

--- a/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
+++ b/sdk/src/client/api/block_builder/input_selection/requirement/mana.rs
@@ -118,10 +118,8 @@ impl InputSelection {
         let additional_inputs = self.get_inputs_for_mana_balance()?;
         // If we needed more inputs to cover the additional allotment mana
         // then update remainders and re-run this requirement
-        if additional_inputs {
-            if !self.requirements.contains(&Requirement::Mana) {
-                self.requirements.push(Requirement::Mana);
-            }
+        if additional_inputs && !self.requirements.contains(&Requirement::Mana) {
+            self.requirements.push(Requirement::Mana);
         }
 
         Ok(Vec::new())

--- a/sdk/src/client/node_manager/syncing.rs
+++ b/sdk/src/client/node_manager/syncing.rs
@@ -71,7 +71,7 @@ impl Client {
         for node in nodes {
             // Put the healthy node url into the network_nodes
             if node.permanode {
-                match crate::client::Client::get_permanode_info(node.clone()).await {
+                match Self::get_permanode_info(node.clone()).await {
                     Ok(info) => {
                         if info.is_healthy || ignore_node_health {
                             // Unwrap: We should always have parameters for this version. If we don't we can't recover.
@@ -101,7 +101,7 @@ impl Client {
                     }
                 }
             } else {
-                match crate::client::Client::get_node_info(node.url.as_ref(), node.auth.clone()).await {
+                match Self::get_node_info(node.url.as_ref(), node.auth.clone()).await {
                     Ok(info) => {
                         if info.status.is_healthy || ignore_node_health {
                             // Unwrap: We should always have parameters for this version. If we don't we can't recover.

--- a/sdk/src/types/block/protocol/samples.rs
+++ b/sdk/src/types/block/protocol/samples.rs
@@ -242,7 +242,7 @@ impl ProtocolParameters {
         self.rewards_parameters.final_target_rewards_rate = (self.token_supply()
             * self.rewards_parameters().reward_to_generation_ratio() as u64
             * self.mana_parameters().generation_rate() as u64)
-            >> self.mana_parameters().generation_rate_exponent() - self.slots_per_epoch_exponent();
+            >> (self.mana_parameters().generation_rate_exponent() - self.slots_per_epoch_exponent());
         let bootstrapping_duration_years =
             self.rewards_parameters().bootstrapping_duration() as f64 * self.epochs_per_year().exp();
         self.rewards_parameters.initial_target_rewards_rate = (self.rewards_parameters.final_target_rewards_rate as f64

--- a/sdk/src/wallet/operations/syncing/mod.rs
+++ b/sdk/src/wallet/operations/syncing/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     wallet::{
         constants::MIN_SYNC_INTERVAL,
-        types::{AddressWithUnspentOutputs, Balance, OutputData},
+        types::{address::AddressWithUnspentOutputs, Balance, OutputData},
         Wallet,
     },
 };
@@ -97,8 +97,6 @@ where
         let wallet_address_with_unspent_outputs = AddressWithUnspentOutputs {
             address: self.address().await,
             output_ids: self.ledger().await.unspent_outputs().keys().copied().collect(),
-            internal: false,
-            key_index: 0,
         };
 
         let address_to_sync = vec![
@@ -106,8 +104,6 @@ where
             AddressWithUnspentOutputs {
                 address: self.implicit_account_creation_address().await?,
                 output_ids: vec![],
-                internal: false,
-                key_index: 0,
             },
         ];
 

--- a/sdk/src/wallet/types/address.rs
+++ b/sdk/src/wallet/types/address.rs
@@ -1,69 +1,18 @@
 // Copyright 2021 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::hash::Hash;
-
 use getset::{Getters, Setters};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    types::{
-        self,
-        block::{address::Bech32Address, output::OutputId},
-    },
-    utils::ConvertTo,
-};
-
-/// A BIP44 address.
-#[derive(Debug, Getters, Setters, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
-#[serde(rename_all = "camelCase")]
-#[getset(get = "pub")]
-pub struct Bip44Address {
-    /// The address.
-    pub(crate) address: Bech32Address,
-    /// The address key index.
-    #[getset(set = "pub(crate)")]
-    pub(crate) key_index: u32,
-    /// Determines if an address is a public or an internal (change) address.
-    #[getset(set = "pub(crate)")]
-    pub(crate) internal: bool,
-}
-
-impl Bip44Address {
-    pub fn into_bech32(self) -> Bech32Address {
-        self.address
-    }
-}
-
-impl ConvertTo<Bech32Address> for Bip44Address {
-    fn convert(self) -> Result<Bech32Address, types::block::Error> {
-        Ok(self.address)
-    }
-
-    fn convert_unchecked(self) -> Bech32Address {
-        self.address
-    }
-}
+use crate::types::block::{address::Bech32Address, output::OutputId};
 
 /// An account address with unspent output_ids for unspent outputs.
 #[derive(Debug, Getters, Setters, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[getset(get = "pub")]
-pub struct AddressWithUnspentOutputs {
+pub(crate) struct AddressWithUnspentOutputs {
     /// The address.
     pub(crate) address: Bech32Address,
-    /// The address key index.
-    #[getset(set = "pub(crate)")]
-    pub(crate) key_index: u32,
-    /// Determines if an address is a public or an internal (change) address.
-    #[getset(set = "pub(crate)")]
-    pub(crate) internal: bool,
     /// Output ids
     pub(crate) output_ids: Vec<OutputId>,
-}
-
-impl AddressWithUnspentOutputs {
-    pub fn into_bech32(self) -> Bech32Address {
-        self.address
-    }
 }

--- a/sdk/src/wallet/types/mod.rs
+++ b/sdk/src/wallet/types/mod.rs
@@ -12,10 +12,7 @@ use std::str::FromStr;
 use crypto::keys::bip44::Bip44;
 use serde::{Deserialize, Serialize};
 
-pub use self::{
-    address::{AddressWithUnspentOutputs, Bip44Address},
-    balance::{Balance, BaseCoinBalance, NativeTokensBalance, RequiredStorageDeposit},
-};
+pub use self::balance::{Balance, BaseCoinBalance, NativeTokensBalance, RequiredStorageDeposit};
 use crate::{
     client::secret::types::InputSigningData,
     types::{


### PR DESCRIPTION
# Description of change

Remove Bip44Address, AddressWithUnspentOutputs::{key_index, internal} as they are no longer needed
Also made `AddressWithUnspentOutputs` private since we don't need it exposed

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-sdk/issues/2025

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

`cargo test`