### PR TITLE
Add missing #[serde(with = "string")], clippy

### DIFF
--- a/sdk/src/client/api/block_builder/transaction.rs
+++ b/sdk/src/client/api/block_builder/transaction.rs
@@ -47,7 +47,7 @@ pub fn verify_semantic(
         protocol_parameters,
     );
 
-    Ok(context.validate()?)
+    context.validate()
 }
 
 /// Verifies that the signed transaction payload doesn't exceed the block size limit with 8 parents.

--- a/sdk/src/types/block/core/block.rs
+++ b/sdk/src/types/block/core/block.rs
@@ -296,7 +296,7 @@ impl Packable for Block {
         };
 
         if let Some(protocol_params) = protocol_params {
-            verify_block_slot(&block.header, &block.body, &protocol_params).map_err(UnpackError::Packable)?;
+            verify_block_slot(&block.header, &block.body, protocol_params).map_err(UnpackError::Packable)?;
 
             let block_len = if let (Some(start), Some(end)) = (start_opt, unpacker.read_bytes()) {
                 end - start

--- a/sdk/src/types/block/semantic/mod.rs
+++ b/sdk/src/types/block/semantic/mod.rs
@@ -261,9 +261,7 @@ impl<'a> SemanticValidationContext<'a> {
                     return Err(TransactionFailureReason::SemanticValidationFailed);
                 }
 
-                if let Err(conflict) = self.output_unlock(consumed_output, output_id, &unlocks[index]) {
-                    return Err(conflict);
-                }
+                self.output_unlock(consumed_output, output_id, &unlocks[index])?
             }
         }
 

--- a/sdk/src/wallet/operations/transaction/high_level/delegation/create.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/delegation/create.rs
@@ -9,6 +9,7 @@ use crate::{
         address::{AccountAddress, Bech32Address},
         output::{unlock_condition::AddressUnlockCondition, DelegationId, DelegationOutputBuilder},
     },
+    utils::serde::string,
     wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet},
 };
 
@@ -21,6 +22,7 @@ pub struct CreateDelegationParams {
     // TODO: https://github.com/iotaledger/iota-sdk/issues/1888
     pub address: Option<Bech32Address>,
     /// The amount to delegate.
+    #[serde(with = "string")]
     pub delegated_amount: u64,
     /// The Account Address of the validator to which this output will delegate.
     pub validator_address: AccountAddress,

--- a/sdk/src/wallet/operations/transaction/high_level/staking/begin.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/staking/begin.rs
@@ -9,6 +9,7 @@ use crate::{
         output::{feature::StakingFeature, AccountId, AccountOutputBuilder},
         slot::EpochIndex,
     },
+    utils::serde::string,
     wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet},
 };
 
@@ -19,8 +20,10 @@ pub struct BeginStakingParams {
     /// The account id which will begin staking.
     pub account_id: AccountId,
     /// The amount of tokens to stake.
+    #[serde(with = "string")]
     pub staked_amount: u64,
     /// The fixed cost of the validator, which it receives as part of its Mana rewards.
+    #[serde(with = "string")]
     pub fixed_cost: u64,
     /// The staking period (in epochs). Will default to the staking unbonding period.
     pub staking_period: Option<u32>,


### PR DESCRIPTION
# Description of change

Add missing #[serde(with = "string")] for u64 values because otherwise there could be overflow issues in bindings, clippy

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/2083

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

