### PR TITLE
Remove result types and clean up errors

### DIFF
--- a/bindings/core/src/error.rs
+++ b/bindings/core/src/error.rs
@@ -8,9 +8,6 @@ use iota_sdk::types::block::{
 use packable::error::UnexpectedEOF;
 use serde::{Serialize, Serializer};
 
-/// Result type of the bindings core crate.
-pub type Result<T> = std::result::Result<T, Error>;
-
 /// Error type for the bindings core crate.
 #[derive(Debug, thiserror::Error, strum::AsRefStr)]
 #[strum(serialize_all = "camelCase")]
@@ -36,10 +33,10 @@ pub enum Error {
     TransactionSemantic(#[from] TransactionFailureReason),
     /// Client errors.
     #[error("{0}")]
-    Client(#[from] iota_sdk::client::Error),
+    Client(#[from] iota_sdk::client::ClientError),
     /// Wallet errors.
     #[error("{0}")]
-    Wallet(#[from] iota_sdk::wallet::Error),
+    Wallet(#[from] iota_sdk::wallet::WalletError),
     /// Prefix hex errors.
     #[error("{0}")]
     PrefixHex(#[from] prefix_hex::Error),
@@ -54,14 +51,14 @@ pub enum Error {
 #[cfg(feature = "stronghold")]
 impl From<iota_sdk::client::stronghold::Error> for Error {
     fn from(error: iota_sdk::client::stronghold::Error) -> Self {
-        Self::Client(iota_sdk::client::Error::Stronghold(error))
+        Self::Client(iota_sdk::client::ClientError::Stronghold(error))
     }
 }
 
 #[cfg(feature = "mqtt")]
 impl From<iota_sdk::client::node_api::mqtt::Error> for Error {
     fn from(error: iota_sdk::client::node_api::mqtt::Error) -> Self {
-        Self::Client(iota_sdk::client::Error::Mqtt(error))
+        Self::Client(iota_sdk::client::ClientError::Mqtt(error))
     }
 }
 

--- a/bindings/core/src/lib.rs
+++ b/bindings/core/src/lib.rs
@@ -19,7 +19,7 @@ use iota_sdk::{
     client::secret::{SecretManager, SecretManagerDto},
     types::block::address::Bech32Address,
     utils::serde::bip44::option_bip44,
-    wallet::{ClientOptions, Wallet},
+    wallet::{ClientOptions, Wallet, WalletError},
 };
 use serde::Deserialize;
 
@@ -28,7 +28,7 @@ pub use self::method_handler::listen_mqtt;
 #[cfg(not(target_family = "wasm"))]
 pub use self::method_handler::CallMethod;
 pub use self::{
-    error::{Error, Result},
+    error::Error,
     method::{ClientMethod, SecretManagerMethod, UtilsMethod, WalletMethod},
     method_handler::{call_client_method, call_secret_manager_method, call_utils_method, call_wallet_method},
     response::Response,
@@ -86,7 +86,7 @@ impl WalletOptions {
         self
     }
 
-    pub async fn build(self) -> iota_sdk::wallet::Result<Wallet> {
+    pub async fn build(self) -> Result<Wallet, WalletError> {
         log::debug!("wallet options: {self:?}");
         let mut builder = Wallet::builder()
             .with_address(self.address)

--- a/bindings/core/src/method_handler/call_method.rs
+++ b/bindings/core/src/method_handler/call_method.rs
@@ -85,7 +85,7 @@ pub async fn call_secret_manager_method<S: SecretManage + DowncastSecretManager>
     method: SecretManagerMethod,
 ) -> Response
 where
-    iota_sdk::client::Error: From<S::Error>,
+    iota_sdk::client::ClientError: From<S::Error>,
 {
     log::debug!("Secret manager method: {method:?}");
     let result =

--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -17,7 +17,7 @@ use iota_sdk::{
     },
 };
 
-use crate::{method::ClientMethod, response::Response, Result};
+use crate::{method::ClientMethod, response::Response};
 
 /// Listen to MQTT events
 #[cfg(feature = "mqtt")]
@@ -52,7 +52,10 @@ where
 }
 
 /// Call a client method.
-pub(crate) async fn call_client_method_internal(client: &Client, method: ClientMethod) -> Result<Response> {
+pub(crate) async fn call_client_method_internal(
+    client: &Client,
+    method: ClientMethod,
+) -> Result<Response, crate::Error> {
     let response = match method {
         ClientMethod::BuildAccountOutput {
             amount,

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -16,15 +16,15 @@ use iota_sdk::{
     },
 };
 
-use crate::{method::SecretManagerMethod, response::Response, Result};
+use crate::{method::SecretManagerMethod, response::Response};
 
 /// Call a secret manager method.
 pub(crate) async fn call_secret_manager_method_internal<S: SecretManage + DowncastSecretManager>(
     secret_manager: &S,
     method: SecretManagerMethod,
-) -> Result<Response>
+) -> Result<Response, crate::Error>
 where
-    iota_sdk::client::Error: From<S::Error>,
+    iota_sdk::client::ClientError: From<S::Error>,
 {
     let response = match method {
         SecretManagerMethod::GenerateEd25519Addresses {
@@ -40,7 +40,7 @@ where
             let addresses = secret_manager
                 .generate_ed25519_addresses(coin_type, account_index, range, options)
                 .await
-                .map_err(iota_sdk::client::Error::from)?
+                .map_err(iota_sdk::client::ClientError::from)?
                 .into_iter()
                 .map(|a| a.to_bech32(bech32_hrp))
                 .collect();
@@ -59,7 +59,7 @@ where
             let addresses = secret_manager
                 .generate_evm_addresses(coin_type, account_index, range, options)
                 .await
-                .map_err(iota_sdk::client::Error::from)?
+                .map_err(iota_sdk::client::ClientError::from)?
                 .into_iter()
                 .map(|a| prefix_hex::encode(a.as_ref()))
                 .collect();
@@ -72,7 +72,7 @@ where
             } else if let Some(SecretManager::LedgerNano(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
             };
             Response::LedgerNanoStatus(secret_manager.get_ledger_nano_status().await)
         }
@@ -86,7 +86,7 @@ where
                     &protocol_parameters,
                 )
                 .await
-                .map_err(iota_sdk::client::Error::from)?;
+                .map_err(iota_sdk::client::ClientError::from)?;
             Response::SignedTransaction(transaction.into())
         }
         SecretManagerMethod::SignBlock { unsigned_block, chain } => Response::Block(BlockDto::from(
@@ -102,7 +102,7 @@ where
             let unlock: Unlock = secret_manager
                 .signature_unlock(&transaction_signing_hash, chain)
                 .await
-                .map_err(iota_sdk::client::Error::from)?;
+                .map_err(iota_sdk::client::ClientError::from)?;
 
             Response::SignatureUnlock(unlock)
         }
@@ -111,7 +111,7 @@ where
             let signature = secret_manager
                 .sign_ed25519(&msg, chain)
                 .await
-                .map_err(iota_sdk::client::Error::from)?;
+                .map_err(iota_sdk::client::ClientError::from)?;
             Response::Ed25519Signature(signature)
         }
         SecretManagerMethod::SignSecp256k1Ecdsa { message, chain } => {
@@ -119,7 +119,7 @@ where
             let (public_key, signature) = secret_manager
                 .sign_secp256k1_ecdsa(&msg, chain)
                 .await
-                .map_err(iota_sdk::client::Error::from)?;
+                .map_err(iota_sdk::client::ClientError::from)?;
             Response::Secp256k1EcdsaSignature {
                 public_key: prefix_hex::encode(public_key.to_bytes()),
                 signature: prefix_hex::encode(signature.to_bytes()),
@@ -135,7 +135,7 @@ where
                 secret_manager.store_mnemonic(mnemonic).await?;
                 Response::Ok
             } else {
-                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
             }
         }
         #[cfg(feature = "stronghold")]
@@ -145,7 +145,7 @@ where
             } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
             };
             stronghold.set_password(password).await?;
             Response::Ok
@@ -157,7 +157,7 @@ where
             } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
             };
             stronghold.change_password(password).await?;
             Response::Ok
@@ -169,7 +169,7 @@ where
             } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::Error::SecretManagerMismatch.into());
+                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
             };
             stronghold.clear_key().await;
             Response::Ok

--- a/bindings/core/src/method_handler/secret_manager.rs
+++ b/bindings/core/src/method_handler/secret_manager.rs
@@ -9,6 +9,7 @@ use iota_sdk::{
     client::{
         api::{GetAddressesOptions, PreparedTransactionData},
         secret::{DowncastSecretManager, SecretManage, SignBlock},
+        ClientError,
     },
     types::{
         block::{address::ToBech32Ext, core::UnsignedBlock, unlock::Unlock, BlockDto},
@@ -24,7 +25,7 @@ pub(crate) async fn call_secret_manager_method_internal<S: SecretManage + Downca
     method: SecretManagerMethod,
 ) -> Result<Response, crate::Error>
 where
-    iota_sdk::client::ClientError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     let response = match method {
         SecretManagerMethod::GenerateEd25519Addresses {
@@ -40,7 +41,7 @@ where
             let addresses = secret_manager
                 .generate_ed25519_addresses(coin_type, account_index, range, options)
                 .await
-                .map_err(iota_sdk::client::ClientError::from)?
+                .map_err(ClientError::from)?
                 .into_iter()
                 .map(|a| a.to_bech32(bech32_hrp))
                 .collect();
@@ -59,7 +60,7 @@ where
             let addresses = secret_manager
                 .generate_evm_addresses(coin_type, account_index, range, options)
                 .await
-                .map_err(iota_sdk::client::ClientError::from)?
+                .map_err(ClientError::from)?
                 .into_iter()
                 .map(|a| prefix_hex::encode(a.as_ref()))
                 .collect();
@@ -72,7 +73,7 @@ where
             } else if let Some(SecretManager::LedgerNano(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
+                return Err(ClientError::SecretManagerMismatch.into());
             };
             Response::LedgerNanoStatus(secret_manager.get_ledger_nano_status().await)
         }
@@ -86,7 +87,7 @@ where
                     &protocol_parameters,
                 )
                 .await
-                .map_err(iota_sdk::client::ClientError::from)?;
+                .map_err(ClientError::from)?;
             Response::SignedTransaction(transaction.into())
         }
         SecretManagerMethod::SignBlock { unsigned_block, chain } => Response::Block(BlockDto::from(
@@ -102,7 +103,7 @@ where
             let unlock: Unlock = secret_manager
                 .signature_unlock(&transaction_signing_hash, chain)
                 .await
-                .map_err(iota_sdk::client::ClientError::from)?;
+                .map_err(ClientError::from)?;
 
             Response::SignatureUnlock(unlock)
         }
@@ -111,7 +112,7 @@ where
             let signature = secret_manager
                 .sign_ed25519(&msg, chain)
                 .await
-                .map_err(iota_sdk::client::ClientError::from)?;
+                .map_err(ClientError::from)?;
             Response::Ed25519Signature(signature)
         }
         SecretManagerMethod::SignSecp256k1Ecdsa { message, chain } => {
@@ -119,7 +120,7 @@ where
             let (public_key, signature) = secret_manager
                 .sign_secp256k1_ecdsa(&msg, chain)
                 .await
-                .map_err(iota_sdk::client::ClientError::from)?;
+                .map_err(ClientError::from)?;
             Response::Secp256k1EcdsaSignature {
                 public_key: prefix_hex::encode(public_key.to_bytes()),
                 signature: prefix_hex::encode(signature.to_bytes()),
@@ -135,7 +136,7 @@ where
                 secret_manager.store_mnemonic(mnemonic).await?;
                 Response::Ok
             } else {
-                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
+                return Err(ClientError::SecretManagerMismatch.into());
             }
         }
         #[cfg(feature = "stronghold")]
@@ -145,7 +146,7 @@ where
             } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
+                return Err(ClientError::SecretManagerMismatch.into());
             };
             stronghold.set_password(password).await?;
             Response::Ok
@@ -157,7 +158,7 @@ where
             } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
+                return Err(ClientError::SecretManagerMismatch.into());
             };
             stronghold.change_password(password).await?;
             Response::Ok
@@ -169,7 +170,7 @@ where
             } else if let Some(SecretManager::Stronghold(secret_manager)) = secret_manager.downcast::<SecretManager>() {
                 secret_manager
             } else {
-                return Err(iota_sdk::client::ClientError::SecretManagerMismatch.into());
+                return Err(ClientError::SecretManagerMismatch.into());
             };
             stronghold.clear_key().await;
             Response::Ok

--- a/bindings/core/src/method_handler/wallet.rs
+++ b/bindings/core/src/method_handler/wallet.rs
@@ -16,7 +16,10 @@ use iota_sdk::{
 use crate::{method::WalletMethod, response::Response};
 
 /// Call a wallet method.
-pub(crate) async fn call_wallet_method_internal(wallet: &Wallet, method: WalletMethod) -> crate::Result<Response> {
+pub(crate) async fn call_wallet_method_internal(
+    wallet: &Wallet,
+    method: WalletMethod,
+) -> Result<Response, crate::Error> {
     let response = match method {
         WalletMethod::Accounts => Response::OutputsData(wallet.ledger().await.accounts().cloned().collect()),
         #[cfg(feature = "stronghold")]
@@ -210,7 +213,7 @@ pub(crate) async fn call_wallet_method_internal(wallet: &Wallet, method: WalletM
         } => {
             let data = if let Some(public_key_str) = public_key {
                 let public_key = PublicKey::try_from_bytes(prefix_hex::decode(public_key_str)?)
-                    .map_err(iota_sdk::wallet::Error::from)?;
+                    .map_err(iota_sdk::wallet::WalletError::from)?;
                 wallet
                     .prepare_implicit_account_transition(&output_id, public_key)
                     .await?

--- a/bindings/core/src/panic.rs
+++ b/bindings/core/src/panic.rs
@@ -39,9 +39,9 @@ where
 
 #[cfg(target_family = "wasm")]
 #[allow(clippy::future_not_send)]
-pub(crate) async fn convert_async_panics<F>(f: impl FnOnce() -> F) -> Result<Response>
+pub(crate) async fn convert_async_panics<F>(f: impl FnOnce() -> F) -> Result<Response, crate::Error>
 where
-    F: Future<Output = Result<Response>>,
+    F: Future<Output = Result<Response, crate::Error>>,
 {
     AssertUnwindSafe(f())
         .catch_unwind()

--- a/bindings/core/src/panic.rs
+++ b/bindings/core/src/panic.rs
@@ -9,7 +9,7 @@ use std::{
 use backtrace::Backtrace;
 use futures::{Future, FutureExt};
 
-use crate::{response::Response, Result};
+use crate::response::Response;
 
 fn panic_to_response_message(panic: Box<dyn Any>) -> Response {
     let msg = panic.downcast_ref::<String>().map_or_else(
@@ -27,9 +27,9 @@ fn panic_to_response_message(panic: Box<dyn Any>) -> Response {
 }
 
 #[cfg(not(target_family = "wasm"))]
-pub(crate) async fn convert_async_panics<F>(f: impl FnOnce() -> F + Send) -> Result<Response>
+pub(crate) async fn convert_async_panics<F>(f: impl FnOnce() -> F + Send) -> Result<Response, crate::Error>
 where
-    F: Future<Output = Result<Response>> + Send,
+    F: Future<Output = Result<Response, crate::Error>> + Send,
 {
     AssertUnwindSafe(f())
         .catch_unwind()
@@ -49,7 +49,7 @@ where
         .unwrap_or_else(|panic| Ok(panic_to_response_message(panic)))
 }
 
-pub(crate) fn convert_panics<F: FnOnce() -> Result<Response>>(f: F) -> Result<Response> {
+pub(crate) fn convert_panics<F: FnOnce() -> Result<Response, crate::Error>>(f: F) -> Result<Response, crate::Error> {
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(result) => result,
         Err(panic) => Ok(panic_to_response_message(panic)),

--- a/bindings/core/tests/combined.rs
+++ b/bindings/core/tests/combined.rs
@@ -17,14 +17,14 @@ use iota_sdk::{
     },
 };
 use iota_sdk_bindings_core::{
-    call_client_method, call_secret_manager_method, CallMethod, ClientMethod, Response, Result, SecretManagerMethod,
+    call_client_method, call_secret_manager_method, CallMethod, ClientMethod, Error, Response, SecretManagerMethod,
     WalletMethod, WalletOptions,
 };
 use pretty_assertions::assert_eq;
 
 #[cfg(feature = "storage")]
 #[tokio::test]
-async fn create_wallet() -> Result<()> {
+async fn create_wallet() -> Result<(), Error> {
     let storage_path = "test-storage/create_wallet";
     std::fs::remove_dir_all(storage_path).ok();
 
@@ -67,7 +67,7 @@ async fn create_wallet() -> Result<()> {
 
 #[cfg(feature = "storage")]
 #[tokio::test]
-async fn client_from_wallet() -> Result<()> {
+async fn client_from_wallet() -> Result<(), Error> {
     let storage_path = "test-storage/client_from_wallet";
     std::fs::remove_dir_all(storage_path).ok();
 

--- a/bindings/core/tests/secrets_manager.rs
+++ b/bindings/core/tests/secrets_manager.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::client::{api::GetAddressesOptions, constants::ETHER_COIN_TYPE, secret::SecretManager};
-use iota_sdk_bindings_core::{call_secret_manager_method, Response, Result, SecretManagerMethod};
+use iota_sdk_bindings_core::{call_secret_manager_method, Error, Response, SecretManagerMethod};
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
-async fn generate_ed25519_addresses() -> Result<()> {
+async fn generate_ed25519_addresses() -> Result<(), Error> {
     let secret_manager = SecretManager::try_from_mnemonic(
         "endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river".to_owned(),
     )?;
@@ -28,7 +28,7 @@ async fn generate_ed25519_addresses() -> Result<()> {
 }
 
 #[tokio::test]
-async fn generate_evm_addresses() -> Result<()> {
+async fn generate_evm_addresses() -> Result<(), Error> {
     let secret_manager = SecretManager::try_from_mnemonic(
         "endorse answer radar about source reunion marriage tag sausage weekend frost daring base attack because joke dream slender leisure group reason prepare broken river".to_owned(),
     )?;

--- a/bindings/core/tests/serialize_error.rs
+++ b/bindings/core/tests/serialize_error.rs
@@ -3,8 +3,8 @@
 
 use crypto::keys::bip44::Bip44;
 use iota_sdk::{
-    client::{constants::SHIMMER_COIN_TYPE, Error as ClientError},
-    wallet::Error as WalletError,
+    client::{constants::SHIMMER_COIN_TYPE, ClientError},
+    wallet::WalletError,
 };
 use iota_sdk_bindings_core::Error;
 use pretty_assertions::assert_eq;

--- a/bindings/nodejs/src/secret_manager.rs
+++ b/bindings/nodejs/src/secret_manager.rs
@@ -65,7 +65,7 @@ pub fn migrate_stronghold_snapshot_v2_to_v3(
         new_path.as_ref(),
         new_password,
     )
-    .map_err(iota_sdk_bindings_core::iota_sdk::client::Error::from)
+    .map_err(iota_sdk_bindings_core::iota_sdk::client::ClientError::from)
     .map_err(NodejsError::new)?;
 
     Ok(())

--- a/bindings/python/src/error.rs
+++ b/bindings/python/src/error.rs
@@ -5,9 +5,6 @@ use core::convert::{From, Infallible};
 
 use pyo3::{exceptions, prelude::*};
 
-/// The `Result` structure to wrap the error type for python binding.
-pub(crate) type Result<T> = std::result::Result<T, Error>;
-
 /// The Error type.
 #[derive(Debug)]
 pub struct Error {
@@ -45,8 +42,8 @@ impl From<iota_sdk_bindings_core::Error> for Error {
     }
 }
 
-impl From<iota_sdk_bindings_core::iota_sdk::client::Error> for Error {
-    fn from(err: iota_sdk_bindings_core::iota_sdk::client::Error) -> Self {
+impl From<iota_sdk_bindings_core::iota_sdk::client::ClientError> for Error {
+    fn from(err: iota_sdk_bindings_core::iota_sdk::client::ClientError) -> Self {
         Self {
             error: PyErr::new::<exceptions::PyValueError, _>(err.to_string()),
         }
@@ -61,8 +58,8 @@ impl From<iota_sdk_bindings_core::iota_sdk::client::mqtt::Error> for Error {
     }
 }
 
-impl From<iota_sdk_bindings_core::iota_sdk::wallet::Error> for Error {
-    fn from(err: iota_sdk_bindings_core::iota_sdk::wallet::Error) -> Self {
+impl From<iota_sdk_bindings_core::iota_sdk::wallet::WalletError> for Error {
+    fn from(err: iota_sdk_bindings_core::iota_sdk::wallet::WalletError) -> Self {
         Self {
             error: PyErr::new::<exceptions::PyValueError, _>(err.to_string()),
         }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -18,12 +18,7 @@ use once_cell::sync::OnceCell;
 use pyo3::{prelude::*, wrap_pyfunction};
 use tokio::runtime::Runtime;
 
-use self::{
-    client::*,
-    error::{Error, Result},
-    secret_manager::*,
-    wallet::*,
-};
+use self::{client::*, error::Error, secret_manager::*, wallet::*};
 
 /// Use one runtime.
 pub(crate) fn block_on<C: futures::Future>(cb: C) -> C::Output {
@@ -34,13 +29,13 @@ pub(crate) fn block_on<C: futures::Future>(cb: C) -> C::Output {
 
 /// Init the Rust logger.
 #[pyfunction]
-pub fn init_logger(config: String) -> Result<()> {
+pub fn init_logger(config: String) -> Result<(), Error> {
     rust_init_logger(config).map_err(|err| Error::from(format!("{:?}", err)))?;
     Ok(())
 }
 
 #[pyfunction]
-pub fn call_utils_method(method: String) -> Result<String> {
+pub fn call_utils_method(method: String) -> Result<String, Error> {
     let method = serde_json::from_str::<UtilsMethod>(&method)?;
     let response = rust_call_utils_method(method);
     Ok(serde_json::to_string(&response)?)
@@ -55,7 +50,7 @@ pub fn migrate_stronghold_snapshot_v2_to_v3(
     rounds: u32,
     new_path: Option<String>,
     new_password: Option<String>,
-) -> Result<()> {
+) -> Result<(), Error> {
     Ok(StrongholdAdapter::migrate_snapshot_v2_to_v3(
         &current_path,
         current_password.into(),
@@ -64,7 +59,7 @@ pub fn migrate_stronghold_snapshot_v2_to_v3(
         new_path.as_ref(),
         new_password.map(Into::into),
     )
-    .map_err(iota_sdk_bindings_core::iota_sdk::client::Error::Stronghold)?)
+    .map_err(iota_sdk_bindings_core::iota_sdk::client::ClientError::Stronghold)?)
 }
 
 /// IOTA SDK implemented in Rust for Python binding.

--- a/bindings/python/src/secret_manager.rs
+++ b/bindings/python/src/secret_manager.rs
@@ -11,7 +11,7 @@ use iota_sdk_bindings_core::{
 use pyo3::prelude::*;
 use tokio::sync::RwLock;
 
-use crate::error::Result;
+use crate::Error;
 
 #[pyclass]
 pub struct SecretManager {
@@ -20,7 +20,7 @@ pub struct SecretManager {
 
 /// Create secret_manager for python-side usage.
 #[pyfunction]
-pub fn create_secret_manager(options: String) -> Result<SecretManager> {
+pub fn create_secret_manager(options: String) -> Result<SecretManager, Error> {
     let secret_manager_dto = serde_json::from_str::<SecretManagerDto>(&options)?;
     let secret_manager = RustSecretManager::try_from(secret_manager_dto)?;
     Ok(SecretManager {
@@ -29,7 +29,7 @@ pub fn create_secret_manager(options: String) -> Result<SecretManager> {
 }
 
 #[pyfunction]
-pub fn call_secret_manager_method(secret_manager: &SecretManager, method: String) -> Result<String> {
+pub fn call_secret_manager_method(secret_manager: &SecretManager, method: String) -> Result<String, Error> {
     let method = serde_json::from_str::<SecretManagerMethod>(&method)?;
     let response = crate::block_on(async {
         let secret_manager = secret_manager.secret_manager.read().await;

--- a/bindings/python/src/wallet.rs
+++ b/bindings/python/src/wallet.rs
@@ -11,11 +11,7 @@ use iota_sdk_bindings_core::{
 use pyo3::{prelude::*, types::PyTuple};
 use tokio::sync::RwLock;
 
-use crate::{
-    client::Client,
-    error::{Error, Result},
-    SecretManager,
-};
+use crate::{client::Client, error::Error, SecretManager};
 
 #[pyclass]
 pub struct Wallet {
@@ -33,7 +29,7 @@ pub fn destroy_wallet(wallet: &Wallet) -> PyResult<()> {
 
 /// Create wallet handler for python-side usage.
 #[pyfunction]
-pub fn create_wallet(options: String) -> Result<Wallet> {
+pub fn create_wallet(options: String) -> Result<Wallet, Error> {
     let wallet_options = serde_json::from_str::<WalletOptions>(&options)?;
     let wallet = crate::block_on(async { wallet_options.build().await })?;
 
@@ -44,7 +40,7 @@ pub fn create_wallet(options: String) -> Result<Wallet> {
 
 /// Call a wallet method.
 #[pyfunction]
-pub fn call_wallet_method(wallet: &Wallet, method: String) -> Result<String> {
+pub fn call_wallet_method(wallet: &Wallet, method: String) -> Result<String, Error> {
     let method = serde_json::from_str::<WalletMethod>(&method)?;
     let response = crate::block_on(async {
         match wallet.wallet.read().await.as_ref() {
@@ -91,7 +87,7 @@ pub fn listen_wallet(wallet: &Wallet, events: Vec<u8>, handler: PyObject) {
 
 /// Get the client from the wallet.
 #[pyfunction]
-pub fn get_client_from_wallet(wallet: &Wallet) -> Result<Client> {
+pub fn get_client_from_wallet(wallet: &Wallet) -> Result<Client, Error> {
     let client = crate::block_on(async {
         wallet
             .wallet
@@ -113,7 +109,7 @@ pub fn get_client_from_wallet(wallet: &Wallet) -> Result<Client> {
 
 /// Get the secret manager from the wallet.
 #[pyfunction]
-pub fn get_secret_manager_from_wallet(wallet: &Wallet) -> Result<SecretManager> {
+pub fn get_secret_manager_from_wallet(wallet: &Wallet) -> Result<SecretManager, Error> {
     let secret_manager = crate::block_on(async {
         wallet
             .wallet

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -26,8 +26,8 @@ use iota_sdk::{
     utils::ConvertTo,
     wallet::{
         types::OutputData, BeginStakingParams, ConsolidationParams, CreateDelegationParams, CreateNativeTokenParams,
-        Error as WalletError, MintNftParams, OutputsToClaim, ReturnStrategy, SendManaParams, SendNativeTokenParams,
-        SendNftParams, SendParams, SyncOptions, TransactionOptions, Wallet,
+        MintNftParams, OutputsToClaim, ReturnStrategy, SendManaParams, SendNativeTokenParams, SendNftParams,
+        SendParams, SyncOptions, TransactionOptions, Wallet, WalletError,
     },
     U256,
 };

--- a/sdk/examples/wallet/spammer.rs
+++ b/sdk/examples/wallet/spammer.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("ROUND {i}/{NUM_ROUNDS}");
         let round_timer = tokio::time::Instant::now();
 
-        let mut tasks = tokio::task::JoinSet::<std::result::Result<(), (usize, iota_sdk::wallet::Error)>>::new();
+        let mut tasks = tokio::task::JoinSet::<std::result::Result<(), (usize, iota_sdk::wallet::WalletError)>>::new();
 
         for n in 0..num_simultaneous_txs {
             let recv_address = recv_address.clone();

--- a/sdk/src/client/api/block_builder/mod.rs
+++ b/sdk/src/client/api/block_builder/mod.rs
@@ -6,7 +6,7 @@ pub mod transaction;
 
 pub use self::transaction::verify_semantic;
 use crate::{
-    client::{constants::FIVE_MINUTES_IN_NANOSECONDS, Client, Error, Result},
+    client::{constants::FIVE_MINUTES_IN_NANOSECONDS, Client, ClientError},
     types::block::{
         core::{BlockHeader, UnsignedBlock},
         output::AccountId,
@@ -20,7 +20,7 @@ impl Client {
         &self,
         issuer_id: AccountId,
         payload: impl Into<Option<Payload>> + Send,
-    ) -> Result<UnsignedBlock> {
+    ) -> Result<UnsignedBlock, ClientError> {
         let issuance = self.get_issuance().await?;
 
         let issuing_time = {
@@ -39,7 +39,7 @@ impl Client {
                 ..issuance.latest_parent_block_issuing_time + FIVE_MINUTES_IN_NANOSECONDS)
                 .contains(&issuing_time)
             {
-                return Err(Error::TimeNotSynced {
+                return Err(ClientError::TimeNotSynced {
                     current_time: issuing_time,
                     tangle_time: issuance.latest_parent_block_issuing_time,
                 });

--- a/sdk/src/client/api/block_builder/transaction.rs
+++ b/sdk/src/client/api/block_builder/transaction.rs
@@ -8,7 +8,7 @@ use alloc::collections::BTreeMap;
 use packable::PackableExt;
 
 use crate::{
-    client::{secret::types::InputSigningData, Error},
+    client::{secret::types::InputSigningData, ClientError},
     types::block::{
         output::{Output, OutputId},
         payload::signed_transaction::{SignedTransactionPayload, Transaction},
@@ -53,10 +53,10 @@ pub fn verify_semantic(
 /// Verifies that the signed transaction payload doesn't exceed the block size limit with 8 parents.
 pub fn validate_signed_transaction_payload_length(
     signed_transaction_payload: &SignedTransactionPayload,
-) -> crate::client::error::Result<()> {
+) -> Result<(), ClientError> {
     let signed_transaction_payload_bytes = signed_transaction_payload.pack_to_vec();
     if signed_transaction_payload_bytes.len() > MAX_TX_LENGTH_FOR_BLOCK_WITH_8_PARENTS {
-        return Err(Error::InvalidSignedTransactionPayloadLength {
+        return Err(ClientError::InvalidSignedTransactionPayloadLength {
             length: signed_transaction_payload_bytes.len(),
             max_length: MAX_TX_LENGTH_FOR_BLOCK_WITH_8_PARENTS,
         });
@@ -67,7 +67,7 @@ pub fn validate_signed_transaction_payload_length(
 /// Verifies that the transaction doesn't exceed the block size limit with 8 parents.
 /// Assuming one signature unlock and otherwise reference/account/nft unlocks. `validate_transaction_payload_length()`
 /// should later be used to check the length again with the correct unlocks.
-pub fn validate_transaction_length(transaction: &Transaction) -> crate::client::error::Result<()> {
+pub fn validate_transaction_length(transaction: &Transaction) -> Result<(), ClientError> {
     let transaction_bytes = transaction.pack_to_vec();
 
     // Assuming there is only 1 signature unlock and the rest is reference/account/nft unlocks
@@ -80,7 +80,7 @@ pub fn validate_transaction_length(transaction: &Transaction) -> crate::client::
         - (reference_account_nft_unlocks_amount * REFERENCE_ACCOUNT_NFT_UNLOCK_LENGTH);
 
     if transaction_bytes.len() > max_length {
-        return Err(Error::InvalidTransactionLength {
+        return Err(ClientError::InvalidTransactionLength {
             length: transaction_bytes.len(),
             max_length,
         });

--- a/sdk/src/client/api/high_level.rs
+++ b/sdk/src/client/api/high_level.rs
@@ -7,11 +7,8 @@ use futures::{StreamExt, TryStreamExt};
 
 use crate::{
     client::{
-        api::input_selection::Error as InputSelectionError,
-        constants::FIVE_MINUTES_IN_NANOSECONDS,
-        error::{Error, Result},
-        node_api::indexer::query_parameters::BasicOutputQueryParameters,
-        unix_timestamp_now, Client,
+        api::input_selection::Error as InputSelectionError, constants::FIVE_MINUTES_IN_NANOSECONDS, error::ClientError,
+        node_api::indexer::query_parameters::BasicOutputQueryParameters, unix_timestamp_now, Client,
     },
     types::{
         api::core::OutputWithMetadataResponse,
@@ -31,14 +28,14 @@ impl Client {
     pub async fn inputs_from_transaction_id(
         &self,
         transaction_id: &TransactionId,
-    ) -> Result<Vec<OutputWithMetadataResponse>> {
+    ) -> Result<Vec<OutputWithMetadataResponse>, ClientError> {
         let block = self.get_included_block(transaction_id).await?;
 
         if let BlockBody::Basic(basic_block_body) = block.body() {
             let inputs = if let Some(Payload::SignedTransaction(t)) = basic_block_body.payload() {
                 t.transaction().inputs()
             } else {
-                return Err(Error::MissingTransactionPayload);
+                return Err(ClientError::MissingTransactionPayload);
             };
 
             let input_ids = inputs
@@ -50,7 +47,7 @@ impl Client {
 
             self.get_outputs_with_metadata(&input_ids).await
         } else {
-            Err(Error::UnexpectedBlockBodyKind {
+            Err(ClientError::UnexpectedBlockBodyKind {
                 expected: BasicBlockBody::KIND,
                 actual: block.body().kind(),
             })
@@ -58,7 +55,7 @@ impl Client {
     }
 
     /// Find all blocks by provided block IDs.
-    pub async fn find_blocks(&self, block_ids: &[BlockId]) -> Result<Vec<Block>> {
+    pub async fn find_blocks(&self, block_ids: &[BlockId]) -> Result<Vec<Block>, ClientError> {
         // Use a `HashSet` to prevent duplicate block_ids.
         let block_ids = block_ids.iter().copied().collect::<HashSet<_>>();
         futures::future::try_join_all(block_ids.iter().map(|block_id| self.get_block(block_id))).await
@@ -66,7 +63,7 @@ impl Client {
 
     /// Function to find inputs from addresses for a provided amount (useful for offline signing), ignoring outputs with
     /// additional unlock conditions
-    pub async fn find_inputs(&self, addresses: Vec<Bech32Address>, amount: u64) -> Result<Vec<UtxoInput>> {
+    pub async fn find_inputs(&self, addresses: Vec<Bech32Address>, amount: u64) -> Result<Vec<UtxoInput>, ClientError> {
         // Get outputs from node and select inputs
         let available_outputs = futures::stream::iter(addresses)
             .then(|address| self.basic_output_ids(BasicOutputQueryParameters::only_address_unlock_condition(address)))
@@ -86,7 +83,7 @@ impl Client {
                     output_with_meta.output().amount(),
                 ))
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, ClientError>>()?;
         basic_outputs.sort_by(|l, r| r.1.cmp(&l.1));
 
         let mut total_already_spent = 0;
@@ -115,7 +112,7 @@ impl Client {
     }
 
     // Returns the slot index corresponding to the current timestamp.
-    pub async fn get_slot_index(&self) -> Result<SlotIndex> {
+    pub async fn get_slot_index(&self) -> Result<SlotIndex, ClientError> {
         let unix_timestamp = unix_timestamp_now();
         let current_time_nanos = unix_timestamp.as_nanos() as u64;
 
@@ -126,7 +123,7 @@ impl Client {
             if !(tangle_time - FIVE_MINUTES_IN_NANOSECONDS..tangle_time + FIVE_MINUTES_IN_NANOSECONDS)
                 .contains(&current_time_nanos)
             {
-                return Err(Error::TimeNotSynced {
+                return Err(ClientError::TimeNotSynced {
                     current_time: current_time_nanos,
                     tangle_time,
                 });

--- a/sdk/src/client/api/wait_for_tx_acceptance.rs
+++ b/sdk/src/client/api/wait_for_tx_acceptance.rs
@@ -4,7 +4,7 @@
 use std::time::Duration;
 
 use crate::{
-    client::{Client, Error},
+    client::{Client, ClientError},
     types::{api::core::TransactionState, block::payload::signed_transaction::TransactionId},
 };
 
@@ -18,7 +18,7 @@ impl Client {
         transaction_id: &TransactionId,
         interval: Option<u64>,
         max_attempts: Option<u64>,
-    ) -> crate::client::Result<()> {
+    ) -> Result<(), ClientError> {
         log::debug!("[wait_for_transaction_acceptance]");
 
         let duration = interval
@@ -32,7 +32,7 @@ impl Client {
                 TransactionState::Accepted | TransactionState::Confirmed | TransactionState::Finalized => {
                     return Ok(());
                 }
-                TransactionState::Failed => return Err(Error::TransactionAcceptance(transaction_id.to_string())),
+                TransactionState::Failed => return Err(ClientError::TransactionAcceptance(transaction_id.to_string())),
                 TransactionState::Pending => {} // Just need to wait longer
             };
 
@@ -42,6 +42,6 @@ impl Client {
             tokio::time::sleep(duration).await;
         }
 
-        Err(Error::TransactionAcceptance(transaction_id.to_string()).into())
+        Err(ClientError::TransactionAcceptance(transaction_id.to_string()).into())
     }
 }

--- a/sdk/src/client/builder.rs
+++ b/sdk/src/client/builder.rs
@@ -12,12 +12,11 @@ use crate::client::node_api::mqtt::{BrokerOptions, MqttEvent};
 use crate::{
     client::{
         constants::DEFAULT_API_TIMEOUT,
-        error::Result,
         node_manager::{
             builder::validate_url,
             node::{Node, NodeAuth},
         },
-        Client,
+        Client, ClientError,
     },
     types::block::protocol::ProtocolParameters,
 };
@@ -78,7 +77,7 @@ impl ClientBuilder {
 
     /// Set the fields from a client JSON config
     #[allow(unused_assignments)]
-    pub fn from_json(mut self, client_config: &str) -> Result<Self> {
+    pub fn from_json(mut self, client_config: &str) -> Result<Self, ClientError> {
         self = serde_json::from_str::<Self>(client_config)?;
         // validate URLs
         for node_dto in &self.node_manager_builder.primary_nodes {
@@ -93,31 +92,31 @@ impl ClientBuilder {
     }
 
     /// Adds an IOTA node by its URL.
-    pub fn with_node(mut self, url: &str) -> Result<Self> {
+    pub fn with_node(mut self, url: &str) -> Result<Self, ClientError> {
         self.node_manager_builder = self.node_manager_builder.with_node(url)?;
         Ok(self)
     }
 
     // Adds a node as primary node.
-    pub fn with_primary_node(mut self, node: Node) -> Result<Self> {
+    pub fn with_primary_node(mut self, node: Node) -> Result<Self, ClientError> {
         self.node_manager_builder = self.node_manager_builder.with_primary_node(node)?;
         Ok(self)
     }
 
     /// Adds a list of IOTA nodes by their URLs to the primary nodes list.
-    pub fn with_primary_nodes(mut self, urls: &[&str]) -> Result<Self> {
+    pub fn with_primary_nodes(mut self, urls: &[&str]) -> Result<Self, ClientError> {
         self.node_manager_builder = self.node_manager_builder.with_primary_nodes(urls)?;
         Ok(self)
     }
 
     /// Adds an IOTA node by its URL with optional jwt and or basic authentication
-    pub fn with_node_auth(mut self, url: &str, auth: impl Into<Option<NodeAuth>>) -> Result<Self> {
+    pub fn with_node_auth(mut self, url: &str, auth: impl Into<Option<NodeAuth>>) -> Result<Self, ClientError> {
         self.node_manager_builder = self.node_manager_builder.with_node_auth(url, auth)?;
         Ok(self)
     }
 
     /// Adds a list of IOTA nodes by their URLs.
-    pub fn with_nodes(mut self, urls: &[&str]) -> Result<Self> {
+    pub fn with_nodes(mut self, urls: &[&str]) -> Result<Self, ClientError> {
         self.node_manager_builder = self.node_manager_builder.with_nodes(urls)?;
         Ok(self)
     }
@@ -190,7 +189,7 @@ impl ClientBuilder {
 
     /// Build the Client instance.
     #[cfg(not(target_family = "wasm"))]
-    pub async fn finish(self) -> Result<Client> {
+    pub async fn finish(self) -> Result<Client, ClientError> {
         use tokio::sync::RwLock;
 
         let node_sync_interval = self.node_manager_builder.node_sync_interval;
@@ -251,7 +250,7 @@ impl ClientBuilder {
 
     /// Build the Client instance.
     #[cfg(target_family = "wasm")]
-    pub async fn finish(self) -> Result<Client> {
+    pub async fn finish(self) -> Result<Client, ClientError> {
         use tokio::sync::RwLock;
 
         #[cfg(feature = "mqtt")]

--- a/sdk/src/client/error.rs
+++ b/sdk/src/client/error.rs
@@ -28,14 +28,11 @@ use crate::{
     utils::ConversionError,
 };
 
-/// Type alias of `Result` in iota-client
-pub type Result<T> = std::result::Result<T, Error>;
-
 /// Error type of the iota client crate.
 #[derive(Debug, thiserror::Error, strum::AsRefStr)]
 #[strum(serialize_all = "camelCase")]
 #[non_exhaustive]
-pub enum Error {
+pub enum ClientError {
     /// Invalid bech32 HRP, should match the one from the used network
     #[error("invalid bech32 hrp for the connected network: {provided}, expected: {expected}")]
     Bech32HrpMismatch {
@@ -206,7 +203,7 @@ pub enum Error {
 }
 
 // Serialize type with Display error
-impl Serialize for Error {
+impl Serialize for ClientError {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -226,7 +223,7 @@ impl Serialize for Error {
     }
 }
 
-crate::impl_from_error_via!(Error via BlockError:
+crate::impl_from_error_via!(ClientError via BlockError:
     PayloadError,
     OutputError,
     InputError,

--- a/sdk/src/client/node_api/core/mod.rs
+++ b/sdk/src/client/node_api/core/mod.rs
@@ -6,7 +6,7 @@
 pub mod routes;
 
 use crate::{
-    client::{node_api::error::Error as NodeApiError, Client, Error, Result},
+    client::{node_api::error::Error as NodeApiError, Client, ClientError},
     types::{
         api::core::{OutputResponse, OutputWithMetadataResponse},
         block::output::{OutputId, OutputMetadata},
@@ -15,36 +15,45 @@ use crate::{
 
 impl Client {
     /// Requests outputs by their output ID in parallel.
-    pub async fn get_outputs(&self, output_ids: &[OutputId]) -> Result<Vec<OutputResponse>> {
+    pub async fn get_outputs(&self, output_ids: &[OutputId]) -> Result<Vec<OutputResponse>, ClientError> {
         futures::future::try_join_all(output_ids.iter().map(|id| self.get_output(id))).await
     }
 
     /// Requests outputs by their output ID in parallel, ignoring outputs not found.
     /// Useful to get data about spent outputs, that might not be pruned yet.
-    pub async fn get_outputs_ignore_not_found(&self, output_ids: &[OutputId]) -> Result<Vec<OutputResponse>> {
+    pub async fn get_outputs_ignore_not_found(
+        &self,
+        output_ids: &[OutputId],
+    ) -> Result<Vec<OutputResponse>, ClientError> {
         futures::future::join_all(output_ids.iter().map(|id| self.get_output(id)))
             .await
             .into_iter()
-            .filter(|res| !matches!(res, Err(Error::Node(NodeApiError::NotFound(_)))))
+            .filter(|res| !matches!(res, Err(ClientError::Node(NodeApiError::NotFound(_)))))
             .collect()
     }
 
     /// Requests metadata for outputs by their output ID in parallel.
-    pub async fn get_outputs_metadata(&self, output_ids: &[OutputId]) -> Result<Vec<OutputMetadata>> {
+    pub async fn get_outputs_metadata(&self, output_ids: &[OutputId]) -> Result<Vec<OutputMetadata>, ClientError> {
         futures::future::try_join_all(output_ids.iter().map(|id| self.get_output_metadata(id))).await
     }
 
     /// Requests metadata for outputs by their output ID in parallel, ignoring outputs not found.
-    pub async fn get_outputs_metadata_ignore_not_found(&self, output_ids: &[OutputId]) -> Result<Vec<OutputMetadata>> {
+    pub async fn get_outputs_metadata_ignore_not_found(
+        &self,
+        output_ids: &[OutputId],
+    ) -> Result<Vec<OutputMetadata>, ClientError> {
         futures::future::join_all(output_ids.iter().map(|id| self.get_output_metadata(id)))
             .await
             .into_iter()
-            .filter(|res| !matches!(res, Err(Error::Node(NodeApiError::NotFound(_)))))
+            .filter(|res| !matches!(res, Err(ClientError::Node(NodeApiError::NotFound(_)))))
             .collect()
     }
 
     /// Requests outputs and their metadata by their output ID in parallel.
-    pub async fn get_outputs_with_metadata(&self, output_ids: &[OutputId]) -> Result<Vec<OutputWithMetadataResponse>> {
+    pub async fn get_outputs_with_metadata(
+        &self,
+        output_ids: &[OutputId],
+    ) -> Result<Vec<OutputWithMetadataResponse>, ClientError> {
         futures::future::try_join_all(output_ids.iter().map(|id| self.get_output_with_metadata(id))).await
     }
 
@@ -53,11 +62,11 @@ impl Client {
     pub async fn get_outputs_with_metadata_ignore_not_found(
         &self,
         output_ids: &[OutputId],
-    ) -> Result<Vec<OutputWithMetadataResponse>> {
+    ) -> Result<Vec<OutputWithMetadataResponse>, ClientError> {
         futures::future::join_all(output_ids.iter().map(|id| self.get_output_with_metadata(id)))
             .await
             .into_iter()
-            .filter(|res| !matches!(res, Err(Error::Node(NodeApiError::NotFound(_)))))
+            .filter(|res| !matches!(res, Err(ClientError::Node(NodeApiError::NotFound(_)))))
             .collect()
     }
 }

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -12,7 +12,7 @@ use crate::{
         constants::{DEFAULT_API_TIMEOUT, DEFAULT_USER_AGENT},
         node_api::query_tuples_to_query_string,
         node_manager::node::{Node, NodeAuth},
-        Client, ClientInner, Result,
+        Client, ClientError, ClientInner,
     },
     types::{
         api::core::{
@@ -50,7 +50,7 @@ impl ClientInner {
 
     /// Returns the health of the node.
     /// GET /health
-    pub async fn get_health(&self, url: &str) -> Result<bool> {
+    pub async fn get_health(&self, url: &str) -> Result<bool, ClientError> {
         const PATH: &str = "health";
 
         let mut url = Url::parse(url)?;
@@ -76,7 +76,7 @@ impl ClientInner {
 
     /// Returns the available API route groups of the node.
     /// GET /api/routes
-    pub async fn get_routes(&self) -> Result<RoutesResponse> {
+    pub async fn get_routes(&self) -> Result<RoutesResponse, ClientError> {
         const PATH: &str = "api/routes";
 
         self.get_request(PATH, None, false).await
@@ -84,7 +84,7 @@ impl ClientInner {
 
     /// Returns general information about the node.
     /// GET /api/core/v3/info
-    pub async fn get_node_info(&self) -> Result<NodeInfoResponse> {
+    pub async fn get_node_info(&self) -> Result<NodeInfoResponse, ClientError> {
         self.get_request(INFO_PATH, None, false).await
     }
 }
@@ -98,7 +98,7 @@ impl Client {
         &self,
         account_id: &AccountId,
         work_score: impl Into<Option<u32>> + Send,
-    ) -> Result<CongestionResponse> {
+    ) -> Result<CongestionResponse, ClientError> {
         let bech32_address = account_id.to_bech32(self.get_bech32_hrp().await?);
         let path = &format!("api/core/v3/accounts/{bech32_address}/congestion");
         let query = query_tuples_to_query_string([work_score.into().map(|i| ("workScore", i.to_string()))]);
@@ -119,7 +119,7 @@ impl Client {
         &self,
         output_id: &OutputId,
         slot_index: impl Into<Option<SlotIndex>> + Send,
-    ) -> Result<ManaRewardsResponse> {
+    ) -> Result<ManaRewardsResponse, ClientError> {
         let path = &format!("api/core/v3/rewards/{output_id}");
         let query = query_tuples_to_query_string([slot_index.into().map(|i| ("slotIndex", i.to_string()))]);
 
@@ -135,7 +135,7 @@ impl Client {
         &self,
         page_size: impl Into<Option<u32>> + Send,
         cursor: impl Into<Option<String>> + Send,
-    ) -> Result<ValidatorsResponse> {
+    ) -> Result<ValidatorsResponse, ClientError> {
         const PATH: &str = "api/core/v3/validators";
         let query = query_tuples_to_query_string([
             page_size.into().map(|i| ("pageSize", i.to_string())),
@@ -147,7 +147,7 @@ impl Client {
 
     /// Return information about a staker (registered validator).
     /// GET /api/core/v3/validators/{bech32Address}
-    pub async fn get_validator(&self, account_id: &AccountId) -> Result<ValidatorResponse> {
+    pub async fn get_validator(&self, account_id: &AccountId) -> Result<ValidatorResponse, ClientError> {
         let bech32_address = account_id.to_bech32(self.get_bech32_hrp().await?);
         let path = &format!("api/core/v3/validators/{bech32_address}");
 
@@ -159,7 +159,10 @@ impl Client {
     /// Returns the information of committee members at the given epoch index. If epoch index is not provided, the
     /// current committee members are returned.
     /// GET /api/core/v3/committee/?epochIndex
-    pub async fn get_committee(&self, epoch_index: impl Into<Option<EpochIndex>> + Send) -> Result<CommitteeResponse> {
+    pub async fn get_committee(
+        &self,
+        epoch_index: impl Into<Option<EpochIndex>> + Send,
+    ) -> Result<CommitteeResponse, ClientError> {
         const PATH: &str = "api/core/v3/committee";
         let query = query_tuples_to_query_string([epoch_index.into().map(|i| ("epochIndex", i.to_string()))]);
 
@@ -170,7 +173,7 @@ impl Client {
 
     /// Returns information that is ideal for attaching a block in the network.
     /// GET /api/core/v3/blocks/issuance
-    pub async fn get_issuance(&self) -> Result<IssuanceBlockHeaderResponse> {
+    pub async fn get_issuance(&self) -> Result<IssuanceBlockHeaderResponse, ClientError> {
         const PATH: &str = "api/core/v3/blocks/issuance";
 
         self.get_request(PATH, None, false).await
@@ -178,7 +181,7 @@ impl Client {
 
     /// Returns the BlockId of the submitted block.
     /// POST /api/core/v3/blocks
-    pub async fn post_block(&self, block: &Block) -> Result<BlockId> {
+    pub async fn post_block(&self, block: &Block) -> Result<BlockId, ClientError> {
         const PATH: &str = "api/core/v3/blocks";
 
         let block_dto = BlockDto::from(block);
@@ -192,7 +195,7 @@ impl Client {
 
     /// Returns the BlockId of the submitted block.
     /// POST /api/core/v3/blocks
-    pub async fn post_block_raw(&self, block: &Block) -> Result<BlockId> {
+    pub async fn post_block_raw(&self, block: &Block) -> Result<BlockId, ClientError> {
         const PATH: &str = "api/core/v3/blocks";
 
         let response = self
@@ -204,7 +207,7 @@ impl Client {
 
     /// Finds a block by its ID and returns it as object.
     /// GET /api/core/v3/blocks/{blockId}
-    pub async fn get_block(&self, block_id: &BlockId) -> Result<Block> {
+    pub async fn get_block(&self, block_id: &BlockId) -> Result<Block, ClientError> {
         let path = &format!("api/core/v3/blocks/{block_id}");
 
         let dto = self.get_request::<BlockDto>(path, None, false).await?;
@@ -217,7 +220,7 @@ impl Client {
 
     /// Finds a block by its ID and returns it as raw bytes.
     /// GET /api/core/v3/blocks/{blockId}
-    pub async fn get_block_raw(&self, block_id: &BlockId) -> Result<Vec<u8>> {
+    pub async fn get_block_raw(&self, block_id: &BlockId) -> Result<Vec<u8>, ClientError> {
         let path = &format!("api/core/v3/blocks/{block_id}");
 
         self.get_request_bytes(path, None).await
@@ -225,7 +228,7 @@ impl Client {
 
     /// Returns the metadata of a block.
     /// GET /api/core/v3/blocks/{blockId}/metadata
-    pub async fn get_block_metadata(&self, block_id: &BlockId) -> Result<BlockMetadataResponse> {
+    pub async fn get_block_metadata(&self, block_id: &BlockId) -> Result<BlockMetadataResponse, ClientError> {
         let path = &format!("api/core/v3/blocks/{block_id}/metadata");
 
         self.get_request(path, None, true).await
@@ -233,7 +236,7 @@ impl Client {
 
     /// Returns a block with its metadata.
     /// GET /api/core/v3/blocks/{blockId}/full
-    pub async fn get_block_with_metadata(&self, block_id: &BlockId) -> Result<BlockWithMetadataResponse> {
+    pub async fn get_block_with_metadata(&self, block_id: &BlockId) -> Result<BlockWithMetadataResponse, ClientError> {
         let path = &format!("api/core/v3/blocks/{block_id}/full");
 
         self.get_request(path, None, true).await
@@ -243,7 +246,7 @@ impl Client {
 
     /// Finds an output by its ID and returns it as object.
     /// GET /api/core/v3/outputs/{outputId}
-    pub async fn get_output(&self, output_id: &OutputId) -> Result<OutputResponse> {
+    pub async fn get_output(&self, output_id: &OutputId) -> Result<OutputResponse, ClientError> {
         let path = &format!("api/core/v3/outputs/{output_id}");
 
         self.get_request(path, None, false).await
@@ -251,7 +254,7 @@ impl Client {
 
     /// Finds an output by its ID and returns it as raw bytes.
     /// GET /api/core/v3/outputs/{outputId}
-    pub async fn get_output_raw(&self, output_id: &OutputId) -> Result<Vec<u8>> {
+    pub async fn get_output_raw(&self, output_id: &OutputId) -> Result<Vec<u8>, ClientError> {
         let path = &format!("api/core/v3/outputs/{output_id}");
 
         self.get_request_bytes(path, None).await
@@ -259,7 +262,7 @@ impl Client {
 
     /// Finds output metadata by output ID.
     /// GET /api/core/v3/outputs/{outputId}/metadata
-    pub async fn get_output_metadata(&self, output_id: &OutputId) -> Result<OutputMetadata> {
+    pub async fn get_output_metadata(&self, output_id: &OutputId) -> Result<OutputMetadata, ClientError> {
         let path = &format!("api/core/v3/outputs/{output_id}/metadata");
 
         self.get_request(path, None, false).await
@@ -267,7 +270,10 @@ impl Client {
 
     /// Finds an output with its metadata by output ID.
     /// GET /api/core/v3/outputs/{outputId}/full
-    pub async fn get_output_with_metadata(&self, output_id: &OutputId) -> Result<OutputWithMetadataResponse> {
+    pub async fn get_output_with_metadata(
+        &self,
+        output_id: &OutputId,
+    ) -> Result<OutputWithMetadataResponse, ClientError> {
         let path = &format!("api/core/v3/outputs/{output_id}/full");
 
         self.get_request(path, None, false).await
@@ -275,7 +281,7 @@ impl Client {
 
     /// Returns the earliest confirmed block containing the transaction with the given ID.
     /// GET /api/core/v3/transactions/{transactionId}/included-block
-    pub async fn get_included_block(&self, transaction_id: &TransactionId) -> Result<Block> {
+    pub async fn get_included_block(&self, transaction_id: &TransactionId) -> Result<Block, ClientError> {
         let path = &format!("api/core/v3/transactions/{transaction_id}/included-block");
 
         let dto = self.get_request::<BlockDto>(path, None, true).await?;
@@ -288,7 +294,7 @@ impl Client {
 
     /// Returns the earliest confirmed block containing the transaction with the given ID, as raw bytes.
     /// GET /api/core/v3/transactions/{transactionId}/included-block
-    pub async fn get_included_block_raw(&self, transaction_id: &TransactionId) -> Result<Vec<u8>> {
+    pub async fn get_included_block_raw(&self, transaction_id: &TransactionId) -> Result<Vec<u8>, ClientError> {
         let path = &format!("api/core/v3/transactions/{transaction_id}/included-block");
 
         self.get_request_bytes(path, None).await
@@ -296,7 +302,10 @@ impl Client {
 
     /// Returns the metadata of the earliest block containing the tx that was confirmed.
     /// GET /api/core/v3/transactions/{transactionId}/included-block/metadata
-    pub async fn get_included_block_metadata(&self, transaction_id: &TransactionId) -> Result<BlockMetadataResponse> {
+    pub async fn get_included_block_metadata(
+        &self,
+        transaction_id: &TransactionId,
+    ) -> Result<BlockMetadataResponse, ClientError> {
         let path = &format!("api/core/v3/transactions/{transaction_id}/included-block/metadata");
 
         self.get_request(path, None, true).await
@@ -307,7 +316,7 @@ impl Client {
     pub async fn get_transaction_metadata(
         &self,
         transaction_id: &TransactionId,
-    ) -> Result<TransactionMetadataResponse> {
+    ) -> Result<TransactionMetadataResponse, ClientError> {
         let path = &format!("api/core/v3/transactions/{transaction_id}/metadata");
 
         self.get_request(path, None, true).await
@@ -317,7 +326,7 @@ impl Client {
 
     /// Finds a slot commitment by its ID and returns it as object.
     /// GET /api/core/v3/commitments/{commitmentId}
-    pub async fn get_commitment(&self, commitment_id: &SlotCommitmentId) -> Result<SlotCommitment> {
+    pub async fn get_commitment(&self, commitment_id: &SlotCommitmentId) -> Result<SlotCommitment, ClientError> {
         let path = &format!("api/core/v3/commitments/{commitment_id}");
 
         self.get_request(path, None, false).await
@@ -325,7 +334,7 @@ impl Client {
 
     /// Finds a slot commitment by its ID and returns it as raw bytes.
     /// GET /api/core/v3/commitments/{commitmentId}
-    pub async fn get_commitment_raw(&self, commitment_id: &SlotCommitmentId) -> Result<Vec<u8>> {
+    pub async fn get_commitment_raw(&self, commitment_id: &SlotCommitmentId) -> Result<Vec<u8>, ClientError> {
         let path = &format!("api/core/v3/commitments/{commitment_id}");
 
         self.get_request_bytes(path, None).await
@@ -333,7 +342,7 @@ impl Client {
 
     /// Get all UTXO changes of a given slot by slot commitment ID.
     /// GET /api/core/v3/commitments/{commitmentId}/utxo-changes
-    pub async fn get_utxo_changes(&self, commitment_id: &SlotCommitmentId) -> Result<UtxoChangesResponse> {
+    pub async fn get_utxo_changes(&self, commitment_id: &SlotCommitmentId) -> Result<UtxoChangesResponse, ClientError> {
         let path = &format!("api/core/v3/commitments/{commitment_id}/utxo-changes");
 
         self.get_request(path, None, false).await
@@ -341,7 +350,10 @@ impl Client {
 
     /// Get all full UTXO changes of a given slot by slot commitment ID.
     /// GET /api/core/v3/commitments/{commitmentId}/utxo-changes/full
-    pub async fn get_utxo_changes_full(&self, commitment_id: &SlotCommitmentId) -> Result<UtxoChangesFullResponse> {
+    pub async fn get_utxo_changes_full(
+        &self,
+        commitment_id: &SlotCommitmentId,
+    ) -> Result<UtxoChangesFullResponse, ClientError> {
         let path = &format!("api/core/v3/commitments/{commitment_id}/utxo-changes/full");
 
         self.get_request(path, None, false).await
@@ -349,7 +361,7 @@ impl Client {
 
     /// Finds a slot commitment by slot index and returns it as object.
     /// GET /api/core/v3/commitments/by-slot/{slot}
-    pub async fn get_commitment_by_slot(&self, slot: SlotIndex) -> Result<SlotCommitment> {
+    pub async fn get_commitment_by_slot(&self, slot: SlotIndex) -> Result<SlotCommitment, ClientError> {
         let path = &format!("api/core/v3/commitments/by-slot/{slot}");
 
         self.get_request(path, None, false).await
@@ -357,7 +369,7 @@ impl Client {
 
     /// Finds a slot commitment by slot index and returns it as raw bytes.
     /// GET /api/core/v3/commitments/by-slot/{slot}
-    pub async fn get_commitment_by_slot_raw(&self, slot: SlotIndex) -> Result<Vec<u8>> {
+    pub async fn get_commitment_by_slot_raw(&self, slot: SlotIndex) -> Result<Vec<u8>, ClientError> {
         let path = &format!("api/core/v3/commitments/by-slot/{slot}");
 
         self.get_request_bytes(path, None).await
@@ -365,7 +377,7 @@ impl Client {
 
     /// Get all UTXO changes of a given slot by its index.
     /// GET /api/core/v3/commitments/by-slot/{slot}/utxo-changes
-    pub async fn get_utxo_changes_by_slot(&self, slot: SlotIndex) -> Result<UtxoChangesResponse> {
+    pub async fn get_utxo_changes_by_slot(&self, slot: SlotIndex) -> Result<UtxoChangesResponse, ClientError> {
         let path = &format!("api/core/v3/commitments/by-slot/{slot}/utxo-changes");
 
         self.get_request(path, None, false).await
@@ -373,7 +385,7 @@ impl Client {
 
     /// Get all full UTXO changes of a given slot by its index.
     /// GET /api/core/v3/commitments/by-slot/{slot}/utxo-changes/full
-    pub async fn get_utxo_changes_full_by_slot(&self, slot: SlotIndex) -> Result<UtxoChangesFullResponse> {
+    pub async fn get_utxo_changes_full_by_slot(&self, slot: SlotIndex) -> Result<UtxoChangesFullResponse, ClientError> {
         let path = &format!("api/core/v3/commitments/by-slot/{slot}/utxo-changes/full");
 
         self.get_request(path, None, false).await
@@ -382,14 +394,13 @@ impl Client {
 
 impl Client {
     /// GET /api/core/v3/info endpoint
-    pub async fn get_info(url: &str, auth: Option<NodeAuth>) -> Result<InfoResponse> {
+    pub async fn get_info(url: &str, auth: Option<NodeAuth>) -> Result<InfoResponse, ClientError> {
         let mut url = crate::client::node_manager::builder::validate_url(Url::parse(url)?)?;
         if let Some(auth) = &auth {
             if let Some((name, password)) = &auth.basic_auth_name_pwd {
-                url.set_username(name)
-                    .map_err(|_| crate::client::Error::UrlAuth("username"))?;
+                url.set_username(name).map_err(|_| ClientError::UrlAuth("username"))?;
                 url.set_password(Some(password))
-                    .map_err(|_| crate::client::Error::UrlAuth("password"))?;
+                    .map_err(|_| ClientError::UrlAuth("password"))?;
             }
         }
 
@@ -418,16 +429,16 @@ impl Client {
     }
 
     /// GET /api/core/v3/info endpoint
-    pub(crate) async fn get_permanode_info(mut node: Node) -> Result<PermanodeInfoResponse> {
+    pub(crate) async fn get_permanode_info(mut node: Node) -> Result<PermanodeInfoResponse, ClientError> {
         log::debug!("get_permanode_info");
         if let Some(auth) = &node.auth {
             if let Some((name, password)) = &auth.basic_auth_name_pwd {
                 node.url
                     .set_username(name)
-                    .map_err(|_| crate::client::Error::UrlAuth("username"))?;
+                    .map_err(|_| ClientError::UrlAuth("username"))?;
                 node.url
                     .set_password(Some(password))
-                    .map_err(|_| crate::client::Error::UrlAuth("password"))?;
+                    .map_err(|_| ClientError::UrlAuth("password"))?;
             }
         }
 

--- a/sdk/src/client/node_api/error.rs
+++ b/sdk/src/client/node_api/error.rs
@@ -1,9 +1,6 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-/// Type alias of `Result` in Node errors
-pub type Result<T> = std::result::Result<T, Error>;
-
 /// Node errors.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/sdk/src/client/node_api/indexer/mod.rs
+++ b/sdk/src/client/node_api/indexer/mod.rs
@@ -8,7 +8,7 @@ pub mod routes;
 
 use self::query_parameters::QueryParameter;
 use crate::{
-    client::{ClientInner, Result},
+    client::{ClientError, ClientInner},
     types::api::plugins::indexer::OutputIdsResponse,
 };
 
@@ -20,7 +20,7 @@ impl ClientInner {
         route: &str,
         mut query_parameters: impl QueryParameter,
         need_quorum: bool,
-    ) -> Result<OutputIdsResponse> {
+    ) -> Result<OutputIdsResponse, ClientError> {
         let mut merged_output_ids_response = OutputIdsResponse {
             committed_slot: 0,
             page_size: 1000,

--- a/sdk/src/client/node_api/indexer/routes.rs
+++ b/sdk/src/client/node_api/indexer/routes.rs
@@ -10,7 +10,7 @@ use crate::{
             DelegationOutputQueryParameters, FoundryOutputQueryParameters, NftOutputQueryParameters,
             OutputQueryParameters,
         },
-        Client, Error, Result,
+        Client, ClientError,
     },
     types::{
         api::plugins::indexer::OutputIdsResponse,
@@ -26,7 +26,7 @@ impl Client {
     /// GET with query parameter returns all outputIDs that fit these filter criteria.
     /// Returns Err(Node(NotFound) if no results are found.
     /// api/indexer/v2/outputs
-    pub async fn output_ids(&self, query_parameters: OutputQueryParameters) -> Result<OutputIdsResponse> {
+    pub async fn output_ids(&self, query_parameters: OutputQueryParameters) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -36,7 +36,10 @@ impl Client {
     /// GET with query parameter returns all outputIDs that fit these filter criteria.
     /// Returns Err(Node(NotFound) if no results are found.
     /// api/indexer/v2/outputs/basic
-    pub async fn basic_output_ids(&self, query_parameters: BasicOutputQueryParameters) -> Result<OutputIdsResponse> {
+    pub async fn basic_output_ids(
+        &self,
+        query_parameters: BasicOutputQueryParameters,
+    ) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs/basic";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -49,7 +52,7 @@ impl Client {
     pub async fn account_output_ids(
         &self,
         query_parameters: AccountOutputQueryParameters,
-    ) -> Result<OutputIdsResponse> {
+    ) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs/account";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -57,7 +60,7 @@ impl Client {
 
     /// Get account output by its accountID.
     /// api/indexer/v2/outputs/account/{bech32Address}
-    pub async fn account_output_id(&self, account_id: AccountId) -> Result<OutputId> {
+    pub async fn account_output_id(&self, account_id: AccountId) -> Result<OutputId, ClientError> {
         let bech32_address = account_id.to_bech32(self.get_bech32_hrp().await?);
         let route = format!("api/indexer/v2/outputs/account/{bech32_address}");
 
@@ -65,14 +68,17 @@ impl Client {
             .get_output_ids(&route, AccountOutputQueryParameters::new(), true)
             .await?
             .first()
-            .ok_or_else(|| Error::NoOutput(format!("{account_id:?}")))?))
+            .ok_or_else(|| ClientError::NoOutput(format!("{account_id:?}")))?))
     }
 
     /// Get anchor outputs filtered by the given parameters.
     /// GET with query parameter returns all outputIDs that fit these filter criteria.
     /// Returns Err(Node(NotFound) if no results are found.
     /// api/indexer/v2/outputs/anchor
-    pub async fn anchor_output_ids(&self, query_parameters: AnchorOutputQueryParameters) -> Result<OutputIdsResponse> {
+    pub async fn anchor_output_ids(
+        &self,
+        query_parameters: AnchorOutputQueryParameters,
+    ) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs/anchor";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -80,7 +86,7 @@ impl Client {
 
     /// Get anchor output by its anchorID.
     /// api/indexer/v2/outputs/anchor/{bech32Address}
-    pub async fn anchor_output_id(&self, anchor_id: AnchorId) -> Result<OutputId> {
+    pub async fn anchor_output_id(&self, anchor_id: AnchorId) -> Result<OutputId, ClientError> {
         let bech32_address = anchor_id.to_bech32(self.get_bech32_hrp().await?);
         let route = format!("api/indexer/v2/outputs/anchor/{bech32_address}");
 
@@ -88,7 +94,7 @@ impl Client {
             .get_output_ids(&route, AnchorOutputQueryParameters::new(), true)
             .await?
             .first()
-            .ok_or_else(|| Error::NoOutput(format!("{anchor_id:?}")))?))
+            .ok_or_else(|| ClientError::NoOutput(format!("{anchor_id:?}")))?))
     }
 
     /// Get delegation outputs filtered by the given parameters.
@@ -98,7 +104,7 @@ impl Client {
     pub async fn delegation_output_ids(
         &self,
         query_parameters: DelegationOutputQueryParameters,
-    ) -> Result<OutputIdsResponse> {
+    ) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs/delegation";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -106,14 +112,14 @@ impl Client {
 
     /// Get delegation output by its delegationID.
     /// api/indexer/v2/outputs/delegation/:{DelegationId}
-    pub async fn delegation_output_id(&self, delegation_id: DelegationId) -> Result<OutputId> {
+    pub async fn delegation_output_id(&self, delegation_id: DelegationId) -> Result<OutputId, ClientError> {
         let route = format!("api/indexer/v2/outputs/delegation/{delegation_id}");
 
         Ok(*(self
             .get_output_ids(&route, DelegationOutputQueryParameters::new(), true)
             .await?
             .first()
-            .ok_or_else(|| Error::NoOutput(format!("{delegation_id:?}")))?))
+            .ok_or_else(|| ClientError::NoOutput(format!("{delegation_id:?}")))?))
     }
 
     /// Get foundry outputs filtered by the given parameters.
@@ -123,7 +129,7 @@ impl Client {
     pub async fn foundry_output_ids(
         &self,
         query_parameters: FoundryOutputQueryParameters,
-    ) -> Result<OutputIdsResponse> {
+    ) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs/foundry";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -131,20 +137,23 @@ impl Client {
 
     /// Get foundry output by its foundryID.
     /// api/indexer/v2/outputs/foundry/:{FoundryID}
-    pub async fn foundry_output_id(&self, foundry_id: FoundryId) -> Result<OutputId> {
+    pub async fn foundry_output_id(&self, foundry_id: FoundryId) -> Result<OutputId, ClientError> {
         let route = format!("api/indexer/v2/outputs/foundry/{foundry_id}");
 
         Ok(*(self
             .get_output_ids(&route, FoundryOutputQueryParameters::new(), true)
             .await?
             .first()
-            .ok_or_else(|| Error::NoOutput(format!("{foundry_id:?}")))?))
+            .ok_or_else(|| ClientError::NoOutput(format!("{foundry_id:?}")))?))
     }
 
     /// Get NFT outputs filtered by the given parameters.
     /// Returns Err(Node(NotFound) if no results are found.
     /// api/indexer/v2/outputs/nft
-    pub async fn nft_output_ids(&self, query_parameters: NftOutputQueryParameters) -> Result<OutputIdsResponse> {
+    pub async fn nft_output_ids(
+        &self,
+        query_parameters: NftOutputQueryParameters,
+    ) -> Result<OutputIdsResponse, ClientError> {
         let route = "api/indexer/v2/outputs/nft";
 
         self.get_output_ids(route, query_parameters, true).await
@@ -152,7 +161,7 @@ impl Client {
 
     /// Get NFT output by its nftID.
     /// api/indexer/v2/outputs/nft/{bech32Address}
-    pub async fn nft_output_id(&self, nft_id: NftId) -> Result<OutputId> {
+    pub async fn nft_output_id(&self, nft_id: NftId) -> Result<OutputId, ClientError> {
         let bech32_address = nft_id.to_bech32(self.get_bech32_hrp().await?);
         let route = format!("api/indexer/v2/outputs/nft/{bech32_address}");
 
@@ -160,6 +169,6 @@ impl Client {
             .get_output_ids(&route, NftOutputQueryParameters::new(), true)
             .await?
             .first()
-            .ok_or_else(|| Error::NoOutput(format!("{nft_id:?}")))?))
+            .ok_or_else(|| ClientError::NoOutput(format!("{nft_id:?}")))?))
     }
 }

--- a/sdk/src/client/node_api/participation.rs
+++ b/sdk/src/client/node_api/participation.rs
@@ -6,7 +6,7 @@
 //! <https://github.com/iotaledger/inx-participation/blob/develop/components/participation/routes.go>
 
 use crate::{
-    client::{node_api::query_tuples_to_query_string, ClientInner, Result},
+    client::{node_api::query_tuples_to_query_string, ClientError, ClientInner},
     types::{
         api::plugins::participation::{
             responses::{AddressOutputsResponse, EventsResponse, OutputStatusResponse},
@@ -22,7 +22,7 @@ use crate::{
 
 impl ClientInner {
     /// RouteParticipationEvents is the route to list all events, returning their ID, the event name and status.
-    pub async fn events(&self, event_type: Option<ParticipationEventType>) -> Result<EventsResponse> {
+    pub async fn events(&self, event_type: Option<ParticipationEventType>) -> Result<EventsResponse, ClientError> {
         let route = "api/participation/v1/events";
 
         let query = query_tuples_to_query_string([event_type.map(|t| ("type", (t as u8).to_string()))]);
@@ -31,7 +31,7 @@ impl ClientInner {
     }
 
     /// RouteParticipationEvent is the route to access a single participation by its ID.
-    pub async fn event(&self, event_id: &ParticipationEventId) -> Result<ParticipationEventData> {
+    pub async fn event(&self, event_id: &ParticipationEventId) -> Result<ParticipationEventData, ClientError> {
         let route = format!("api/participation/v1/events/{event_id}");
 
         self.get_request(&route, None, false).await
@@ -42,7 +42,7 @@ impl ClientInner {
         &self,
         event_id: &ParticipationEventId,
         milestone_index: Option<u32>,
-    ) -> Result<ParticipationEventStatus> {
+    ) -> Result<ParticipationEventStatus, ClientError> {
         let route = format!("api/participation/v1/events/{event_id}/status");
 
         let query = query_tuples_to_query_string([milestone_index.map(|i| ("milestoneIndex", i.to_string()))]);
@@ -51,7 +51,7 @@ impl ClientInner {
     }
 
     /// RouteOutputStatus is the route to get the vote status for a given output ID.
-    pub async fn output_status(&self, output_id: &OutputId) -> Result<OutputStatusResponse> {
+    pub async fn output_status(&self, output_id: &OutputId) -> Result<OutputStatusResponse, ClientError> {
         let route = format!("api/participation/v1/outputs/{output_id}");
 
         self.get_request(&route, None, false).await
@@ -61,7 +61,7 @@ impl ClientInner {
     pub async fn address_staking_status(
         &self,
         bech32_address: impl ConvertTo<Bech32Address>,
-    ) -> Result<AddressStakingStatus> {
+    ) -> Result<AddressStakingStatus, ClientError> {
         let route = format!("api/participation/v1/addresses/{}", bech32_address.convert()?);
 
         self.get_request(&route, None, false).await
@@ -71,7 +71,7 @@ impl ClientInner {
     pub async fn address_participation_output_ids(
         &self,
         bech32_address: impl ConvertTo<Bech32Address>,
-    ) -> Result<AddressOutputsResponse> {
+    ) -> Result<AddressOutputsResponse, ClientError> {
         let route = format!("api/participation/v1/addresses/{}/outputs", bech32_address.convert()?);
 
         self.get_request(&route, None, false).await

--- a/sdk/src/client/node_api/plugin/mod.rs
+++ b/sdk/src/client/node_api/plugin/mod.rs
@@ -7,7 +7,7 @@ use core::str::FromStr;
 
 use reqwest::Method;
 
-use crate::client::{ClientInner, Result};
+use crate::client::{ClientError, ClientInner};
 
 impl ClientInner {
     /// Extension method which provides request methods for plugins.
@@ -18,7 +18,7 @@ impl ClientInner {
         endpoint: &str,
         query_params: Vec<String>,
         request_object: Option<String>,
-    ) -> Result<T>
+    ) -> Result<T, ClientError>
     where
         T: serde::de::DeserializeOwned + std::fmt::Debug + serde::Serialize,
     {
@@ -32,9 +32,9 @@ impl ClientInner {
         match req_method {
             Ok(Method::GET) => self.get_request(&path, None, false).await,
             Ok(Method::POST) => self.post_request(&path, request_object.into()).await,
-            _ => Err(crate::client::Error::Node(
-                crate::client::node_api::error::Error::NotSupported(method.to_string()),
-            )),
+            _ => Err(ClientError::Node(crate::client::node_api::error::Error::NotSupported(
+                method.to_string(),
+            ))),
         }
     }
 }

--- a/sdk/src/client/secret/ledger_nano.rs
+++ b/sdk/src/client/secret/ledger_nano.rs
@@ -28,9 +28,12 @@ use tokio::sync::Mutex;
 
 use super::{GenerateAddressOptions, SecretManage, SecretManagerConfig};
 use crate::{
-    client::secret::{
-        types::{LedgerApp, LedgerDeviceType},
-        LedgerNanoStatus, PreparedTransactionData,
+    client::{
+        secret::{
+            types::{LedgerApp, LedgerDeviceType},
+            LedgerNanoStatus, PreparedTransactionData,
+        },
+        ClientError,
     },
     types::block::{
         address::{AccountAddress, Address, NftAddress},
@@ -136,7 +139,7 @@ impl TryFrom<u8> for LedgerDeviceType {
 
 #[async_trait]
 impl SecretManage for LedgerSecretManager {
-    type Error = crate::client::Error;
+    type Error = ClientError;
 
     async fn generate_ed25519_public_keys(
         &self,

--- a/sdk/src/client/secret/private_key.rs
+++ b/sdk/src/client/secret/private_key.rs
@@ -17,7 +17,7 @@ use zeroize::{Zeroize, Zeroizing};
 
 use super::{GenerateAddressOptions, SecretManage};
 use crate::{
-    client::{api::PreparedTransactionData, Error},
+    client::{api::PreparedTransactionData, ClientError},
     types::block::{
         payload::signed_transaction::SignedTransactionPayload, protocol::ProtocolParameters,
         signature::Ed25519Signature, unlock::Unlocks,
@@ -35,7 +35,7 @@ impl std::fmt::Debug for PrivateKeySecretManager {
 
 #[async_trait]
 impl SecretManage for PrivateKeySecretManager {
-    type Error = Error;
+    type Error = ClientError;
 
     async fn generate_ed25519_public_keys(
         &self,
@@ -44,7 +44,7 @@ impl SecretManage for PrivateKeySecretManager {
         _address_indexes: Range<u32>,
         _options: impl Into<Option<GenerateAddressOptions>> + Send,
     ) -> Result<Vec<ed25519::PublicKey>, Self::Error> {
-        crate::client::Result::Ok(vec![self.0.public_key()])
+        Result::Ok(vec![self.0.public_key()])
     }
 
     async fn generate_evm_addresses(
@@ -55,7 +55,7 @@ impl SecretManage for PrivateKeySecretManager {
         _options: impl Into<Option<GenerateAddressOptions>> + Send,
     ) -> Result<Vec<EvmAddress>, Self::Error> {
         // TODO replace with a more fitting variant.
-        Err(Error::SecretManagerMismatch)
+        Err(ClientError::SecretManagerMismatch)
     }
 
     async fn sign_ed25519(&self, msg: &[u8], _chain: Bip44) -> Result<Ed25519Signature, Self::Error> {
@@ -71,7 +71,7 @@ impl SecretManage for PrivateKeySecretManager {
         _chain: Bip44,
     ) -> Result<(secp256k1_ecdsa::PublicKey, secp256k1_ecdsa::RecoverableSignature), Self::Error> {
         // TODO replace with a more fitting variant.
-        Err(Error::SecretManagerMismatch)
+        Err(ClientError::SecretManagerMismatch)
     }
 
     async fn transaction_unlocks(
@@ -93,7 +93,7 @@ impl SecretManage for PrivateKeySecretManager {
 
 impl PrivateKeySecretManager {
     /// Create a new [`PrivateKeySecretManager`] from a base 58 encoded private key.
-    pub fn try_from_b58<T: AsRef<[u8]>>(b58: T) -> Result<Self, Error> {
+    pub fn try_from_b58<T: AsRef<[u8]>>(b58: T) -> Result<Self, ClientError> {
         let mut bytes = [0u8; ed25519::SecretKey::LENGTH];
 
         // TODO replace with a more fitting variant.
@@ -114,7 +114,7 @@ impl PrivateKeySecretManager {
     }
 
     /// Create a new [`PrivateKeySecretManager`] from an hex encoded private key.
-    pub fn try_from_hex(hex: impl Into<Zeroizing<String>>) -> Result<Self, Error> {
+    pub fn try_from_hex(hex: impl Into<Zeroizing<String>>) -> Result<Self, ClientError> {
         let mut bytes = prefix_hex::decode(hex.into())?;
 
         let private_key = Self(ed25519::SecretKey::from_bytes(&bytes));

--- a/sdk/src/client/secret/private_key.rs
+++ b/sdk/src/client/secret/private_key.rs
@@ -44,7 +44,7 @@ impl SecretManage for PrivateKeySecretManager {
         _address_indexes: Range<u32>,
         _options: impl Into<Option<GenerateAddressOptions>> + Send,
     ) -> Result<Vec<ed25519::PublicKey>, Self::Error> {
-        Result::Ok(vec![self.0.public_key()])
+        Ok(vec![self.0.public_key()])
     }
 
     async fn generate_evm_addresses(

--- a/sdk/src/client/stronghold/secret.rs
+++ b/sdk/src/client/stronghold/secret.rs
@@ -33,6 +33,7 @@ use crate::{
         api::PreparedTransactionData,
         secret::{types::StrongholdDto, GenerateAddressOptions, SecretManage, SecretManagerConfig},
         stronghold::Error,
+        ClientError,
     },
     types::block::{
         payload::signed_transaction::SignedTransactionPayload, protocol::ProtocolParameters,
@@ -42,7 +43,7 @@ use crate::{
 
 #[async_trait]
 impl SecretManage for StrongholdAdapter {
-    type Error = crate::client::Error;
+    type Error = ClientError;
 
     async fn generate_ed25519_public_keys(
         &self,

--- a/sdk/src/client/utils.rs
+++ b/sdk/src/client/utils.rs
@@ -16,7 +16,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::Client;
 use crate::{
-    client::{Error, Result},
+    client::ClientError,
     types::block::{
         address::{Address, Bech32Address, Ed25519Address, Hrp, ToBech32Ext},
         output::{AccountId, AnchorId, NftId},
@@ -27,7 +27,7 @@ use crate::{
 };
 
 /// Transforms bech32 to hex
-pub fn bech32_to_hex(bech32: impl ConvertTo<Bech32Address>) -> Result<String> {
+pub fn bech32_to_hex(bech32: impl ConvertTo<Bech32Address>) -> Result<String, ClientError> {
     Ok(match bech32.convert()?.inner() {
         Address::Ed25519(ed) => ed.to_string(),
         Address::Account(account) => account.to_string(),
@@ -40,14 +40,17 @@ pub fn bech32_to_hex(bech32: impl ConvertTo<Bech32Address>) -> Result<String> {
 }
 
 /// Transforms a hex encoded address to a bech32 encoded address
-pub fn hex_to_bech32(hex: &str, bech32_hrp: impl ConvertTo<Hrp>) -> Result<Bech32Address> {
+pub fn hex_to_bech32(hex: &str, bech32_hrp: impl ConvertTo<Hrp>) -> Result<Bech32Address, ClientError> {
     let address = hex.parse::<Ed25519Address>()?;
 
     Ok(Address::Ed25519(address).try_to_bech32(bech32_hrp)?)
 }
 
 /// Transforms a prefix hex encoded public key to a bech32 encoded address
-pub fn hex_public_key_to_bech32_address(hex: &str, bech32_hrp: impl ConvertTo<Hrp>) -> Result<Bech32Address> {
+pub fn hex_public_key_to_bech32_address(
+    hex: &str,
+    bech32_hrp: impl ConvertTo<Hrp>,
+) -> Result<Bech32Address, ClientError> {
     let public_key: [u8; Ed25519Address::LENGTH] = prefix_hex::decode(hex)?;
     let address = Ed25519Address::new(Blake2b256::digest(public_key).into());
 
@@ -55,22 +58,22 @@ pub fn hex_public_key_to_bech32_address(hex: &str, bech32_hrp: impl ConvertTo<Hr
 }
 
 /// Generates a new mnemonic.
-pub fn generate_mnemonic() -> Result<Mnemonic> {
+pub fn generate_mnemonic() -> Result<Mnemonic, ClientError> {
     let mut entropy = [0u8; 32];
     utils::rand::fill(&mut entropy)?;
     let mnemonic = wordlist::encode(&entropy, &crypto::keys::bip39::wordlist::ENGLISH)
-        .map_err(|e| crate::client::Error::InvalidMnemonic(format!("{e:?}")))?;
+        .map_err(|e| ClientError::InvalidMnemonic(format!("{e:?}")))?;
     entropy.zeroize();
     Ok(mnemonic)
 }
 
 /// Returns a hex encoded seed for a mnemonic.
-pub fn mnemonic_to_hex_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<String> {
+pub fn mnemonic_to_hex_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<String, ClientError> {
     Ok(prefix_hex::encode(mnemonic_to_seed(mnemonic)?.as_ref()))
 }
 
 /// Returns a seed for a mnemonic.
-pub fn mnemonic_to_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<Seed> {
+pub fn mnemonic_to_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<Seed, ClientError> {
     // first we check if the mnemonic is valid to give meaningful errors
     verify_mnemonic(mnemonic.borrow())?;
     Ok(crypto::keys::bip39::mnemonic_to_seed(
@@ -80,14 +83,14 @@ pub fn mnemonic_to_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<Seed> {
 }
 
 /// Verifies that a &str is a valid mnemonic.
-pub fn verify_mnemonic(mnemonic: impl Borrow<MnemonicRef>) -> Result<()> {
+pub fn verify_mnemonic(mnemonic: impl Borrow<MnemonicRef>) -> Result<(), ClientError> {
     crypto::keys::bip39::wordlist::verify(mnemonic.borrow(), &crypto::keys::bip39::wordlist::ENGLISH)
-        .map_err(|e| crate::client::Error::InvalidMnemonic(format!("{e:?}")))?;
+        .map_err(|e| ClientError::InvalidMnemonic(format!("{e:?}")))?;
     Ok(())
 }
 
 /// Requests funds from a faucet
-pub async fn request_funds_from_faucet(url: &str, bech32_address: &Bech32Address) -> Result<String> {
+pub async fn request_funds_from_faucet(url: &str, bech32_address: &Bech32Address) -> Result<String, ClientError> {
     let mut map = HashMap::new();
     map.insert("address", bech32_address.to_string());
 
@@ -97,10 +100,10 @@ pub async fn request_funds_from_faucet(url: &str, bech32_address: &Bech32Address
         .json(&map)
         .send()
         .await
-        .map_err(|err| Error::Node(err.into()))?
+        .map_err(|err| ClientError::Node(err.into()))?
         .text()
         .await
-        .map_err(|err| Error::Node(err.into()))?;
+        .map_err(|err| ClientError::Node(err.into()))?;
     Ok(faucet_response)
 }
 
@@ -110,7 +113,7 @@ impl Client {
         &self,
         hex: &str,
         bech32_hrp: Option<impl ConvertTo<Hrp>>,
-    ) -> crate::client::Result<Bech32Address> {
+    ) -> Result<Bech32Address, ClientError> {
         match bech32_hrp {
             Some(hrp) => Ok(hex_to_bech32(hex, hrp)?),
             None => Ok(hex_to_bech32(hex, self.get_bech32_hrp().await?)?),
@@ -122,7 +125,7 @@ impl Client {
         &self,
         address: Address,
         bech32_hrp: Option<impl ConvertTo<Hrp>>,
-    ) -> crate::client::Result<Bech32Address> {
+    ) -> Result<Bech32Address, ClientError> {
         match bech32_hrp {
             Some(hrp) => Ok(address.to_bech32(hrp.convert()?)),
             None => Ok(address.to_bech32(self.get_bech32_hrp().await?)),
@@ -134,7 +137,7 @@ impl Client {
         &self,
         account_id: AccountId,
         bech32_hrp: Option<impl ConvertTo<Hrp>>,
-    ) -> crate::client::Result<Bech32Address> {
+    ) -> Result<Bech32Address, ClientError> {
         match bech32_hrp {
             Some(hrp) => Ok(account_id.to_bech32(hrp.convert()?)),
             None => Ok(account_id.to_bech32(self.get_bech32_hrp().await?)),
@@ -146,7 +149,7 @@ impl Client {
         &self,
         anchor_id: AnchorId,
         bech32_hrp: Option<impl ConvertTo<Hrp>>,
-    ) -> crate::client::Result<Bech32Address> {
+    ) -> Result<Bech32Address, ClientError> {
         match bech32_hrp {
             Some(hrp) => Ok(anchor_id.to_bech32(hrp.convert()?)),
             None => Ok(anchor_id.to_bech32(self.get_bech32_hrp().await?)),
@@ -158,7 +161,7 @@ impl Client {
         &self,
         nft_id: NftId,
         bech32_hrp: Option<impl ConvertTo<Hrp>>,
-    ) -> crate::client::Result<Bech32Address> {
+    ) -> Result<Bech32Address, ClientError> {
         match bech32_hrp {
             Some(hrp) => Ok(nft_id.to_bech32(hrp.convert()?)),
             None => Ok(nft_id.to_bech32(self.get_bech32_hrp().await?)),
@@ -170,7 +173,7 @@ impl Client {
         &self,
         hex: &str,
         bech32_hrp: Option<impl ConvertTo<Hrp>>,
-    ) -> crate::client::Result<Bech32Address> {
+    ) -> Result<Bech32Address, ClientError> {
         match bech32_hrp {
             Some(hrp) => Ok(hex_public_key_to_bech32_address(hex, hrp)?),
             None => Ok(hex_public_key_to_bech32_address(hex, self.get_bech32_hrp().await?)?),
@@ -178,41 +181,43 @@ impl Client {
     }
 
     /// Transforms bech32 to hex
-    pub fn bech32_to_hex(bech32: impl ConvertTo<Bech32Address>) -> crate::client::Result<String> {
+    pub fn bech32_to_hex(bech32: impl ConvertTo<Bech32Address>) -> Result<String, ClientError> {
         bech32_to_hex(bech32)
     }
 
     /// Generates a new mnemonic.
-    pub fn generate_mnemonic() -> Result<Mnemonic> {
+    pub fn generate_mnemonic() -> Result<Mnemonic, ClientError> {
         generate_mnemonic()
     }
 
     /// Returns a seed for a mnemonic.
-    pub fn mnemonic_to_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<Seed> {
+    pub fn mnemonic_to_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<Seed, ClientError> {
         mnemonic_to_seed(mnemonic)
     }
 
     /// Returns a hex encoded seed for a mnemonic.
-    pub fn mnemonic_to_hex_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<String> {
+    pub fn mnemonic_to_hex_seed(mnemonic: impl Borrow<MnemonicRef>) -> Result<String, ClientError> {
         mnemonic_to_hex_seed(mnemonic)
     }
 
     /// UTF-8 encodes the `tag` of a given TaggedDataPayload.
-    pub fn tag_to_utf8(payload: &TaggedDataPayload) -> Result<String> {
-        String::from_utf8(payload.tag().to_vec()).map_err(|_| Error::TaggedData("found invalid UTF-8".to_string()))
+    pub fn tag_to_utf8(payload: &TaggedDataPayload) -> Result<String, ClientError> {
+        String::from_utf8(payload.tag().to_vec())
+            .map_err(|_| ClientError::TaggedData("found invalid UTF-8".to_string()))
     }
 
     /// UTF-8 encodes the `data` of a given TaggedDataPayload.
-    pub fn data_to_utf8(payload: &TaggedDataPayload) -> Result<String> {
-        String::from_utf8(payload.data().to_vec()).map_err(|_| Error::TaggedData("found invalid UTF-8".to_string()))
+    pub fn data_to_utf8(payload: &TaggedDataPayload) -> Result<String, ClientError> {
+        String::from_utf8(payload.data().to_vec())
+            .map_err(|_| ClientError::TaggedData("found invalid UTF-8".to_string()))
     }
 
     /// UTF-8 encodes both the `tag` and `data` of a given TaggedDataPayload.
-    pub fn tagged_data_to_utf8(payload: &TaggedDataPayload) -> Result<(String, String)> {
+    pub fn tagged_data_to_utf8(payload: &TaggedDataPayload) -> Result<(String, String), ClientError> {
         Ok((Self::tag_to_utf8(payload)?, Self::data_to_utf8(payload)?))
     }
 
-    pub async fn block_id(&self, block: &Block) -> Result<BlockId> {
+    pub async fn block_id(&self, block: &Block) -> Result<BlockId, ClientError> {
         Ok(block.id(&self.get_protocol_parameters().await?))
     }
 }

--- a/sdk/src/types/block/address/error.rs
+++ b/sdk/src/types/block/address/error.rs
@@ -1,0 +1,55 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::{
+    types::block::{
+        address::{AddressCapabilityFlag, WeightedAddressCount},
+        capabilities::CapabilityError,
+        IdentifierError,
+    },
+    utils::ConversionError,
+};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum AddressError {
+    #[display(fmt = "invalid address kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid address weight: {_0}")]
+    Weight(u8),
+    #[display(fmt = "invalid address length: {_0}")]
+    Length(usize),
+    #[display(fmt = "invalid multi address threshold: {_0}")]
+    MultiAddressThreshold(u16),
+    #[display(fmt = "invalid multi address cumulative weight {cumulative_weight} < threshold {threshold}")]
+    MultiAddressCumulativeWeight { cumulative_weight: u16, threshold: u16 },
+    #[display(fmt = "invalid weighted address count: {_0}")]
+    WeightedAddressCount(<WeightedAddressCount as TryFrom<usize>>::Error),
+    #[display(fmt = "weighted addresses are not unique and/or sorted")]
+    WeightedAddressesNotUniqueSorted,
+    #[display(fmt = "restricted address capability: {_0:?}")]
+    RestrictedAddressCapability(AddressCapabilityFlag),
+    #[from]
+    Bech32Encoding(::bech32::DecodeError),
+    #[from]
+    Bech32Hrp(::bech32::primitives::hrp::Error),
+    #[from]
+    Hex(prefix_hex::Error),
+    #[from]
+    Identifier(IdentifierError),
+    #[from]
+    Convert(ConversionError),
+    #[from]
+    Capability(CapabilityError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AddressError {}
+
+impl From<Infallible> for AddressError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/address/restricted.rs
+++ b/sdk/src/types/block/address/restricted.rs
@@ -86,7 +86,7 @@ fn verify_address(address: &Address) -> Result<(), AddressError> {
         address,
         Address::Ed25519(_) | Address::Account(_) | Address::Nft(_) | Address::Anchor(_) | Address::Multi(_)
     ) {
-        Err(AddressError::InvalidAddressKind(address.kind()))
+        Err(AddressError::Kind(address.kind()))
     } else {
         Ok(())
     }

--- a/sdk/src/types/block/context_input/error.rs
+++ b/sdk/src/types/block/context_input/error.rs
@@ -1,0 +1,33 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{
+    context_input::{reward::RewardContextInputIndex, ContextInputCount},
+    IdentifierError,
+};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum ContextInputError {
+    #[display(fmt = "invalid context input kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid context input count: {_0}")]
+    Count(<ContextInputCount as TryFrom<usize>>::Error),
+    #[display(fmt = "context inputs are not unique and/or sorted")]
+    NotUniqueSorted,
+    #[display(fmt = "invalid reward input index: {_0}")]
+    RewardIndex(<RewardContextInputIndex as TryFrom<u16>>::Error),
+    #[from]
+    Identifier(IdentifierError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ContextInputError {}
+
+impl From<Infallible> for ContextInputError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/context_input/reward.rs
+++ b/sdk/src/types/block/context_input/reward.rs
@@ -15,9 +15,7 @@ pub(crate) type RewardContextInputIndex =
 /// A Reward Context Input indicates which transaction Input is claiming Mana rewards.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, packable::Packable)]
 #[packable(unpack_error = ContextInputError)]
-pub struct RewardContextInput(
-    #[packable(unpack_error_with = ContextInputError::InvalidRewardInputIndex)] RewardContextInputIndex,
-);
+pub struct RewardContextInput(#[packable(unpack_error_with = ContextInputError::RewardIndex)] RewardContextInputIndex);
 
 impl RewardContextInput {
     /// The context input kind of a [`RewardContextInput`].
@@ -25,10 +23,7 @@ impl RewardContextInput {
 
     /// Creates a new [`RewardContextInput`].
     pub fn new(index: u16) -> Result<Self, ContextInputError> {
-        index
-            .try_into()
-            .map(Self)
-            .map_err(ContextInputError::InvalidRewardInputIndex)
+        index.try_into().map(Self).map_err(ContextInputError::RewardIndex)
     }
 
     /// Returns the index of a [`RewardContextInput`].

--- a/sdk/src/types/block/core/block.rs
+++ b/sdk/src/types/block/core/block.rs
@@ -305,7 +305,7 @@ impl Packable for Block {
             };
 
             if block_len > Self::LENGTH_MAX {
-                return Err(UnpackError::Packable(BlockError::InvalidBlockLength(block_len)));
+                return Err(UnpackError::Packable(BlockError::Length(block_len)));
             }
         }
 

--- a/sdk/src/types/block/core/error.rs
+++ b/sdk/src/types/block/core/error.rs
@@ -21,9 +21,9 @@ use crate::types::block::{
 #[allow(missing_docs)]
 pub enum BlockError {
     #[display(fmt = "invalid block body kind: {_0}")]
-    InvalidBlockBodyKind(u8),
+    Kind(u8),
     #[display(fmt = "invalid block length {_0}")]
-    InvalidBlockLength(usize),
+    Length(usize),
     #[display(fmt = "remaining bytes after block")]
     RemainingBytesAfterBlock,
     #[display(fmt = "invalid parent count")]

--- a/sdk/src/types/block/core/mod.rs
+++ b/sdk/src/types/block/core/mod.rs
@@ -28,7 +28,7 @@ use crate::types::block::{
 #[derive(Clone, Debug, Eq, PartialEq, From, Packable)]
 #[packable(unpack_error = BlockError)]
 #[packable(unpack_visitor = ProtocolParameters)]
-#[packable(tag_type = u8, with_error = BlockError::InvalidBlockBodyKind)]
+#[packable(tag_type = u8, with_error = BlockError::Kind)]
 pub enum BlockBody {
     #[packable(tag = BasicBlockBody::KIND)]
     Basic(Box<BasicBlockBody>),
@@ -55,7 +55,7 @@ impl TryFrom<BlockBody> for BasicBlockBodyBuilder {
         if let BlockBody::Basic(block) = value {
             Ok((*block).into())
         } else {
-            Err(BlockError::InvalidBlockBodyKind(value.kind()))
+            Err(BlockError::Kind(value.kind()))
         }
     }
 }
@@ -67,7 +67,7 @@ impl TryFrom<BlockBody> for ValidationBlockBodyBuilder {
         if let BlockBody::Validation(block) = value {
             Ok((*block).into())
         } else {
-            Err(BlockError::InvalidBlockBodyKind(value.kind()))
+            Err(BlockError::Kind(value.kind()))
         }
     }
 }

--- a/sdk/src/types/block/core/validation.rs
+++ b/sdk/src/types/block/core/validation.rs
@@ -166,7 +166,7 @@ fn verify_protocol_parameters_hash(
     let params_hash = params.hash();
 
     if hash != &params_hash {
-        return Err(ProtocolParametersError::InvalidProtocolParametersHash {
+        return Err(ProtocolParametersError::Hash {
             expected: params_hash,
             actual: *hash,
         });

--- a/sdk/src/types/block/input/error.rs
+++ b/sdk/src/types/block/input/error.rs
@@ -1,0 +1,26 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{payload::InputCount, IdentifierError};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum InputError {
+    #[display(fmt = "invalid input kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid input count: {_0}")]
+    Count(<InputCount as TryFrom<usize>>::Error),
+    #[from]
+    Identifier(IdentifierError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for InputError {}
+
+impl From<Infallible> for InputError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/mana/error.rs
+++ b/sdk/src/types/block/mana/error.rs
@@ -1,0 +1,30 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{mana::allotment::ManaAllotmentCount, slot::EpochIndex};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[allow(missing_docs)]
+pub enum ManaError {
+    #[display(fmt = "invalid mana value: {_0}")]
+    Value(u64),
+    #[display(fmt = "invalid mana allotment count: {_0}")]
+    AllotmentCount(<ManaAllotmentCount as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid mana allotment sum: {sum} greater than max of {max}")]
+    AllotmentSum { max: u64, sum: u128 },
+    #[display(fmt = "mana allotments are not unique and/or sorted")]
+    AllotmentsNotUniqueSorted,
+    #[display(fmt = "invalid epoch diff: created {created}, target {target}")]
+    EpochDiff { created: EpochIndex, target: EpochIndex },
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ManaError {}
+
+impl From<Infallible> for ManaError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/mana/mod.rs
+++ b/sdk/src/types/block/mana/mod.rs
@@ -2,39 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod allotment;
+mod error;
 mod parameters;
 mod rewards;
 
-use core::convert::Infallible;
-
-pub(crate) use self::allotment::{verify_mana_allotments_sum, ManaAllotmentCount};
+pub(crate) use self::allotment::verify_mana_allotments_sum;
 pub use self::{
     allotment::{ManaAllotment, ManaAllotments},
+    error::ManaError,
     parameters::ManaParameters,
     rewards::RewardsParameters,
 };
-use crate::types::block::slot::EpochIndex;
-
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
-#[allow(missing_docs)]
-pub enum ManaError {
-    #[display(fmt = "invalid mana value: {_0}")]
-    InvalidManaValue(u64),
-    #[display(fmt = "invalid mana allotment count: {_0}")]
-    InvalidManaAllotmentCount(<ManaAllotmentCount as TryFrom<usize>>::Error),
-    #[display(fmt = "invalid mana allotment sum: {sum} greater than max of {max}")]
-    InvalidManaAllotmentSum { max: u64, sum: u128 },
-    #[display(fmt = "mana allotments are not unique and/or sorted")]
-    ManaAllotmentsNotUniqueSorted,
-    #[display(fmt = "invalid epoch diff: created {created}, target {target}")]
-    InvalidEpochDiff { created: EpochIndex, target: EpochIndex },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ManaError {}
-
-impl From<Infallible> for ManaError {
-    fn from(error: Infallible) -> Self {
-        match error {}
-    }
-}

--- a/sdk/src/types/block/mana/parameters.rs
+++ b/sdk/src/types/block/mana/parameters.rs
@@ -28,7 +28,7 @@ pub struct ManaParameters {
     pub(crate) generation_rate_exponent: u8,
     /// A lookup table of epoch index diff to mana decay factor.
     /// The actual decay factor is given by decay_factors\[epoch_diff\] * 2^(-decay_factors_exponent).
-    #[packable(unpack_error_with = |_| ProtocolParametersError::InvalidManaDecayFactors)]
+    #[packable(unpack_error_with = |_| ProtocolParametersError::ManaDecayFactors)]
     #[cfg_attr(feature = "serde", serde(with = "crate::utils::serde::boxed_slice_prefix"))]
     #[getset(skip)]
     pub(crate) decay_factors: BoxedSlicePrefix<u32, u16>,
@@ -112,7 +112,7 @@ impl ProtocolParameters {
         );
 
         if epoch_index_created > epoch_index_target {
-            return Err(ManaError::InvalidEpochDiff {
+            return Err(ManaError::EpochDiff {
                 created: epoch_index_created,
                 target: epoch_index_target,
             });
@@ -133,7 +133,7 @@ impl ProtocolParameters {
         let (reward_epoch, claimed_epoch) = (reward_epoch.into(), claimed_epoch.into());
 
         if reward_epoch > claimed_epoch {
-            return Err(ManaError::InvalidEpochDiff {
+            return Err(ManaError::EpochDiff {
                 created: reward_epoch,
                 target: claimed_epoch,
             });
@@ -157,7 +157,7 @@ impl ProtocolParameters {
         );
 
         if epoch_index_created > epoch_index_target {
-            return Err(ManaError::InvalidEpochDiff {
+            return Err(ManaError::EpochDiff {
                 created: epoch_index_created,
                 target: epoch_index_target,
             });
@@ -253,7 +253,7 @@ mod test {
                 stored_mana: 0,
                 created_slot: params().first_slot_of(2),
                 target_slot: params().first_slot_of(1),
-                err: Some(ManaError::InvalidEpochDiff {
+                err: Some(ManaError::EpochDiff {
                     created: 2.into(),
                     target: 1.into(),
                 }),
@@ -343,7 +343,7 @@ mod test {
                 created_slot: params().first_slot_of(2),
                 target_slot: params().first_slot_of(1),
                 potential_mana: None,
-                err: Some(ManaError::InvalidEpochDiff {
+                err: Some(ManaError::EpochDiff {
                     created: 2.into(),
                     target: 1.into(),
                 }),

--- a/sdk/src/types/block/output/delegation.rs
+++ b/sdk/src/types/block/output/delegation.rs
@@ -425,7 +425,7 @@ fn verify_validator_address(validator_address: &Address) -> Result<(), OutputErr
             return Err(OutputError::NullDelegationValidatorId);
         }
     } else {
-        return Err(OutputError::ValidatorAddress(AddressError::InvalidAddressKind(
+        return Err(OutputError::ValidatorAddress(AddressError::Kind(
             validator_address.kind(),
         )));
     }

--- a/sdk/src/types/block/output/error.rs
+++ b/sdk/src/types/block/output/error.rs
@@ -1,0 +1,71 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{
+    address::AddressError,
+    mana::ManaError,
+    output::{
+        feature::FeatureError, unlock_condition::UnlockConditionError, AccountId, AnchorId, NativeTokenError, NftId,
+        TokenSchemeError,
+    },
+};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum OutputError {
+    #[display(fmt = "invalid output kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid output amount: {_0}")]
+    Amount(u64),
+    #[display(fmt = "consumed mana overflow")]
+    ConsumedManaOverflow,
+    #[display(fmt = "the return deposit ({deposit}) must be greater than the minimum output amount ({required})")]
+    InsufficientStorageDepositReturnAmount { deposit: u64, required: u64 },
+    #[display(fmt = "insufficient output amount: {amount} (should be at least {required})")]
+    AmountLessThanMinimum { amount: u64, required: u64 },
+    #[display(fmt = "storage deposit return of {deposit} exceeds the original output amount of {amount}")]
+    StorageDepositReturnExceedsOutputAmount { deposit: u64, amount: u64 },
+    #[display(fmt = "missing address unlock condition")]
+    MissingAddressUnlockCondition,
+    #[display(fmt = "missing governor address unlock condition")]
+    MissingGovernorUnlockCondition,
+    #[display(fmt = "missing state controller address unlock condition")]
+    MissingStateControllerUnlockCondition,
+    #[display(fmt = "null delegation validator ID")]
+    NullDelegationValidatorId,
+    #[display(fmt = "invalid foundry zero serial number")]
+    InvalidFoundryZeroSerialNumber,
+    #[display(fmt = "non zero state index or foundry counter while account ID is all zero")]
+    NonZeroStateIndexOrFoundryCounter,
+    #[display(fmt = "invalid stakes amount")]
+    InvalidStakedAmount,
+    #[display(fmt = "invalid validator address: {_0}")]
+    ValidatorAddress(AddressError),
+    #[display(fmt = "self deposit nft output, NFT ID {_0}")]
+    SelfDepositNft(NftId),
+    #[display(fmt = "self controlled anchor output, anchor ID {_0}")]
+    SelfControlledAnchorOutput(AnchorId),
+    #[display(fmt = "self deposit account output, account ID {_0}")]
+    SelfDepositAccount(AccountId),
+    #[from]
+    UnlockCondition(UnlockConditionError),
+    #[from]
+    Feature(FeatureError),
+    #[from]
+    Mana(ManaError),
+    #[from]
+    NativeToken(NativeTokenError),
+    #[from]
+    TokenScheme(TokenSchemeError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for OutputError {}
+
+impl From<Infallible> for OutputError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/output/feature/error.rs
+++ b/sdk/src/types/block/output/feature/error.rs
@@ -1,0 +1,59 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{
+    address::AddressError,
+    output::{
+        feature::{
+            BlockIssuerKeyCount, FeatureCount, MetadataFeatureEntryCount, MetadataFeatureKeyLength,
+            MetadataFeatureValueLength, TagFeatureLength,
+        },
+        NativeTokenError,
+    },
+};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum FeatureError {
+    #[display(fmt = "invalid feature kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid feature count: {_0}")]
+    Count(<FeatureCount as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid tag feature length {_0}")]
+    TagFeatureLength(<TagFeatureLength as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid metadata feature: {_0}")]
+    MetadataFeature(String),
+    #[display(fmt = "invalid metadata feature entry count: {_0}")]
+    MetadataFeatureEntryCount(<MetadataFeatureEntryCount as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid metadata feature key length: {_0}")]
+    MetadataFeatureKeyLength(<MetadataFeatureKeyLength as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid metadata feature value length: {_0}")]
+    MetadataFeatureValueLength(<MetadataFeatureValueLength as TryFrom<usize>>::Error),
+    #[display(fmt = "features are not unique and/or sorted")]
+    NotUniqueSorted,
+    #[display(fmt = "disallowed feature at index {index} with kind {kind}")]
+    Disallowed { index: usize, kind: u8 },
+    #[display(fmt = "non graphic ASCII key: {_0:?}")]
+    NonGraphicAsciiMetadataKey(Vec<u8>),
+    #[display(fmt = "invalid block issuer key kind: {_0}")]
+    InvalidBlockIssuerKeyKind(u8),
+    #[display(fmt = "invalid block issuer key count: {_0}")]
+    InvalidBlockIssuerKeyCount(<BlockIssuerKeyCount as TryFrom<usize>>::Error),
+    #[display(fmt = "block issuer keys are not unique and/or sorted")]
+    BlockIssuerKeysNotUniqueSorted,
+    #[from]
+    NativeToken(NativeTokenError),
+    #[from]
+    Address(AddressError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FeatureError {}
+
+impl From<Infallible> for FeatureError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/output/feature/error.rs
+++ b/sdk/src/types/block/output/feature/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::{string::String, vec::Vec};
 use core::convert::Infallible;
 
 use crate::types::block::{

--- a/sdk/src/types/block/output/feature/metadata.rs
+++ b/sdk/src/types/block/output/feature/metadata.rs
@@ -50,10 +50,8 @@ pub(crate) fn verify_keys(map: &MetadataBTreeMapPrefix) -> Result<(), FeatureErr
 }
 
 pub(crate) fn verify_packed_len(len: usize, bytes_length_range: RangeInclusive<u16>) -> Result<(), FeatureError> {
-    if !bytes_length_range
-        .contains(&u16::try_from(len).map_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?)
-    {
-        return Err(FeatureError::InvalidMetadataFeature(format!(
+    if !bytes_length_range.contains(&u16::try_from(len).map_err(|e| FeatureError::MetadataFeature(e.to_string()))?) {
+        return Err(FeatureError::MetadataFeature(format!(
             "Out of bounds byte length: {len}"
         )));
     }
@@ -138,14 +136,14 @@ impl MetadataFeatureMap {
                             BoxedSlicePrefix::<u8, MetadataFeatureKeyLength>::try_from(
                                 k.as_bytes().to_vec().into_boxed_slice(),
                             )
-                            .map_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?,
+                            .map_err(|e| FeatureError::MetadataFeature(e.to_string()))?,
                             BoxedSlicePrefix::<u8, MetadataFeatureValueLength>::try_from(v.clone().into_boxed_slice())
-                                .map_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?,
+                                .map_err(|e| FeatureError::MetadataFeature(e.to_string()))?,
                         ))
                     })
                     .collect::<Result<MetadataBTreeMap, FeatureError>>()?,
             )
-            .map_err(FeatureError::InvalidMetadataFeatureEntryCount)?,
+            .map_err(FeatureError::MetadataFeatureEntryCount)?,
         );
 
         verify_keys(&res.0)?;
@@ -188,7 +186,7 @@ impl Packable for MetadataFeature {
         let mut unpacker = CounterUnpacker::new(unpacker);
         let res = Self(
             MetadataBTreeMapPrefix::unpack(&mut unpacker, visitor)
-                .map_packable_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?,
+                .map_packable_err(|e| FeatureError::MetadataFeature(e.to_string()))?,
         );
 
         if visitor.is_some() {

--- a/sdk/src/types/block/output/feature/state_metadata.rs
+++ b/sdk/src/types/block/output/feature/state_metadata.rs
@@ -108,14 +108,14 @@ impl StateMetadataFeatureMap {
                             BoxedSlicePrefix::<u8, MetadataFeatureKeyLength>::try_from(
                                 k.as_bytes().to_vec().into_boxed_slice(),
                             )
-                            .map_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?,
+                            .map_err(|e| FeatureError::MetadataFeature(e.to_string()))?,
                             BoxedSlicePrefix::<u8, MetadataFeatureValueLength>::try_from(v.clone().into_boxed_slice())
-                                .map_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?,
+                                .map_err(|e| FeatureError::MetadataFeature(e.to_string()))?,
                         ))
                     })
                     .collect::<Result<MetadataBTreeMap, FeatureError>>()?,
             )
-            .map_err(FeatureError::InvalidMetadataFeatureEntryCount)?,
+            .map_err(FeatureError::MetadataFeatureEntryCount)?,
         );
 
         verify_keys(&res.0)?;
@@ -158,7 +158,7 @@ impl Packable for StateMetadataFeature {
         let mut unpacker = CounterUnpacker::new(unpacker);
         let res = Self(
             MetadataBTreeMapPrefix::unpack(&mut unpacker, visitor)
-                .map_packable_err(|e| FeatureError::InvalidMetadataFeature(e.to_string()))?,
+                .map_packable_err(|e| FeatureError::MetadataFeature(e.to_string()))?,
         );
 
         if visitor.is_some() {

--- a/sdk/src/types/block/output/feature/tag.rs
+++ b/sdk/src/types/block/output/feature/tag.rs
@@ -16,7 +16,7 @@ pub(crate) type TagFeatureLength =
 
 /// Makes it possible to tag outputs with an index, so they can be retrieved through an indexer API.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, packable::Packable)]
-#[packable(unpack_error = FeatureError, with = |e| FeatureError::InvalidTagFeatureLength(e.into_prefix_err().into()))]
+#[packable(unpack_error = FeatureError, with = |e| FeatureError::TagFeatureLength(e.into_prefix_err().into()))]
 pub struct TagFeature(
     // Binary tag.
     pub(crate) BoxedSlicePrefix<u8, TagFeatureLength>,
@@ -57,7 +57,7 @@ impl TryFrom<Box<[u8]>> for TagFeature {
     type Error = FeatureError;
 
     fn try_from(tag: Box<[u8]>) -> Result<Self, Self::Error> {
-        tag.try_into().map(Self).map_err(FeatureError::InvalidTagFeatureLength)
+        tag.try_into().map(Self).map_err(FeatureError::TagFeatureLength)
     }
 }
 

--- a/sdk/src/types/block/output/output_id_proof.rs
+++ b/sdk/src/types/block/output/output_id_proof.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug, derive_more::Display)]
 pub enum ProofError {
     #[display(fmt = "invalid output ID proof kind: {_0}")]
-    InvalidProofKind(u8),
+    Kind(u8),
     #[display(fmt = "index {index} is out of range, outputs length {len}")]
     IndexOutOfRange { index: u16, len: u16 },
     #[display(fmt = "no outputs provided")]
@@ -117,14 +117,14 @@ impl OutputCommitmentProof {
 
 fn verify_output_commitment_type(proof: &OutputCommitmentProof) -> Result<(), ProofError> {
     match proof {
-        OutputCommitmentProof::Leaf(_) => Err(ProofError::InvalidProofKind(LeafHash::KIND)),
+        OutputCommitmentProof::Leaf(_) => Err(ProofError::Kind(LeafHash::KIND)),
         _ => Ok(()),
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, derive_more::From, Packable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
-#[packable(tag_type = u8, with_error = ProofError::InvalidProofKind)]
+#[packable(tag_type = u8, with_error = ProofError::Kind)]
 #[packable(unpack_error = ProofError)]
 pub enum OutputCommitmentProof {
     #[packable(tag = HashableNode::KIND)]

--- a/sdk/src/types/block/output/token_scheme/error.rs
+++ b/sdk/src/types/block/output/token_scheme/error.rs
@@ -1,0 +1,24 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use primitive_types::U256;
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[allow(missing_docs)]
+pub enum TokenSchemeError {
+    #[display(fmt = "invalid token scheme kind {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid foundry output supply: minted {minted}, melted {melted} max {max}")]
+    FoundryOutputSupply { minted: U256, melted: U256, max: U256 },
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TokenSchemeError {}
+
+impl From<Infallible> for TokenSchemeError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/output/token_scheme/error.rs
+++ b/sdk/src/types/block/output/token_scheme/error.rs
@@ -11,7 +11,7 @@ pub enum TokenSchemeError {
     #[display(fmt = "invalid token scheme kind {_0}")]
     Kind(u8),
     #[display(fmt = "invalid foundry output supply: minted {minted}, melted {melted} max {max}")]
-    FoundryOutputSupply { minted: U256, melted: U256, max: U256 },
+    Supply { minted: U256, melted: U256, max: U256 },
 }
 
 #[cfg(feature = "std")]

--- a/sdk/src/types/block/output/token_scheme/mod.rs
+++ b/sdk/src/types/block/output/token_scheme/mod.rs
@@ -1,37 +1,16 @@
 // Copyright 2020-2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+mod error;
 mod simple;
 
-use core::convert::Infallible;
-
-use primitive_types::U256;
-
-pub use self::simple::SimpleTokenScheme;
+pub use self::{error::TokenSchemeError, simple::SimpleTokenScheme};
 use crate::types::block::protocol::{WorkScore, WorkScoreParameters};
-
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
-#[allow(missing_docs)]
-pub enum TokenSchemeError {
-    #[display(fmt = "invalid token scheme kind {_0}")]
-    InvalidTokenSchemeKind(u8),
-    #[display(fmt = "invalid foundry output supply: minted {minted}, melted {melted} max {max}")]
-    InvalidFoundryOutputSupply { minted: U256, melted: U256, max: U256 },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for TokenSchemeError {}
-
-impl From<Infallible> for TokenSchemeError {
-    fn from(error: Infallible) -> Self {
-        match error {}
-    }
-}
 
 ///
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, derive_more::From, packable::Packable)]
 #[packable(unpack_error = TokenSchemeError)]
-#[packable(tag_type = u8, with_error = TokenSchemeError::InvalidTokenSchemeKind)]
+#[packable(tag_type = u8, with_error = TokenSchemeError::Kind)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum TokenScheme {
     ///

--- a/sdk/src/types/block/output/token_scheme/simple.rs
+++ b/sdk/src/types/block/output/token_scheme/simple.rs
@@ -85,7 +85,7 @@ fn verify_simple_token_scheme(token_scheme: &SimpleTokenScheme) -> Result<(), To
         || token_scheme.melted_tokens > token_scheme.minted_tokens
         || token_scheme.minted_tokens - token_scheme.melted_tokens > token_scheme.maximum_supply
     {
-        return Err(TokenSchemeError::InvalidFoundryOutputSupply {
+        return Err(TokenSchemeError::FoundryOutputSupply {
             minted: token_scheme.minted_tokens,
             melted: token_scheme.melted_tokens,
             max: token_scheme.maximum_supply,

--- a/sdk/src/types/block/output/token_scheme/simple.rs
+++ b/sdk/src/types/block/output/token_scheme/simple.rs
@@ -85,7 +85,7 @@ fn verify_simple_token_scheme(token_scheme: &SimpleTokenScheme) -> Result<(), To
         || token_scheme.melted_tokens > token_scheme.minted_tokens
         || token_scheme.minted_tokens - token_scheme.melted_tokens > token_scheme.maximum_supply
     {
-        return Err(TokenSchemeError::FoundryOutputSupply {
+        return Err(TokenSchemeError::Supply {
             minted: token_scheme.minted_tokens,
             melted: token_scheme.melted_tokens,
             max: token_scheme.maximum_supply,

--- a/sdk/src/types/block/output/unlock_condition/error.rs
+++ b/sdk/src/types/block/output/unlock_condition/error.rs
@@ -1,0 +1,36 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{address::AddressError, output::unlock_condition::UnlockConditionCount};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum UnlockConditionError {
+    #[display(fmt = "invalid unlock condition kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid unlock condition count: {_0}")]
+    Count(<UnlockConditionCount as TryFrom<usize>>::Error),
+    #[display(fmt = "expiration unlock condition with milestone index and timestamp set to 0")]
+    ExpirationZero,
+    #[display(fmt = "timelock unlock condition with milestone index and timestamp set to 0")]
+    TimelockZero,
+    #[display(fmt = "unlock conditions are not unique and/or sorted")]
+    NotUniqueSorted,
+    #[display(fmt = "disallowed unlock condition at index {index} with kind {kind}")]
+    Disallowed { index: usize, kind: u8 },
+    #[display(fmt = "missing slot index")]
+    MissingSlotIndex,
+    #[from]
+    Address(AddressError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnlockConditionError {}
+
+impl From<Infallible> for UnlockConditionError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/output/unlock_condition/expiration.rs
+++ b/sdk/src/types/block/output/unlock_condition/expiration.rs
@@ -100,7 +100,7 @@ impl StorageScore for ExpirationUnlockCondition {
 #[inline]
 fn verify_return_address(return_address: &Address) -> Result<(), UnlockConditionError> {
     if return_address.is_implicit_account_creation() {
-        Err(AddressError::InvalidAddressKind(return_address.kind()).into())
+        Err(AddressError::Kind(return_address.kind()).into())
     } else {
         Ok(())
     }
@@ -109,7 +109,7 @@ fn verify_return_address(return_address: &Address) -> Result<(), UnlockCondition
 #[inline]
 fn verify_slot_index(slot_index: &SlotIndex) -> Result<(), UnlockConditionError> {
     if *slot_index == 0 {
-        Err(UnlockConditionError::ExpirationUnlockConditionZero)
+        Err(UnlockConditionError::ExpirationZero)
     } else {
         Ok(())
     }

--- a/sdk/src/types/block/output/unlock_condition/immutable_account_address.rs
+++ b/sdk/src/types/block/output/unlock_condition/immutable_account_address.rs
@@ -39,7 +39,7 @@ impl StorageScore for ImmutableAccountAddressUnlockCondition {
 #[inline]
 fn verify_address(address: &Address) -> Result<(), UnlockConditionError> {
     if !address.is_account() {
-        Err(AddressError::InvalidAddressKind(address.kind()).into())
+        Err(AddressError::Kind(address.kind()).into())
     } else {
         Ok(())
     }

--- a/sdk/src/types/block/output/unlock_condition/mod.rs
+++ b/sdk/src/types/block/output/unlock_condition/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod address;
+mod error;
 mod expiration;
 mod governor_address;
 mod immutable_account_address;
@@ -10,7 +11,6 @@ mod storage_deposit_return;
 mod timelock;
 
 use alloc::{boxed::Box, collections::BTreeSet, vec::Vec};
-use core::convert::Infallible;
 
 use bitflags::bitflags;
 use derive_more::{Deref, From};
@@ -18,7 +18,7 @@ use iterator_sorted::is_unique_sorted;
 use packable::{bounded::BoundedU8, prefix::BoxedSlicePrefix, Packable};
 
 pub use self::{
-    address::AddressUnlockCondition, expiration::ExpirationUnlockCondition,
+    address::AddressUnlockCondition, error::UnlockConditionError, expiration::ExpirationUnlockCondition,
     governor_address::GovernorAddressUnlockCondition,
     immutable_account_address::ImmutableAccountAddressUnlockCondition,
     state_controller_address::StateControllerAddressUnlockCondition,
@@ -34,42 +34,12 @@ use crate::types::block::{
     slot::SlotIndex,
 };
 
-#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
-#[allow(missing_docs)]
-pub enum UnlockConditionError {
-    #[display(fmt = "invalid unlock condition kind: {_0}")]
-    InvalidUnlockConditionKind(u8),
-    #[display(fmt = "invalid unlock condition count: {_0}")]
-    InvalidUnlockConditionCount(<UnlockConditionCount as TryFrom<usize>>::Error),
-    #[display(fmt = "expiration unlock condition with milestone index and timestamp set to 0")]
-    ExpirationUnlockConditionZero,
-    #[display(fmt = "timelock unlock condition with milestone index and timestamp set to 0")]
-    TimelockUnlockConditionZero,
-    #[display(fmt = "unlock conditions are not unique and/or sorted")]
-    UnlockConditionsNotUniqueSorted,
-    #[display(fmt = "disallowed unlock condition at index {index} with kind {kind}")]
-    DisallowedUnlockCondition { index: usize, kind: u8 },
-    #[display(fmt = "missing slot index")]
-    MissingSlotIndex,
-    #[from]
-    Address(AddressError),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for UnlockConditionError {}
-
-impl From<Infallible> for UnlockConditionError {
-    fn from(error: Infallible) -> Self {
-        match error {}
-    }
-}
-
 ///
 #[derive(Clone, Eq, PartialEq, Hash, From, Packable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 #[packable(unpack_error = UnlockConditionError)]
 #[packable(unpack_visitor = ProtocolParameters)]
-#[packable(tag_type = u8, with_error = UnlockConditionError::InvalidUnlockConditionKind)]
+#[packable(tag_type = u8, with_error = UnlockConditionError::Kind)]
 pub enum UnlockCondition {
     /// An address unlock condition.
     #[packable(tag = AddressUnlockCondition::KIND)]
@@ -193,7 +163,7 @@ pub(crate) type UnlockConditionCount = BoundedU8<0, { UnlockConditionFlags::ALL_
 
 ///
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, Packable)]
-#[packable(unpack_error = UnlockConditionError, with = |e| e.unwrap_item_err_or_else(|p| UnlockConditionError::InvalidUnlockConditionCount(p.into())))]
+#[packable(unpack_error = UnlockConditionError, with = |e| e.unwrap_item_err_or_else(|p| UnlockConditionError::Count(p.into())))]
 #[packable(unpack_visitor = ProtocolParameters)]
 pub struct UnlockConditions(
     #[packable(verify_with = verify_unique_sorted_packable)] BoxedSlicePrefix<UnlockCondition, UnlockConditionCount>,
@@ -231,7 +201,7 @@ impl UnlockConditions {
     pub fn from_vec(unlock_conditions: Vec<UnlockCondition>) -> Result<Self, UnlockConditionError> {
         let mut unlock_conditions =
             BoxedSlicePrefix::<UnlockCondition, UnlockConditionCount>::try_from(unlock_conditions.into_boxed_slice())
-                .map_err(UnlockConditionError::InvalidUnlockConditionCount)?;
+                .map_err(UnlockConditionError::Count)?;
 
         unlock_conditions.sort_by_key(UnlockCondition::kind);
         // Sort is obviously fine now but uniqueness still needs to be checked.
@@ -247,7 +217,7 @@ impl UnlockConditions {
                 .into_iter()
                 .collect::<Box<[_]>>()
                 .try_into()
-                .map_err(UnlockConditionError::InvalidUnlockConditionCount)?,
+                .map_err(UnlockConditionError::Count)?,
         ))
     }
 
@@ -374,7 +344,7 @@ impl StorageScore for UnlockConditions {
 #[inline]
 fn verify_unique_sorted(unlock_conditions: &[UnlockCondition]) -> Result<(), UnlockConditionError> {
     if !is_unique_sorted(unlock_conditions.iter().map(UnlockCondition::kind)) {
-        Err(UnlockConditionError::UnlockConditionsNotUniqueSorted)
+        Err(UnlockConditionError::NotUniqueSorted)
     } else {
         Ok(())
     }
@@ -394,7 +364,7 @@ pub(crate) fn verify_allowed_unlock_conditions(
 ) -> Result<(), UnlockConditionError> {
     for (index, unlock_condition) in unlock_conditions.iter().enumerate() {
         if !allowed_unlock_conditions.contains(unlock_condition.flag()) {
-            return Err(UnlockConditionError::DisallowedUnlockCondition {
+            return Err(UnlockConditionError::Disallowed {
                 index,
                 kind: unlock_condition.kind(),
             });

--- a/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
+++ b/sdk/src/types/block/output/unlock_condition/storage_deposit_return.rs
@@ -57,7 +57,7 @@ impl StorageScore for StorageDepositReturnUnlockCondition {
 #[inline]
 fn verify_return_address(return_address: &Address) -> Result<(), UnlockConditionError> {
     if return_address.is_implicit_account_creation() {
-        Err(AddressError::InvalidAddressKind(return_address.kind()).into())
+        Err(AddressError::Kind(return_address.kind()).into())
     } else {
         Ok(())
     }

--- a/sdk/src/types/block/output/unlock_condition/timelock.rs
+++ b/sdk/src/types/block/output/unlock_condition/timelock.rs
@@ -44,7 +44,7 @@ impl StorageScore for TimelockUnlockCondition {}
 #[inline]
 fn verify_slot_index(slot_index: &SlotIndex) -> Result<(), UnlockConditionError> {
     if *slot_index == 0 {
-        Err(UnlockConditionError::TimelockUnlockConditionZero)
+        Err(UnlockConditionError::TimelockZero)
     } else {
         Ok(())
     }

--- a/sdk/src/types/block/payload/error.rs
+++ b/sdk/src/types/block/payload/error.rs
@@ -1,0 +1,83 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{
+    capabilities::CapabilityError,
+    context_input::ContextInputError,
+    input::{InputError, UtxoInput},
+    mana::ManaError,
+    output::{
+        feature::FeatureError, unlock_condition::UnlockConditionError, ChainId, NativeTokenError, OutputError,
+        TokenSchemeError,
+    },
+    payload::{
+        tagged_data::{TagLength, TaggedDataLength},
+        InputCount, OutputCount,
+    },
+    semantic::TransactionFailureReason,
+    unlock::UnlockError,
+};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum PayloadError {
+    #[display(fmt = "invalid payload kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid payload length: expected {expected} but got {actual}")]
+    Length { expected: usize, actual: usize },
+    #[display(fmt = "invalid timestamp: {_0}")]
+    Timestamp(String),
+    #[display(fmt = "invalid network id: {_0}")]
+    NetworkId(String),
+    #[display(fmt = "network ID mismatch: expected {expected} but got {actual}")]
+    NetworkIdMismatch { expected: u64, actual: u64 },
+    #[display(fmt = "invalid tagged data length: {_0}")]
+    TaggedDataLength(<TaggedDataLength as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid tag length: {_0}")]
+    TagLength(<TagLength as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid input count: {_0}")]
+    InputCount(<InputCount as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid output count: {_0}")]
+    OutputCount(<OutputCount as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid transaction amount sum: {_0}")]
+    TransactionAmountSum(u128),
+    #[display(fmt = "duplicate output chain: {_0}")]
+    DuplicateOutputChain(ChainId),
+    #[display(fmt = "duplicate UTXO {_0} in inputs")]
+    DuplicateUtxo(UtxoInput),
+    #[display(fmt = "missing creation slot")]
+    MissingCreationSlot,
+    #[display(fmt = "input count and unlock count mismatch: {input_count} != {unlock_count}")]
+    InputUnlockCountMismatch { input_count: usize, unlock_count: usize },
+    #[from]
+    TransactionSemantic(TransactionFailureReason),
+    #[from]
+    Input(InputError),
+    #[from]
+    Output(OutputError),
+    #[from]
+    Unlock(UnlockError),
+    #[from]
+    ContextInput(ContextInputError),
+    #[from]
+    Capabilities(CapabilityError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PayloadError {}
+
+crate::impl_from_error_via!(PayloadError via OutputError:
+    NativeTokenError,
+    ManaError,
+    UnlockConditionError,
+    FeatureError,
+    TokenSchemeError,
+);
+
+impl From<Infallible> for PayloadError {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}

--- a/sdk/src/types/block/payload/error.rs
+++ b/sdk/src/types/block/payload/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::string::String;
 use core::convert::Infallible;
 
 use crate::types::block::{

--- a/sdk/src/types/block/payload/tagged_data.rs
+++ b/sdk/src/types/block/payload/tagged_data.rs
@@ -27,9 +27,9 @@ pub(crate) type TaggedDataLength =
 #[derive(Clone, Eq, PartialEq, Packable)]
 #[packable(unpack_error = PayloadError)]
 pub struct TaggedDataPayload {
-    #[packable(unpack_error_with = |err| PayloadError::InvalidTagLength(err.into_prefix_err().into()))]
+    #[packable(unpack_error_with = |err| PayloadError::TagLength(err.into_prefix_err().into()))]
     tag: BoxedSlicePrefix<u8, TagLength>,
-    #[packable(unpack_error_with = |err| PayloadError::InvalidTaggedDataLength(err.into_prefix_err().into()))]
+    #[packable(unpack_error_with = |err| PayloadError::TaggedDataLength(err.into_prefix_err().into()))]
     data: BoxedSlicePrefix<u8, TaggedDataLength>,
 }
 
@@ -44,8 +44,8 @@ impl TaggedDataPayload {
     /// Creates a new [`TaggedDataPayload`].
     pub fn new(tag: impl Into<Box<[u8]>>, data: impl Into<Box<[u8]>>) -> Result<Self, PayloadError> {
         Ok(Self {
-            tag: tag.into().try_into().map_err(PayloadError::InvalidTagLength)?,
-            data: data.into().try_into().map_err(PayloadError::InvalidTaggedDataLength)?,
+            tag: tag.into().try_into().map_err(PayloadError::TagLength)?,
+            data: data.into().try_into().map_err(PayloadError::TaggedDataLength)?,
         })
     }
 

--- a/sdk/src/types/block/protocol/error.rs
+++ b/sdk/src/types/block/protocol/error.rs
@@ -1,0 +1,35 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use alloc::string::FromUtf8Error;
+use core::convert::Infallible;
+
+use crate::types::block::{address::AddressError, mana::ManaError, protocol::ProtocolParametersHash};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum ProtocolParametersError {
+    #[display(fmt = "invalid network name: {_0}")]
+    NetworkName(FromUtf8Error),
+    #[display(fmt = "invalid mana decay factors")]
+    ManaDecayFactors,
+    StringPrefix(<u8 as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid protocol parameters hash: expected {expected} but got {actual}")]
+    Hash {
+        expected: ProtocolParametersHash,
+        actual: ProtocolParametersHash,
+    },
+    #[from]
+    ManaParameters(ManaError),
+    #[from]
+    Address(AddressError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ProtocolParametersError {}
+
+impl From<Infallible> for ProtocolParametersError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/signature/ed25519.rs
+++ b/sdk/src/types/block/signature/ed25519.rs
@@ -97,16 +97,13 @@ impl Ed25519Signature {
         let signature_address: [u8; Self::PUBLIC_KEY_LENGTH] = Blake2b256::digest(self.public_key).into();
 
         if address.deref() != &signature_address {
-            return Err(SignatureError::SignaturePublicKeyMismatch {
+            return Err(SignatureError::PublicKeyMismatch {
                 expected: prefix_hex::encode(address.as_ref()),
                 actual: prefix_hex::encode(signature_address),
             });
         }
 
-        if !self
-            .try_verify(message)
-            .map_err(SignatureError::InvalidSignatureBytes)?
-        {
+        if !self.try_verify(message).map_err(SignatureError::SignatureBytes)? {
             return Err(SignatureError::SignatureMismatch(prefix_hex::encode(message)));
         }
 
@@ -199,8 +196,8 @@ pub(crate) mod dto {
 
         fn try_from(value: Ed25519SignatureDto) -> Result<Self, Self::Error> {
             Ok(Self::from_bytes(
-                prefix_hex::decode(&value.public_key).map_err(SignatureError::InvalidPublicKeyHex)?,
-                prefix_hex::decode(&value.signature).map_err(SignatureError::InvalidSignatureHex)?,
+                prefix_hex::decode(&value.public_key).map_err(SignatureError::PublicKeyHex)?,
+                prefix_hex::decode(&value.signature).map_err(SignatureError::SignatureHex)?,
             ))
         }
     }

--- a/sdk/src/types/block/signature/error.rs
+++ b/sdk/src/types/block/signature/error.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::string::String;
 use core::convert::Infallible;
 
 #[derive(Debug, PartialEq, Eq, derive_more::Display)]

--- a/sdk/src/types/block/signature/error.rs
+++ b/sdk/src/types/block/signature/error.rs
@@ -1,0 +1,32 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display)]
+#[allow(missing_docs)]
+pub enum SignatureError {
+    #[display(fmt = "invalid signature kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "signature public key mismatch: expected {expected} but got {actual}")]
+    PublicKeyMismatch { expected: String, actual: String },
+    #[display(fmt = "signature does not match the message: {_0}")]
+    SignatureMismatch(String),
+    #[display(fmt = "invalid public key hex: {_0}")]
+    PublicKeyHex(prefix_hex::Error),
+    #[display(fmt = "invalid signature hex: {_0}")]
+    SignatureHex(prefix_hex::Error),
+    #[display(fmt = "invalid public key bytes: {_0}")]
+    PublicKeyBytes(crypto::Error),
+    #[display(fmt = "invalid signature bytes: {_0}")]
+    SignatureBytes(crypto::Error),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SignatureError {}
+
+impl From<Infallible> for SignatureError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/signature/mod.rs
+++ b/sdk/src/types/block/signature/mod.rs
@@ -2,42 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod ed25519;
-
-use alloc::string::String;
-use core::convert::Infallible;
+mod error;
 
 use derive_more::From;
 
-pub use self::ed25519::Ed25519Signature;
+pub use self::{ed25519::Ed25519Signature, error::SignatureError};
 use crate::types::block::protocol::{WorkScore, WorkScoreParameters};
-
-#[derive(Debug, PartialEq, Eq, derive_more::Display)]
-#[allow(missing_docs)]
-pub enum SignatureError {
-    #[display(fmt = "invalid signature kind: {_0}")]
-    InvalidSignatureKind(u8),
-    #[display(fmt = "signature public key mismatch: expected {expected} but got {actual}")]
-    SignaturePublicKeyMismatch { expected: String, actual: String },
-    #[display(fmt = "invalid public key hex: {_0}")]
-    InvalidPublicKeyHex(prefix_hex::Error),
-    #[display(fmt = "invalid signature hex: {_0}")]
-    InvalidSignatureHex(prefix_hex::Error),
-    #[display(fmt = "invalid public key bytes: {_0}")]
-    InvalidPublicKeyBytes(crypto::Error),
-    #[display(fmt = "invalid signature bytes: {_0}")]
-    InvalidSignatureBytes(crypto::Error),
-    #[display(fmt = "signature does not match the message: {_0}")]
-    SignatureMismatch(String),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for SignatureError {}
-
-impl From<Infallible> for SignatureError {
-    fn from(error: Infallible) -> Self {
-        match error {}
-    }
-}
 
 /// A `Signature` contains a signature which is used to unlock a transaction input.
 ///
@@ -46,7 +16,7 @@ impl From<Infallible> for SignatureError {
 /// RFC: <https://github.com/luca-moser/protocol-rfcs/blob/signed-tx-payload/text/0000-transaction-payload/0000-transaction-payload.md#signature-unlock-block>
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, packable::Packable, From)]
 #[packable(unpack_error = SignatureError)]
-#[packable(tag_type = u8, with_error = SignatureError::InvalidSignatureKind)]
+#[packable(tag_type = u8, with_error = SignatureError::Kind)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum Signature {
     /// An Ed25519 signature.

--- a/sdk/src/types/block/unlock/account.rs
+++ b/sdk/src/types/block/unlock/account.rs
@@ -8,7 +8,7 @@ use crate::types::block::{
 
 /// Points to the unlock of a consumed account output.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, packable::Packable)]
-#[packable(unpack_error = UnlockError, with = UnlockError::InvalidAccountIndex)]
+#[packable(unpack_error = UnlockError, with = UnlockError::AccountIndex)]
 pub struct AccountUnlock(
     /// Index of input and unlock corresponding to an [`AccountOutput`](crate::types::block::output::AccountOutput).
     UnlockIndex,
@@ -21,7 +21,7 @@ impl AccountUnlock {
     /// Creates a new [`AccountUnlock`].
     #[inline(always)]
     pub fn new(index: u16) -> Result<Self, UnlockError> {
-        index.try_into().map(Self).map_err(UnlockError::InvalidAccountIndex)
+        index.try_into().map(Self).map_err(UnlockError::AccountIndex)
     }
 
     /// Return the index of an [`AccountUnlock`].

--- a/sdk/src/types/block/unlock/anchor.rs
+++ b/sdk/src/types/block/unlock/anchor.rs
@@ -8,7 +8,7 @@ use crate::types::block::{
 
 /// Points to the unlock of a consumed anchor output.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, packable::Packable)]
-#[packable(unpack_error = UnlockError, with = UnlockError::InvalidAnchorIndex)]
+#[packable(unpack_error = UnlockError, with = UnlockError::AnchorIndex)]
 pub struct AnchorUnlock(
     /// Index of input and unlock corresponding to an [`AnchorOutput`](crate::types::block::output::AnchorOutput).
     UnlockIndex,
@@ -21,7 +21,7 @@ impl AnchorUnlock {
     /// Creates a new [`AnchorUnlock`].
     #[inline(always)]
     pub fn new(index: u16) -> Result<Self, UnlockError> {
-        index.try_into().map(Self).map_err(UnlockError::InvalidAnchorIndex)
+        index.try_into().map(Self).map_err(UnlockError::AnchorIndex)
     }
 
     /// Return the index of an [`AnchorUnlock`].

--- a/sdk/src/types/block/unlock/error.rs
+++ b/sdk/src/types/block/unlock/error.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use core::convert::Infallible;
+
+use crate::types::block::{
+    signature::SignatureError,
+    unlock::{multi::UnlocksCount, UnlockCount, UnlockIndex},
+};
+
+#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
+#[allow(missing_docs)]
+pub enum UnlockError {
+    #[display(fmt = "invalid unlock kind: {_0}")]
+    Kind(u8),
+    #[display(fmt = "invalid unlock count: {_0}")]
+    Count(<UnlockCount as TryFrom<usize>>::Error),
+    #[display(fmt = "invalid unlock reference: {_0}")]
+    Reference(u16),
+    #[display(fmt = "invalid unlock account: {_0}")]
+    Account(u16),
+    #[display(fmt = "invalid unlock nft: {_0}")]
+    Nft(u16),
+    #[display(fmt = "invalid unlock anchor: {_0}")]
+    Anchor(u16),
+    #[display(fmt = "duplicate signature unlock at index: {_0}")]
+    DuplicateSignature(u16),
+    #[display(fmt = "multi unlock recursion")]
+    MultiUnlockRecursion,
+    #[display(fmt = "invalid account index: {_0}")]
+    AccountIndex(<UnlockIndex as TryFrom<u16>>::Error),
+    #[display(fmt = "invalid anchor index: {_0}")]
+    AnchorIndex(<UnlockIndex as TryFrom<u16>>::Error),
+    #[display(fmt = "invalid nft index: {_0}")]
+    NftIndex(<UnlockIndex as TryFrom<u16>>::Error),
+    #[display(fmt = "invalid reference index: {_0}")]
+    ReferenceIndex(<UnlockIndex as TryFrom<u16>>::Error),
+    #[display(fmt = "invalid multi unlock count: {_0}")]
+    MultiUnlockCount(<UnlocksCount as TryFrom<usize>>::Error),
+    #[from]
+    Signature(SignatureError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UnlockError {}
+
+impl From<Infallible> for UnlockError {
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}

--- a/sdk/src/types/block/unlock/mod.rs
+++ b/sdk/src/types/block/unlock/mod.rs
@@ -4,27 +4,26 @@
 mod account;
 mod anchor;
 mod empty;
+mod error;
 mod multi;
 mod nft;
 mod reference;
 mod signature;
 
 use alloc::boxed::Box;
-use core::{convert::Infallible, ops::RangeInclusive};
+use core::ops::RangeInclusive;
 
 use derive_more::{Deref, From};
 use hashbrown::HashSet;
 use packable::{bounded::BoundedU16, prefix::BoxedSlicePrefix, Packable};
 
-pub(crate) use self::multi::UnlocksCount;
 pub use self::{
-    account::AccountUnlock, anchor::AnchorUnlock, empty::EmptyUnlock, multi::MultiUnlock, nft::NftUnlock,
-    reference::ReferenceUnlock, signature::SignatureUnlock,
+    account::AccountUnlock, anchor::AnchorUnlock, empty::EmptyUnlock, error::UnlockError, multi::MultiUnlock,
+    nft::NftUnlock, reference::ReferenceUnlock, signature::SignatureUnlock,
 };
 use crate::types::block::{
     input::{INPUT_COUNT_MAX, INPUT_COUNT_RANGE, INPUT_INDEX_MAX},
     protocol::{WorkScore, WorkScoreParameters},
-    signature::SignatureError,
 };
 
 /// The maximum number of unlocks of a transaction.
@@ -38,52 +37,10 @@ pub const UNLOCK_INDEX_RANGE: RangeInclusive<u16> = 0..=UNLOCK_INDEX_MAX; // [0.
 
 pub(crate) type UnlockIndex = BoundedU16<{ *UNLOCK_INDEX_RANGE.start() }, { *UNLOCK_INDEX_RANGE.end() }>;
 
-#[derive(Debug, PartialEq, Eq, derive_more::Display, derive_more::From)]
-#[allow(missing_docs)]
-pub enum UnlockError {
-    #[display(fmt = "invalid unlock kind: {_0}")]
-    InvalidUnlockKind(u8),
-    #[display(fmt = "invalid unlock count: {_0}")]
-    InvalidUnlockCount(<UnlockCount as TryFrom<usize>>::Error),
-    #[display(fmt = "invalid unlock reference: {_0}")]
-    InvalidUnlockReference(u16),
-    #[display(fmt = "invalid unlock account: {_0}")]
-    InvalidUnlockAccount(u16),
-    #[display(fmt = "invalid unlock nft: {_0}")]
-    InvalidUnlockNft(u16),
-    #[display(fmt = "invalid unlock anchor: {_0}")]
-    InvalidUnlockAnchor(u16),
-    #[display(fmt = "duplicate signature unlock at index: {_0}")]
-    DuplicateSignatureUnlock(u16),
-    #[display(fmt = "multi unlock recursion")]
-    MultiUnlockRecursion,
-    #[display(fmt = "invalid account index: {_0}")]
-    InvalidAccountIndex(<UnlockIndex as TryFrom<u16>>::Error),
-    #[display(fmt = "invalid anchor index: {_0}")]
-    InvalidAnchorIndex(<UnlockIndex as TryFrom<u16>>::Error),
-    #[display(fmt = "invalid nft index: {_0}")]
-    InvalidNftIndex(<UnlockIndex as TryFrom<u16>>::Error),
-    #[display(fmt = "invalid reference index: {_0}")]
-    InvalidReferenceIndex(<UnlockIndex as TryFrom<u16>>::Error),
-    #[display(fmt = "invalid multi unlock count: {_0}")]
-    InvalidMultiUnlockCount(<UnlocksCount as TryFrom<usize>>::Error),
-    #[from]
-    Signature(SignatureError),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for UnlockError {}
-
-impl From<Infallible> for UnlockError {
-    fn from(error: Infallible) -> Self {
-        match error {}
-    }
-}
-
 /// Defines the mechanism by which a transaction input is authorized to be consumed.
 #[derive(Clone, Eq, PartialEq, Hash, From, Packable)]
 #[packable(unpack_error = UnlockError)]
-#[packable(tag_type = u8, with_error = UnlockError::InvalidUnlockKind)]
+#[packable(tag_type = u8, with_error = UnlockError::Kind)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum Unlock {
     /// A signature unlock.
@@ -165,14 +122,13 @@ pub(crate) type UnlockCount = BoundedU16<{ *UNLOCK_COUNT_RANGE.start() }, { *UNL
 
 /// A collection of unlocks.
 #[derive(Clone, Debug, Eq, PartialEq, Deref, Packable)]
-#[packable(unpack_error = UnlockError, with = |e| e.unwrap_item_err_or_else(|p| UnlockError::InvalidUnlockCount(p.into())))]
+#[packable(unpack_error = UnlockError, with = |e| e.unwrap_item_err_or_else(|p| UnlockError::Count(p.into())))]
 pub struct Unlocks(#[packable(verify_with = verify_unlocks)] BoxedSlicePrefix<Unlock, UnlockCount>);
 
 impl Unlocks {
     /// Creates a new [`Unlocks`].
     pub fn new(unlocks: impl Into<Box<[Unlock]>>) -> Result<Self, UnlockError> {
-        let unlocks: BoxedSlicePrefix<Unlock, UnlockCount> =
-            unlocks.into().try_into().map_err(UnlockError::InvalidUnlockCount)?;
+        let unlocks: BoxedSlicePrefix<Unlock, UnlockCount> = unlocks.into().try_into().map_err(UnlockError::Count)?;
 
         verify_unlocks(&unlocks)?;
 
@@ -201,7 +157,7 @@ fn verify_non_multi_unlock<'a>(
     match unlock {
         Unlock::Signature(signature) => {
             if !seen_signatures.insert(signature.as_ref()) {
-                return Err(UnlockError::DuplicateSignatureUnlock(index));
+                return Err(UnlockError::DuplicateSignature(index));
             }
         }
         Unlock::Reference(reference) => {
@@ -209,22 +165,22 @@ fn verify_non_multi_unlock<'a>(
                 || reference.index() >= index
                 || !matches!(unlocks[reference.index() as usize], Unlock::Signature(_))
             {
-                return Err(UnlockError::InvalidUnlockReference(index));
+                return Err(UnlockError::Reference(index));
             }
         }
         Unlock::Account(account) => {
             if index == 0 || account.index() >= index {
-                return Err(UnlockError::InvalidUnlockAccount(index));
+                return Err(UnlockError::Account(index));
             }
         }
         Unlock::Anchor(anchor) => {
             if index == 0 || anchor.index() >= index {
-                return Err(UnlockError::InvalidUnlockAnchor(index));
+                return Err(UnlockError::Anchor(index));
             }
         }
         Unlock::Nft(nft) => {
             if index == 0 || nft.index() >= index {
-                return Err(UnlockError::InvalidUnlockNft(index));
+                return Err(UnlockError::Nft(index));
             }
         }
         Unlock::Multi(_) => return Err(UnlockError::MultiUnlockRecursion),

--- a/sdk/src/types/block/unlock/multi.rs
+++ b/sdk/src/types/block/unlock/multi.rs
@@ -16,7 +16,7 @@ pub(crate) type UnlocksCount = WeightedAddressCount;
 
 /// Unlocks a [`MultiAddress`](crate::types::block::address::MultiAddress) with a list of other unlocks.
 #[derive(Clone, Debug, Deref, Eq, PartialEq, Hash, Packable)]
-#[packable(unpack_error = UnlockError, with = |e| e.unwrap_item_err_or_else(|p| UnlockError::InvalidMultiUnlockCount(p.into())))]
+#[packable(unpack_error = UnlockError, with = |e| e.unwrap_item_err_or_else(|p| UnlockError::MultiUnlockCount(p.into())))]
 pub struct MultiUnlock(#[packable(verify_with = verify_unlocks)] BoxedSlicePrefix<Unlock, UnlocksCount>);
 
 impl MultiUnlock {
@@ -31,8 +31,7 @@ impl MultiUnlock {
         verify_unlocks(&unlocks)?;
 
         Ok(Self(
-            BoxedSlicePrefix::<Unlock, UnlocksCount>::try_from(unlocks)
-                .map_err(UnlockError::InvalidMultiUnlockCount)?,
+            BoxedSlicePrefix::<Unlock, UnlocksCount>::try_from(unlocks).map_err(UnlockError::MultiUnlockCount)?,
         ))
     }
 

--- a/sdk/src/types/block/unlock/nft.rs
+++ b/sdk/src/types/block/unlock/nft.rs
@@ -8,7 +8,7 @@ use crate::types::block::{
 
 /// Points to the unlock of a consumed NFT output.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, packable::Packable)]
-#[packable(unpack_error = UnlockError, with = UnlockError::InvalidNftIndex)]
+#[packable(unpack_error = UnlockError, with = UnlockError::NftIndex)]
 pub struct NftUnlock(
     /// Index of input and unlock corresponding to an [`NftOutput`](crate::types::block::output::NftOutput).
     UnlockIndex,
@@ -21,7 +21,7 @@ impl NftUnlock {
     /// Creates a new [`NftUnlock`].
     #[inline(always)]
     pub fn new(index: u16) -> Result<Self, UnlockError> {
-        index.try_into().map(Self).map_err(UnlockError::InvalidNftIndex)
+        index.try_into().map(Self).map_err(UnlockError::NftIndex)
     }
 
     /// Return the index of a [`NftUnlock`].

--- a/sdk/src/types/block/unlock/reference.rs
+++ b/sdk/src/types/block/unlock/reference.rs
@@ -8,7 +8,7 @@ use crate::types::block::{
 
 /// An [`Unlock`](crate::types::block::unlock::Unlock) that refers to another unlock.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, packable::Packable)]
-#[packable(unpack_error = UnlockError, with = UnlockError::InvalidReferenceIndex)]
+#[packable(unpack_error = UnlockError, with = UnlockError::ReferenceIndex)]
 pub struct ReferenceUnlock(UnlockIndex);
 
 impl TryFrom<u16> for ReferenceUnlock {
@@ -26,7 +26,7 @@ impl ReferenceUnlock {
     /// Creates a new [`ReferenceUnlock`].
     #[inline(always)]
     pub fn new(index: u16) -> Result<Self, UnlockError> {
-        index.try_into().map(Self).map_err(UnlockError::InvalidReferenceIndex)
+        index.try_into().map(Self).map_err(UnlockError::ReferenceIndex)
     }
 
     /// Return the index of a [`ReferenceUnlock`].

--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -16,11 +16,14 @@ use crate::wallet::storage::adapter::memory::Memory;
 #[cfg(feature = "storage")]
 use crate::wallet::storage::{StorageManager, StorageOptions};
 use crate::{
-    client::secret::{GenerateAddressOptions, SecretManage, SecretManager},
+    client::{
+        secret::{GenerateAddressOptions, SecretManage, SecretManager},
+        ClientError,
+    },
     types::block::address::{Bech32Address, Ed25519Address},
     wallet::{
         core::{operations::background_syncing::BackgroundSyncStatus, Bip44, WalletInner, WalletLedger},
-        ClientOptions, Wallet,
+        ClientOptions, Wallet, WalletError,
     },
 };
 
@@ -54,7 +57,7 @@ impl<S: SecretManage> Default for WalletBuilder<S> {
 
 impl<S: 'static + SecretManage> WalletBuilder<S>
 where
-    crate::wallet::Error: From<S::Error>,
+    WalletError: From<S::Error>,
 {
     /// Initialises a new instance of the wallet builder with the default storage adapter.
     pub fn new() -> Self {
@@ -120,12 +123,12 @@ where
 
 impl<S: 'static + SecretManage> WalletBuilder<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
     Self: SaveLoadWallet,
 {
     /// Builds the wallet.
-    pub async fn finish(mut self) -> crate::wallet::Result<Wallet<S>> {
+    pub async fn finish(mut self) -> Result<Wallet<S>, WalletError> {
         log::debug!("[WalletBuilder]");
 
         #[cfg(feature = "storage")]
@@ -134,7 +137,7 @@ where
         // would be created with an empty parameter which just leads to errors later
         #[cfg(feature = "storage")]
         if !storage_options.path.is_dir() && self.client_options.is_none() {
-            return Err(crate::wallet::Error::MissingParameter("client_options"));
+            return Err(WalletError::MissingParameter("client_options"));
         }
 
         #[cfg(all(feature = "rocksdb", feature = "storage"))]
@@ -156,7 +159,7 @@ where
             let loaded_client_options = loaded_wallet_builder
                 .as_ref()
                 .and_then(|data| data.client_options.clone())
-                .ok_or(crate::wallet::Error::MissingParameter("client_options"))?;
+                .ok_or(WalletError::MissingParameter("client_options"))?;
 
             // Update self so it gets used and stored again
             self.client_options = Some(loaded_client_options);
@@ -183,7 +186,7 @@ where
         if let Some(address) = &self.address {
             if let Some(loaded_address) = &loaded_address {
                 if address != loaded_address {
-                    return Err(crate::wallet::Error::WalletAddressMismatch(address.clone()));
+                    return Err(WalletError::WalletAddressMismatch(address.clone()));
                 }
             } else {
                 verify_address = true;
@@ -198,7 +201,7 @@ where
         if let Some(bip_path) = self.bip_path {
             if let Some(loaded_bip_path) = loaded_bip_path {
                 if bip_path != loaded_bip_path {
-                    return Err(crate::wallet::Error::BipPathMismatch {
+                    return Err(WalletError::BipPathMismatch {
                         new_bip_path: Some(bip_path),
                         old_bip_path: Some(loaded_bip_path),
                     });
@@ -214,7 +217,7 @@ where
         let client = self
             .client_options
             .clone()
-            .ok_or(crate::wallet::Error::MissingParameter("client_options"))?
+            .ok_or(WalletError::MissingParameter("client_options"))?
             .finish()
             .await?;
 
@@ -225,7 +228,7 @@ where
                     if let Some(backing_ed25519_address) = address.inner.backing_ed25519() {
                         self.verify_ed25519_address(backing_ed25519_address, bip_path).await?;
                     } else {
-                        return Err(crate::wallet::Error::InvalidParameter("address/bip_path mismatch"));
+                        return Err(WalletError::InvalidParameter("address/bip_path mismatch"));
                     }
                 }
             }
@@ -237,7 +240,7 @@ where
                 ));
             }
             (None, None) => {
-                return Err(crate::wallet::Error::MissingParameter("address or bip_path"));
+                return Err(WalletError::MissingParameter("address or bip_path"));
             }
         };
 
@@ -322,13 +325,13 @@ where
         &self,
         ed25519_address: &Ed25519Address,
         bip_path: &Bip44,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         (ed25519_address == &self.generate_ed25519_address(bip_path).await?)
             .then_some(())
-            .ok_or(crate::wallet::Error::InvalidParameter("address/bip_path mismatch"))
+            .ok_or(WalletError::InvalidParameter("address/bip_path mismatch"))
     }
 
-    async fn generate_ed25519_address(&self, bip_path: &Bip44) -> crate::wallet::Result<Ed25519Address> {
+    async fn generate_ed25519_address(&self, bip_path: &Bip44) -> Result<Ed25519Address, WalletError> {
         if let Some(secret_manager) = &self.secret_manager {
             let secret_manager = &*secret_manager.read().await;
             Ok(secret_manager
@@ -344,7 +347,7 @@ where
                 // Panic: if it didn't return an Err, then there must be at least one address
                 .await?[0])
         } else {
-            Err(crate::wallet::Error::MissingParameter("secret_manager"))
+            Err(WalletError::MissingParameter("secret_manager"))
         }
     }
 }
@@ -352,7 +355,7 @@ where
 // Check if any of the locked inputs is not used in a transaction and unlock them, so they get available for new
 // transactions
 #[cfg(feature = "storage")]
-fn unlock_unused_inputs(wallet_ledger: &mut WalletLedger) -> crate::wallet::Result<()> {
+fn unlock_unused_inputs(wallet_ledger: &mut WalletLedger) -> Result<(), WalletError> {
     log::debug!("[unlock_unused_inputs]");
     let mut used_inputs = HashSet::new();
     for transaction_id in &wallet_ledger.pending_transactions {

--- a/sdk/src/wallet/core/operations/background_syncing.rs
+++ b/sdk/src/wallet/core/operations/background_syncing.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::{
-    client::secret::SecretManage,
-    wallet::{operations::syncing::SyncOptions, task, Wallet},
+    client::{secret::SecretManage, ClientError},
+    wallet::{operations::syncing::SyncOptions, task, Wallet, WalletError},
 };
 
 /// The default interval for background syncing
@@ -22,15 +22,15 @@ pub(crate) enum BackgroundSyncStatus {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Start the background syncing process for the wallet, default interval is 7 seconds
     pub async fn start_background_syncing(
         &self,
         options: Option<SyncOptions>,
         interval: Option<Duration>,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("[start_background_syncing]");
 
         let (tx_background_sync, mut rx_background_sync) = self.background_syncing_status.clone();
@@ -89,7 +89,7 @@ where
     }
 
     /// Stop the background syncing of the wallet
-    pub async fn stop_background_syncing(&self) -> crate::wallet::Result<()> {
+    pub async fn stop_background_syncing(&self) -> Result<(), WalletError> {
         log::debug!("[stop_background_syncing]");
 
         let mut rx_background_sync = self.background_syncing_status.1.clone();

--- a/sdk/src/wallet/core/operations/client.rs
+++ b/sdk/src/wallet/core/operations/client.rs
@@ -13,9 +13,9 @@ use crate::{
             node::{Node, NodeAuth, NodeDto},
         },
         secret::SecretManage,
-        Client, ClientBuilder, NetworkInfo,
+        Client, ClientBuilder, ClientError, NetworkInfo,
     },
-    wallet::{Wallet, WalletBuilder},
+    wallet::{Wallet, WalletBuilder, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S> {
@@ -30,11 +30,11 @@ impl<S: 'static + SecretManage> Wallet<S> {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::client::Error: From<S::Error>,
-    crate::wallet::Error: From<S::Error>,
+    ClientError: From<S::Error>,
+    WalletError: From<S::Error>,
     WalletBuilder<S>: SaveLoadWallet,
 {
-    pub async fn set_client_options(&self, client_options: ClientBuilder) -> crate::wallet::Result<()> {
+    pub async fn set_client_options(&self, client_options: ClientBuilder) -> Result<(), WalletError> {
         let ClientBuilder {
             node_manager_builder,
             #[cfg(feature = "mqtt")]
@@ -88,7 +88,7 @@ where
     }
 
     /// Update the authentication for a node.
-    pub async fn update_node_auth(&self, url: Url, auth: Option<NodeAuth>) -> crate::wallet::Result<()> {
+    pub async fn update_node_auth(&self, url: Url, auth: Option<NodeAuth>) -> Result<(), WalletError> {
         log::debug!("[update_node_auth]");
         let mut node_manager_builder = NodeManagerBuilder::from(&*self.client.node_manager.read().await);
 

--- a/sdk/src/wallet/core/operations/ledger_nano.rs
+++ b/sdk/src/wallet/core/operations/ledger_nano.rs
@@ -2,24 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::secret::{ledger_nano::LedgerSecretManager, LedgerNanoStatus, SecretManager},
-    wallet::Wallet,
+    client::{
+        secret::{ledger_nano::LedgerSecretManager, LedgerNanoStatus, SecretManager},
+        ClientError,
+    },
+    wallet::{Wallet, WalletError},
 };
 
 impl Wallet<LedgerSecretManager> {
     /// Get the ledger nano status
-    pub async fn get_ledger_nano_status(&self) -> crate::wallet::Result<LedgerNanoStatus> {
+    pub async fn get_ledger_nano_status(&self) -> Result<LedgerNanoStatus, WalletError> {
         Ok(self.secret_manager.read().await.get_ledger_nano_status().await)
     }
 }
 
 impl Wallet {
     /// Get the ledger nano status
-    pub async fn get_ledger_nano_status(&self) -> crate::wallet::Result<LedgerNanoStatus> {
+    pub async fn get_ledger_nano_status(&self) -> Result<LedgerNanoStatus, WalletError> {
         if let SecretManager::LedgerNano(ledger) = &*self.secret_manager.read().await {
             Ok(ledger.get_ledger_nano_status().await)
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 }

--- a/sdk/src/wallet/core/operations/stronghold.rs
+++ b/sdk/src/wallet/core/operations/stronghold.rs
@@ -6,20 +6,20 @@ use std::time::Duration;
 use crypto::keys::bip39::Mnemonic;
 
 use crate::{
-    client::{secret::SecretManager, stronghold::StrongholdAdapter, utils::Password},
-    wallet::Wallet,
+    client::{secret::SecretManager, stronghold::StrongholdAdapter, utils::Password, ClientError},
+    wallet::{Wallet, WalletError},
 };
 
 impl Wallet {
     /// Sets the Stronghold password
-    pub async fn set_stronghold_password(&self, password: impl Into<Password> + Send) -> crate::wallet::Result<()> {
+    pub async fn set_stronghold_password(&self, password: impl Into<Password> + Send) -> Result<(), WalletError> {
         let password = password.into();
 
         if let SecretManager::Stronghold(stronghold) = &mut *self.secret_manager.write().await {
             stronghold.set_password(password).await?;
             Ok(())
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 
@@ -28,7 +28,7 @@ impl Wallet {
         &self,
         current_password: impl Into<Password> + Send,
         new_password: impl Into<Password> + Send,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         let current_password = current_password.into();
         let new_password = new_password.into();
 
@@ -37,55 +37,55 @@ impl Wallet {
             stronghold.change_password(new_password).await?;
             Ok(())
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 
     /// Sets the Stronghold password clear interval
-    pub async fn set_stronghold_password_clear_interval(&self, timeout: Option<Duration>) -> crate::wallet::Result<()> {
+    pub async fn set_stronghold_password_clear_interval(&self, timeout: Option<Duration>) -> Result<(), WalletError> {
         if let SecretManager::Stronghold(stronghold) = &mut *self.secret_manager.write().await {
             stronghold.set_timeout(timeout).await;
             Ok(())
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 
     /// Stores a mnemonic into the Stronghold vault
-    pub async fn store_mnemonic(&self, mnemonic: Mnemonic) -> crate::wallet::Result<()> {
+    pub async fn store_mnemonic(&self, mnemonic: Mnemonic) -> Result<(), WalletError> {
         if let SecretManager::Stronghold(stronghold) = &mut *self.secret_manager.write().await {
             stronghold.store_mnemonic(mnemonic).await?;
             Ok(())
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 
     /// Clears the Stronghold password from memory.
-    pub async fn clear_stronghold_password(&self) -> crate::wallet::Result<()> {
+    pub async fn clear_stronghold_password(&self) -> Result<(), WalletError> {
         log::debug!("[clear_stronghold_password]");
         if let SecretManager::Stronghold(stronghold) = &mut *self.secret_manager.write().await {
             stronghold.clear_key().await;
             Ok(())
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 
     /// Checks if the Stronghold password is available.
-    pub async fn is_stronghold_password_available(&self) -> crate::wallet::Result<bool> {
+    pub async fn is_stronghold_password_available(&self) -> Result<bool, WalletError> {
         log::debug!("[is_stronghold_password_available]");
         if let SecretManager::Stronghold(stronghold) = &*self.secret_manager.write().await {
             Ok(stronghold.is_key_available().await)
         } else {
-            Err(crate::client::Error::SecretManagerMismatch.into())
+            Err(ClientError::SecretManagerMismatch.into())
         }
     }
 }
 
 impl Wallet<StrongholdAdapter> {
     /// Sets the Stronghold password
-    pub async fn set_stronghold_password(&self, password: impl Into<Password> + Send) -> crate::wallet::Result<()> {
+    pub async fn set_stronghold_password(&self, password: impl Into<Password> + Send) -> Result<(), WalletError> {
         Ok(self.secret_manager.write().await.set_password(password).await?)
     }
 
@@ -94,7 +94,7 @@ impl Wallet<StrongholdAdapter> {
         &self,
         current_password: impl Into<Password> + Send,
         new_password: impl Into<Password> + Send,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         let stronghold = &mut *self.secret_manager.write().await;
         stronghold.set_password(current_password).await?;
         stronghold.change_password(new_password).await?;
@@ -102,25 +102,25 @@ impl Wallet<StrongholdAdapter> {
     }
 
     /// Sets the Stronghold password clear interval
-    pub async fn set_stronghold_password_clear_interval(&self, timeout: Option<Duration>) -> crate::wallet::Result<()> {
+    pub async fn set_stronghold_password_clear_interval(&self, timeout: Option<Duration>) -> Result<(), WalletError> {
         self.secret_manager.write().await.set_timeout(timeout).await;
         Ok(())
     }
 
     /// Stores a mnemonic into the Stronghold vault
-    pub async fn store_mnemonic(&self, mnemonic: Mnemonic) -> crate::wallet::Result<()> {
+    pub async fn store_mnemonic(&self, mnemonic: Mnemonic) -> Result<(), WalletError> {
         Ok(self.secret_manager.write().await.store_mnemonic(mnemonic).await?)
     }
 
     /// Clears the Stronghold password from memory.
-    pub async fn clear_stronghold_password(&self) -> crate::wallet::Result<()> {
+    pub async fn clear_stronghold_password(&self) -> Result<(), WalletError> {
         log::debug!("[clear_stronghold_password]");
         self.secret_manager.write().await.clear_key().await;
         Ok(())
     }
 
     /// Checks if the Stronghold password is available.
-    pub async fn is_stronghold_password_available(&self) -> crate::wallet::Result<bool> {
+    pub async fn is_stronghold_password_available(&self) -> Result<bool, WalletError> {
         log::debug!("[is_stronghold_password_available]");
         Ok(self.secret_manager.write().await.is_key_available().await)
     }

--- a/sdk/src/wallet/events/types.rs
+++ b/sdk/src/wallet/events/types.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     wallet::{
         types::{InclusionState, OutputData},
-        Error,
+        WalletError,
     },
 };
 
@@ -147,7 +147,7 @@ pub enum WalletEventType {
 }
 
 impl TryFrom<u8> for WalletEventType {
-    type Error = Error;
+    type Error = WalletError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         let event_type = match value {
@@ -157,7 +157,7 @@ impl TryFrom<u8> for WalletEventType {
             2 => Self::SpentOutput,
             3 => Self::TransactionInclusion,
             4 => Self::TransactionProgress,
-            _ => return Err(Error::InvalidEventType(value)),
+            _ => return Err(WalletError::InvalidEventType(value)),
         };
         Ok(event_type)
     }

--- a/sdk/src/wallet/migration/migrate_0.rs
+++ b/sdk/src/wallet/migration/migrate_0.rs
@@ -15,7 +15,7 @@ impl MigrationData for Migrate {
 #[async_trait]
 #[cfg(feature = "storage")]
 impl Migration<crate::wallet::storage::Storage> for Migrate {
-    async fn migrate(_storage: &crate::wallet::storage::Storage) -> Result<()> {
+    async fn migrate(_storage: &crate::wallet::storage::Storage) -> Result<(), WalletError> {
         Ok(())
     }
 }
@@ -23,7 +23,7 @@ impl Migration<crate::wallet::storage::Storage> for Migrate {
 #[async_trait]
 #[cfg(feature = "stronghold")]
 impl Migration<crate::client::stronghold::StrongholdAdapter> for Migrate {
-    async fn migrate(_storage: &crate::client::stronghold::StrongholdAdapter) -> Result<()> {
+    async fn migrate(_storage: &crate::client::stronghold::StrongholdAdapter) -> Result<(), WalletError> {
         Ok(())
     }
 }

--- a/sdk/src/wallet/mod.rs
+++ b/sdk/src/wallet/mod.rs
@@ -41,7 +41,7 @@ pub use self::operations::participation::{ParticipationEventWithNodes, Participa
 use self::types::TransactionWithMetadata;
 pub use self::{
     core::{Wallet, WalletBuilder},
-    error::Error,
+    error::WalletError,
     operations::{
         output_claiming::OutputsToClaim,
         output_consolidation::ConsolidationParams,
@@ -84,9 +84,6 @@ use crate::{
     wallet::types::InclusionState,
 };
 
-/// The wallet Result type.
-pub type Result<T> = std::result::Result<T, Error>;
-
 /// Options to filter outputs
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -113,7 +110,7 @@ pub(crate) fn build_transaction_from_payload_and_inputs(
     tx_id: TransactionId,
     tx_payload: SignedTransactionPayload,
     inputs: Vec<OutputWithMetadataResponse>,
-) -> crate::wallet::Result<TransactionWithMetadata> {
+) -> Result<TransactionWithMetadata, WalletError> {
     Ok(TransactionWithMetadata {
         payload: tx_payload.clone(),
         block_id: inputs.first().map(|i| *i.metadata.block_id()),

--- a/sdk/src/wallet/operations/announce_candidacy.rs
+++ b/sdk/src/wallet/operations/announce_candidacy.rs
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::secret::SecretManage,
+    client::{secret::SecretManage, ClientError},
     types::block::{
         output::AccountId,
         payload::{CandidacyAnnouncementPayload, Payload},
         BlockId,
     },
-    wallet::Wallet,
+    wallet::{Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Announce a staking account's candidacy for the staking period.
-    pub async fn announce_candidacy(&self, account_id: AccountId) -> crate::wallet::Result<BlockId> {
+    pub async fn announce_candidacy(&self, account_id: AccountId) -> Result<BlockId, WalletError> {
         self.submit_basic_block(
             Payload::CandidacyAnnouncement(CandidacyAnnouncementPayload),
             account_id,

--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -11,17 +11,13 @@ use crate::{
     wallet::{
         operations::{helpers::time::can_output_be_unlocked_forever_from_now_on, output_claiming::OutputsToClaim},
         types::{Balance, NativeTokensBalance},
-        Result, Wallet,
+        Wallet, WalletError,
     },
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Get the balance of the wallet.
-    pub async fn balance(&self) -> Result<Balance> {
+    pub async fn balance(&self) -> Result<Balance, WalletError> {
         log::debug!("[BALANCE] balance");
 
         let protocol_parameters = self.client().get_protocol_parameters().await?;
@@ -40,7 +36,7 @@ where
             let mut total_native_tokens = NativeTokensBuilder::default();
 
             #[cfg(feature = "participation")]
-            let voting_output = wallet_ledger.get_voting_output()?;
+            let voting_output = wallet_ledger.get_voting_output();
 
             let claimable_outputs =
                 wallet_ledger.claimable_outputs(&wallet_address, OutputsToClaim::All, slot_index, &protocol_parameters)?;

--- a/sdk/src/wallet/operations/block.rs
+++ b/sdk/src/wallet/operations/block.rs
@@ -2,27 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::secret::{SecretManage, SignBlock},
+    client::{
+        secret::{SecretManage, SignBlock},
+        ClientError,
+    },
     types::block::{output::AccountId, payload::Payload, BlockId},
-    wallet::{Error, Result, Wallet},
+    wallet::{Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     pub(crate) async fn submit_basic_block(
         &self,
         payload: impl Into<Option<Payload>> + Send,
         issuer_id: impl Into<Option<AccountId>> + Send,
         allow_negative_bic: bool,
-    ) -> Result<BlockId> {
+    ) -> Result<BlockId, WalletError> {
         log::debug!("submit_basic_block");
         // If an issuer ID is provided, use it; otherwise, use the first available account or implicit account.
         let issuer_id = match issuer_id.into() {
             Some(id) => id,
-            None => self.ledger().await.first_account_id().ok_or(Error::AccountNotFound)?,
+            None => self
+                .ledger()
+                .await
+                .first_account_id()
+                .ok_or(WalletError::AccountNotFound)?,
         };
 
         let unsigned_block = self.client().build_basic_block(issuer_id, payload).await?;
@@ -32,7 +39,7 @@ where
             let work_score = protocol_parameters.work_score(unsigned_block.body.as_basic());
             let congestion = self.client().get_account_congestion(&issuer_id, work_score).await?;
             if (congestion.reference_mana_cost * work_score as u64) as i128 > congestion.block_issuance_credits {
-                return Err(crate::wallet::Error::InsufficientBic {
+                return Err(WalletError::InsufficientBic {
                     available: congestion.block_issuance_credits,
                     required: work_score as u64 * congestion.reference_mana_cost,
                 });
@@ -42,7 +49,7 @@ where
         let block = unsigned_block
             .sign_ed25519(
                 &*self.get_secret_manager().read().await,
-                self.bip_path().await.ok_or(Error::MissingBipPath)?,
+                self.bip_path().await.ok_or(WalletError::MissingBipPath)?,
             )
             .await?;
 

--- a/sdk/src/wallet/operations/helpers/time.rs
+++ b/sdk/src/wallet/operations/helpers/time.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     types::block::{address::Address, output::Output, protocol::CommittableAgeRange, slot::SlotIndex},
-    wallet::types::OutputData,
+    wallet::{types::OutputData, WalletError},
 };
 
 // Check if an output can be unlocked by the wallet address at the current time
@@ -12,7 +12,7 @@ pub(crate) fn can_output_be_unlocked_now(
     output_data: &OutputData,
     commitment_slot_index: impl Into<SlotIndex> + Copy,
     committable_age_range: CommittableAgeRange,
-) -> crate::wallet::Result<bool> {
+) -> Result<bool, WalletError> {
     if let Some(unlock_conditions) = output_data.output.unlock_conditions() {
         if unlock_conditions.is_timelocked(commitment_slot_index, committable_age_range.min) {
             return Ok(false);

--- a/sdk/src/wallet/operations/output_consolidation.rs
+++ b/sdk/src/wallet/operations/output_consolidation.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "ledger_nano")]
 use crate::client::secret::{ledger_nano::LedgerSecretManager, DowncastSecretManager};
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::{Address, Bech32Address},
         input::INPUT_COUNT_MAX,
@@ -19,7 +19,7 @@ use crate::{
         constants::DEFAULT_OUTPUT_CONSOLIDATION_THRESHOLD,
         operations::{helpers::time::can_output_be_unlocked_now, transaction::TransactionOptions},
         types::{OutputData, TransactionWithMetadata},
-        RemainderValueStrategy, Result, Wallet,
+        RemainderValueStrategy, Wallet, WalletError,
     },
 };
 
@@ -69,13 +69,16 @@ impl ConsolidationParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Consolidates basic outputs from an account by sending them to a provided address or to an own address again if
     /// the output amount is >= the output_threshold. When `force` is set to `true`, the threshold is ignored. Only
     /// consolidates the amount of outputs that fit into a single transaction.
-    pub async fn consolidate_outputs(&self, params: ConsolidationParams) -> Result<TransactionWithMetadata> {
+    pub async fn consolidate_outputs(
+        &self,
+        params: ConsolidationParams,
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let prepared_transaction = self.prepare_consolidate_outputs(params).await?;
         let consolidation_tx = self.sign_and_submit_transaction(prepared_transaction, None).await?;
 
@@ -89,7 +92,10 @@ where
     }
 
     /// Prepares the transaction for [Wallet::consolidate_outputs()].
-    pub async fn prepare_consolidate_outputs(&self, params: ConsolidationParams) -> Result<PreparedTransactionData> {
+    pub async fn prepare_consolidate_outputs(
+        &self,
+        params: ConsolidationParams,
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[OUTPUT_CONSOLIDATION] prepare consolidating outputs if needed");
         let wallet_address = self.address().await;
 
@@ -116,7 +122,7 @@ where
         output_data: &OutputData,
         slot_index: SlotIndex,
         wallet_address: &Address,
-    ) -> Result<bool> {
+    ) -> Result<bool, WalletError> {
         Ok(if let Output::Basic(basic_output) = &output_data.output {
             let protocol_parameters = self.client().get_protocol_parameters().await?;
             let unlock_conditions = basic_output.unlock_conditions();
@@ -155,7 +161,7 @@ where
     }
 
     /// Returns all outputs that should be consolidated.
-    async fn get_outputs_to_consolidate(&self, params: &ConsolidationParams) -> Result<Vec<OutputData>> {
+    async fn get_outputs_to_consolidate(&self, params: &ConsolidationParams) -> Result<Vec<OutputData>, WalletError> {
         // #[cfg(feature = "participation")]
         // let voting_output = self.get_voting_output().await?;
         let slot_index = self.client().get_slot_index().await?;
@@ -221,7 +227,7 @@ where
                 outputs_to_consolidate.len(),
                 output_threshold
             );
-            return Err(crate::wallet::Error::NoOutputsToConsolidate {
+            return Err(WalletError::NoOutputsToConsolidate {
                 available_outputs: outputs_to_consolidate.len(),
                 consolidation_threshold: output_threshold,
             });
@@ -240,7 +246,7 @@ where
 
     /// Returns the max amount of inputs that can be used in a consolidation transaction. For Ledger Nano it's more
     /// limited.
-    async fn get_max_inputs(&self) -> Result<u16> {
+    async fn get_max_inputs(&self) -> Result<u16, WalletError> {
         #[cfg(feature = "ledger_nano")]
         let max_inputs = {
             use crate::client::secret::SecretManager;
@@ -281,7 +287,7 @@ where
 
     /// Returns the threshold value above which outputs should be consolidated. Lower for ledger nano secret manager, as
     /// their memory size is limited.
-    async fn get_output_consolidation_threshold(&self, params: &ConsolidationParams) -> Result<usize> {
+    async fn get_output_consolidation_threshold(&self, params: &ConsolidationParams) -> Result<usize, WalletError> {
         #[allow(clippy::option_if_let_else)]
         let output_threshold = match params.output_threshold {
             Some(t) => t,

--- a/sdk/src/wallet/operations/participation/event.rs
+++ b/sdk/src/wallet/operations/participation/event.rs
@@ -25,7 +25,7 @@ where
     pub async fn register_participation_events(
         &self,
         options: &ParticipationEventRegistrationOptions,
-    ) -> crate::wallet::Result<HashMap<ParticipationEventId, ParticipationEventWithNodes>> {
+    ) -> Result<HashMap<ParticipationEventId, ParticipationEventWithNodes>, WalletError> {
         let client = Client::builder()
             .with_ignore_node_health()
             .with_node_auth(options.node.url.as_str(), options.node.auth.clone())?
@@ -71,7 +71,7 @@ where
     }
 
     /// Removes a previously registered participation event from local storage.
-    pub async fn deregister_participation_event(&self, id: &ParticipationEventId) -> crate::wallet::Result<()> {
+    pub async fn deregister_participation_event(&self, id: &ParticipationEventId) -> Result<(), WalletError> {
         self.storage_manager().remove_participation_event(id).await?;
         Ok(())
     }
@@ -80,7 +80,7 @@ where
     pub async fn get_participation_event(
         &self,
         id: ParticipationEventId,
-    ) -> crate::wallet::Result<Option<ParticipationEventWithNodes>> {
+    ) -> Result<Option<ParticipationEventWithNodes>, WalletError> {
         Ok(self
             .storage_manager()
             .get_participation_events()
@@ -92,7 +92,7 @@ where
     /// Retrieves information for all registered participation events.
     pub async fn get_participation_events(
         &self,
-    ) -> crate::wallet::Result<HashMap<ParticipationEventId, ParticipationEventWithNodes>> {
+    ) -> Result<HashMap<ParticipationEventId, ParticipationEventWithNodes>, WalletError> {
         self.storage_manager().get_participation_events().await
     }
 
@@ -101,7 +101,7 @@ where
         &self,
         node: &Node,
         event_type: Option<ParticipationEventType>,
-    ) -> crate::wallet::Result<Vec<ParticipationEventId>> {
+    ) -> Result<Vec<ParticipationEventId>, WalletError> {
         let client = Client::builder()
             .with_ignore_node_health()
             .with_node_auth(node.url.as_str(), node.auth.clone())?
@@ -114,7 +114,7 @@ where
     pub async fn get_participation_event_status(
         &self,
         id: &ParticipationEventId,
-    ) -> crate::wallet::Result<ParticipationEventStatus> {
+    ) -> Result<ParticipationEventStatus, WalletError> {
         Ok(self.get_client_for_event(id).await?.event_status(id, None).await?)
     }
 }

--- a/sdk/src/wallet/operations/participation/mod.rs
+++ b/sdk/src/wallet/operations/participation/mod.rs
@@ -25,7 +25,7 @@ use crate::{
         },
         block::output::{unlock_condition::UnlockCondition, Output, OutputId},
     },
-    wallet::{core::WalletLedger, types::OutputData, Result, Wallet},
+    wallet::{core::WalletLedger, types::OutputData, Wallet},
 };
 
 /// An object containing an account's entire participation overview.
@@ -46,17 +46,13 @@ pub struct ParticipationEventWithNodes {
     pub nodes: Vec<Node>,
 }
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     // /// Calculates the voting overview of a wallet. If event_ids are provided, only return outputs and tracked
     // /// participations for them.
     // pub async fn get_participation_overview(
     //     &self,
     //     event_ids: Option<Vec<ParticipationEventId>>,
-    // ) -> Result<ParticipationOverview> {
+    // ) -> Result<ParticipationOverview, WalletError> {
     //     log::debug!("[get_participation_overview]");
     //     // TODO: Could use the address endpoint in the future when https://github.com/iotaledger/inx-participation/issues/50 is done.
 
@@ -217,13 +213,13 @@ where
     /// Returns the voting output ("PARTICIPATION" tag).
     ///
     /// If multiple outputs with this tag exist, the one with the largest amount will be returned.
-    pub async fn get_voting_output(&self) -> Result<Option<OutputData>> {
+    pub async fn get_voting_output(&self) -> Option<OutputData> {
         self.ledger().await.get_voting_output()
     }
 
     // /// Gets client for an event.
     // /// If event isn't found, the client from the account will be returned.
-    // pub(crate) async fn get_client_for_event(&self, id: &ParticipationEventId) -> crate::wallet::Result<Client> {
+    // pub(crate) async fn get_client_for_event(&self, id: &ParticipationEventId) -> Result<Client, WalletError> {
     //     log::debug!("[get_client_for_event]");
     //     let events = self.storage_manager().get_participation_events().await?;
 
@@ -244,7 +240,7 @@ where
     // pub(crate) async fn remove_ended_participation_events(
     //     &self,
     //     participations: &mut Participations,
-    // ) -> crate::wallet::Result<()> {
+    // ) -> Result<(), WalletError> {
     //     log::debug!("[remove_ended_participation_events]");
     //     // TODO change to one of the new timestamps, which ones ?
     //     let latest_milestone_index = 0;
@@ -275,14 +271,13 @@ impl WalletLedger {
     /// Returns the voting output ("PARTICIPATION" tag).
     ///
     /// If multiple outputs with this tag exist, the one with the largest amount will be returned.
-    pub(crate) fn get_voting_output(&self) -> Result<Option<OutputData>> {
+    pub(crate) fn get_voting_output(&self) -> Option<OutputData> {
         log::debug!("[get_voting_output]");
-        Ok(self
-            .unspent_outputs
+        self.unspent_outputs
             .values()
             .filter(|output_data| is_valid_participation_output(&output_data.output))
             .max_by_key(|output_data| output_data.output.amount())
-            .cloned())
+            .cloned()
     }
 }
 

--- a/sdk/src/wallet/operations/participation/voting.rs
+++ b/sdk/src/wallet/operations/participation/voting.rs
@@ -38,7 +38,7 @@ where
         &self,
         event_id: impl Into<Option<ParticipationEventId>> + Send,
         answers: impl Into<Option<Vec<u8>>> + Send,
-    ) -> Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let prepared = self.prepare_vote(event_id, answers).await?;
 
         self.sign_and_submit_transaction(prepared, None, None).await
@@ -49,7 +49,7 @@ where
         &self,
         event_id: impl Into<Option<ParticipationEventId>> + Send,
         answers: impl Into<Option<Vec<u8>>> + Send,
-    ) -> Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         let event_id = event_id.into();
         let answers = answers.into();
         if let Some(event_id) = event_id {
@@ -128,14 +128,20 @@ where
     /// Removes metadata for any event that has expired (use event IDs to get cached event information, checks event
     /// milestones in there against latest network milestone).
     /// If NOT already voting for this event, throws an error.
-    pub async fn stop_participating(&self, event_id: ParticipationEventId) -> Result<TransactionWithMetadata> {
+    pub async fn stop_participating(
+        &self,
+        event_id: ParticipationEventId,
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let prepared = self.prepare_stop_participating(event_id).await?;
 
         self.sign_and_submit_transaction(prepared, None, None).await
     }
 
     /// Prepares the transaction for [Wallet::stop_participating()].
-    pub async fn prepare_stop_participating(&self, event_id: ParticipationEventId) -> Result<PreparedTransactionData> {
+    pub async fn prepare_stop_participating(
+        &self,
+        event_id: ParticipationEventId,
+    ) -> Result<PreparedTransactionData, WalletError> {
         let voting_output = self
             .get_voting_output()
             .await?

--- a/sdk/src/wallet/operations/participation/voting_power.rs
+++ b/sdk/src/wallet/operations/participation/voting_power.rs
@@ -23,7 +23,7 @@ where
     crate::client::Error: From<S::Error>,
 {
     /// Returns an account's total voting power (voting or NOT voting).
-    pub async fn get_voting_power(&self) -> Result<u64> {
+    pub async fn get_voting_power(&self) -> Result<u64, WalletError> {
         Ok(self
             .get_voting_output()
             .await?
@@ -41,14 +41,14 @@ where
     /// cached event information, checks event milestones in there against latest network milestone).
     /// Prioritizes consuming outputs that are designated for voting but don't have any metadata (only possible if user
     /// increases voting power then increases again immediately after).
-    pub async fn increase_voting_power(&self, amount: u64) -> Result<TransactionWithMetadata> {
+    pub async fn increase_voting_power(&self, amount: u64) -> Result<TransactionWithMetadata, WalletError> {
         let prepared = self.prepare_increase_voting_power(amount).await?;
 
         self.sign_and_submit_transaction(prepared, None, None).await
     }
 
     /// Prepares the transaction for [Wallet::increase_voting_power()].
-    pub async fn prepare_increase_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
+    pub async fn prepare_increase_voting_power(&self, amount: u64) -> Result<PreparedTransactionData, WalletError> {
         let (new_output, tx_options) = match self.get_voting_output().await? {
             Some(current_output_data) => {
                 let output = current_output_data.output.as_basic();
@@ -89,14 +89,14 @@ where
     /// milestones in there against latest network milestone).
     /// Prioritizes consuming outputs that are designated for voting but don't have any metadata (only possible if user
     /// increases voting power then decreases immediately after).
-    pub async fn decrease_voting_power(&self, amount: u64) -> Result<TransactionWithMetadata> {
+    pub async fn decrease_voting_power(&self, amount: u64) -> Result<TransactionWithMetadata, WalletError> {
         let prepared = self.prepare_decrease_voting_power(amount).await?;
 
         self.sign_and_submit_transaction(prepared, None, None).await
     }
 
     /// Prepares the transaction for [Wallet::decrease_voting_power()].
-    pub async fn prepare_decrease_voting_power(&self, amount: u64) -> Result<PreparedTransactionData> {
+    pub async fn prepare_decrease_voting_power(&self, amount: u64) -> Result<PreparedTransactionData, WalletError> {
         let current_output_data = self
             .get_voting_output()
             .await?

--- a/sdk/src/wallet/operations/syncing/addresses/output_ids/basic.rs
+++ b/sdk/src/wallet/operations/syncing/addresses/output_ids/basic.rs
@@ -5,18 +5,15 @@ use crate::{
     client::{node_api::indexer::query_parameters::BasicOutputQueryParameters, secret::SecretManage},
     types::block::{address::Bech32Address, output::OutputId},
     utils::ConvertTo,
-    wallet::Wallet,
+    wallet::{Wallet, WalletError},
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Returns output ids of basic outputs that have only the address unlock condition
     pub(crate) async fn get_basic_output_ids_with_address_unlock_condition_only(
         &self,
         bech32_address: impl ConvertTo<Bech32Address>,
-    ) -> crate::client::Result<Vec<OutputId>> {
+    ) -> Result<Vec<OutputId>, WalletError> {
         let bech32_address = bech32_address.convert()?;
 
         Ok(self
@@ -33,7 +30,7 @@ where
     pub(crate) async fn get_basic_output_ids_with_any_unlock_condition(
         &self,
         bech32_address: impl ConvertTo<Bech32Address>,
-    ) -> crate::wallet::Result<Vec<OutputId>> {
+    ) -> Result<Vec<OutputId>, WalletError> {
         let bech32_address = bech32_address.convert()?;
 
         Ok(self

--- a/sdk/src/wallet/operations/syncing/addresses/output_ids/mod.rs
+++ b/sdk/src/wallet/operations/syncing/addresses/output_ids/mod.rs
@@ -21,15 +21,11 @@ use crate::{
     types::block::{address::Bech32Address, output::OutputId},
     wallet::{
         constants::PARALLEL_REQUESTS_AMOUNT, operations::syncing::SyncOptions,
-        types::address::AddressWithUnspentOutputs, Wallet,
+        types::address::AddressWithUnspentOutputs, Wallet, WalletError,
     },
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Returns output ids for outputs that are directly (Ed25519 address in AddressUnlockCondition) or indirectly
     /// (account/nft address in AddressUnlockCondition and the account/nft output is controlled with the Ed25519
     /// address) connected to
@@ -37,7 +33,7 @@ where
         &self,
         address: &Bech32Address,
         sync_options: &SyncOptions,
-    ) -> crate::wallet::Result<Vec<OutputId>> {
+    ) -> Result<Vec<OutputId>, WalletError> {
         if sync_options.sync_only_most_basic_outputs {
             let output_ids = self
                 .get_basic_output_ids_with_address_unlock_condition_only(address.clone())
@@ -235,7 +231,7 @@ where
         &self,
         addresses_with_unspent_outputs: Vec<AddressWithUnspentOutputs>,
         options: &SyncOptions,
-    ) -> crate::wallet::Result<(Vec<AddressWithUnspentOutputs>, Vec<OutputId>)> {
+    ) -> Result<(Vec<AddressWithUnspentOutputs>, Vec<OutputId>), WalletError> {
         log::debug!("[SYNC] start get_output_ids_for_addresses");
         let address_output_ids_start_time = Instant::now();
 
@@ -248,13 +244,13 @@ where
             .chunks(PARALLEL_REQUESTS_AMOUNT)
             .map(|x: &[AddressWithUnspentOutputs]| x.to_vec())
         {
-            let results;
+            let results: Vec<Result<_, WalletError>>;
             #[cfg(target_family = "wasm")]
             {
                 let mut tasks = Vec::new();
                 for address in addresses_chunk {
                     let output_ids = self.get_output_ids_for_address(&address.address, options).await?;
-                    tasks.push(crate::wallet::Result::Ok((address, output_ids)));
+                    tasks.push(Ok((address, output_ids)));
                 }
                 results = tasks;
             }
@@ -270,7 +266,7 @@ where
                             let output_ids = wallet
                                 .get_output_ids_for_address(&address.address, &sync_options)
                                 .await?;
-                            crate::wallet::Result::Ok((address, output_ids))
+                            Ok((address, output_ids))
                         })
                         .await
                     });

--- a/sdk/src/wallet/operations/syncing/addresses/output_ids/nft.rs
+++ b/sdk/src/wallet/operations/syncing/addresses/output_ids/nft.rs
@@ -5,19 +5,16 @@ use crate::{
     client::{node_api::indexer::query_parameters::NftOutputQueryParameters, secret::SecretManage},
     types::block::{address::Bech32Address, output::OutputId},
     utils::ConvertTo,
-    wallet::Wallet,
+    wallet::{Wallet, WalletError},
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Returns output ids of NFT outputs that have the address in the `AddressUnlockCondition` or
     /// `ExpirationUnlockCondition`
     pub(crate) async fn get_nft_output_ids_with_any_unlock_condition(
         &self,
         bech32_address: impl ConvertTo<Bech32Address>,
-    ) -> crate::wallet::Result<Vec<OutputId>> {
+    ) -> Result<Vec<OutputId>, WalletError> {
         let bech32_address = bech32_address.convert()?;
 
         Ok(self

--- a/sdk/src/wallet/operations/syncing/mod.rs
+++ b/sdk/src/wallet/operations/syncing/mod.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use self::options::SyncOptions;
 use crate::{
-    client::secret::SecretManage,
+    client::{secret::SecretManage, ClientError},
     types::block::{
         address::{AccountAddress, Address, Bech32Address, NftAddress},
         output::{FoundryId, Output, OutputId, OutputMetadata},
@@ -19,18 +19,14 @@ use crate::{
     wallet::{
         constants::MIN_SYNC_INTERVAL,
         types::{address::AddressWithUnspentOutputs, Balance, OutputData},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Set the fallback SyncOptions for account syncing.
     /// If storage is enabled, will persist during restarts.
-    pub async fn set_default_sync_options(&self, options: SyncOptions) -> crate::wallet::Result<()> {
+    pub async fn set_default_sync_options(&self, options: SyncOptions) -> Result<(), WalletError> {
         #[cfg(feature = "storage")]
         {
             self.storage_manager().set_default_sync_options(&options).await?;
@@ -45,116 +41,6 @@ where
         self.default_sync_options.lock().await.clone()
     }
 
-    /// Sync the wallet by fetching new information from the nodes. Will also reissue pending transactions
-    /// if necessary. A custom default can be set using set_default_sync_options.
-    pub async fn sync(&self, options: Option<SyncOptions>) -> crate::wallet::Result<Balance> {
-        let options = match options {
-            Some(opt) => opt,
-            None => self.default_sync_options().await,
-        };
-
-        log::debug!("[SYNC] start syncing with {:?}", options);
-        let syc_start_time = instant::Instant::now();
-
-        // Prevent syncing the account multiple times simultaneously
-        let time_now = crate::client::unix_timestamp_now().as_millis();
-        let mut last_synced = self.last_synced.lock().await;
-        log::debug!("[SYNC] last time synced before {}ms", time_now - *last_synced);
-        if !options.force_syncing && time_now - *last_synced < MIN_SYNC_INTERVAL {
-            log::debug!(
-                "[SYNC] synced within the latest {} ms, only calculating balance",
-                MIN_SYNC_INTERVAL
-            );
-            // Calculate the balance because if we created a transaction in the meantime, the amount for the inputs
-            // is not available anymore
-            return self.balance().await;
-        }
-
-        self.sync_internal(&options).await?;
-
-        // Sync transactions after updating account with outputs, so we can use them to check the transaction
-        // status
-        if options.sync_pending_transactions {
-            let confirmed_tx_with_unknown_output = self.sync_pending_transactions().await?;
-            // Sync again if we don't know the output yet, to prevent having no unspent outputs after syncing
-            if confirmed_tx_with_unknown_output {
-                log::debug!("[SYNC] a transaction for which no output is known got confirmed, syncing outputs again");
-                self.sync_internal(&options).await?;
-            }
-        };
-
-        let balance = self.balance().await?;
-        // Update last_synced mutex
-        let time_now = crate::client::unix_timestamp_now().as_millis();
-        *last_synced = time_now;
-        log::debug!("[SYNC] finished syncing in {:.2?}", syc_start_time.elapsed());
-        Ok(balance)
-    }
-
-    async fn sync_internal(&self, options: &SyncOptions) -> crate::wallet::Result<()> {
-        log::debug!("[SYNC] sync_internal");
-
-        let wallet_address_with_unspent_outputs = AddressWithUnspentOutputs {
-            address: self.address().await,
-            output_ids: self.ledger().await.unspent_outputs().keys().copied().collect(),
-        };
-
-        let address_to_sync = vec![
-            wallet_address_with_unspent_outputs,
-            AddressWithUnspentOutputs {
-                address: self.implicit_account_creation_address().await?,
-                output_ids: vec![],
-            },
-        ];
-
-        let (_addresses_with_unspent_outputs, spent_or_not_synced_output_ids, outputs_data) =
-            self.request_outputs_recursively(address_to_sync, options).await?;
-
-        // Request possible spent outputs
-        log::debug!("[SYNC] spent_or_not_synced_outputs: {spent_or_not_synced_output_ids:?}");
-        let spent_or_unsynced_output_metadata_responses = self
-            .client()
-            .get_outputs_metadata_ignore_not_found(&spent_or_not_synced_output_ids)
-            .await?;
-
-        // Add the output response to the output ids, the output response is optional, because an output could be
-        // pruned and then we can't get the metadata
-        let mut spent_or_unsynced_output_metadata: HashMap<OutputId, Option<OutputMetadata>> =
-            spent_or_not_synced_output_ids.into_iter().map(|o| (o, None)).collect();
-        for output_metadata_response in spent_or_unsynced_output_metadata_responses {
-            let output_id = output_metadata_response.output_id();
-            spent_or_unsynced_output_metadata.insert(*output_id, Some(output_metadata_response));
-        }
-
-        if options.sync_incoming_transactions {
-            let transaction_ids = outputs_data
-                .iter()
-                .map(|output| *output.output_id.transaction_id())
-                .collect();
-            // Request and store transaction payload for newly received unspent outputs
-            self.request_incoming_transaction_data(transaction_ids).await?;
-        }
-
-        if options.sync_native_token_foundries {
-            let native_token_foundry_ids = outputs_data
-                .iter()
-                .filter_map(|output| {
-                    output
-                        .output
-                        .native_token()
-                        .map(|native_token| FoundryId::from(*native_token.token_id()))
-                })
-                .collect::<HashSet<_>>();
-
-            // Request and store foundry outputs
-            self.request_and_store_foundry_outputs(native_token_foundry_ids).await?;
-        }
-
-        // Updates wallet with balances, output ids, outputs
-        self.update_after_sync(outputs_data, spent_or_unsynced_output_metadata)
-            .await
-    }
-
     // First request all outputs directly related to the wallet address, then for each nft and account output we got,
     // request all outputs that are related to their account/nft addresses in a loop until no new account or nft outputs
     // are found.
@@ -162,7 +48,7 @@ where
         &self,
         addresses_to_sync: Vec<AddressWithUnspentOutputs>,
         options: &SyncOptions,
-    ) -> crate::wallet::Result<(Vec<AddressWithUnspentOutputs>, Vec<OutputId>, Vec<OutputData>)> {
+    ) -> Result<(Vec<AddressWithUnspentOutputs>, Vec<OutputId>, Vec<OutputData>), WalletError> {
         // Cache account and nft addresses with the related Ed25519 address, so we can update the account
         // address with the new output ids.
         let mut addresses_to_scan: HashMap<Address, Address> = HashMap::new();
@@ -253,5 +139,121 @@ where
             spent_or_not_synced_output_ids,
             unspent_outputs_data_all,
         ))
+    }
+}
+
+impl<S: 'static + SecretManage> Wallet<S>
+where
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
+{
+    /// Sync the wallet by fetching new information from the nodes. Will also reissue pending transactions
+    /// if necessary. A custom default can be set using set_default_sync_options.
+    pub async fn sync(&self, options: Option<SyncOptions>) -> Result<Balance, WalletError> {
+        let options = match options {
+            Some(opt) => opt,
+            None => self.default_sync_options().await,
+        };
+
+        log::debug!("[SYNC] start syncing with {:?}", options);
+        let syc_start_time = instant::Instant::now();
+
+        // Prevent syncing the account multiple times simultaneously
+        let time_now = crate::client::unix_timestamp_now().as_millis();
+        let mut last_synced = self.last_synced.lock().await;
+        log::debug!("[SYNC] last time synced before {}ms", time_now - *last_synced);
+        if !options.force_syncing && time_now - *last_synced < MIN_SYNC_INTERVAL {
+            log::debug!(
+                "[SYNC] synced within the latest {} ms, only calculating balance",
+                MIN_SYNC_INTERVAL
+            );
+            // Calculate the balance because if we created a transaction in the meantime, the amount for the inputs
+            // is not available anymore
+            return self.balance().await;
+        }
+
+        self.sync_internal(&options).await?;
+
+        // Sync transactions after updating account with outputs, so we can use them to check the transaction
+        // status
+        if options.sync_pending_transactions {
+            let confirmed_tx_with_unknown_output = self.sync_pending_transactions().await?;
+            // Sync again if we don't know the output yet, to prevent having no unspent outputs after syncing
+            if confirmed_tx_with_unknown_output {
+                log::debug!("[SYNC] a transaction for which no output is known got confirmed, syncing outputs again");
+                self.sync_internal(&options).await?;
+            }
+        };
+
+        let balance = self.balance().await?;
+        // Update last_synced mutex
+        let time_now = crate::client::unix_timestamp_now().as_millis();
+        *last_synced = time_now;
+        log::debug!("[SYNC] finished syncing in {:.2?}", syc_start_time.elapsed());
+        Ok(balance)
+    }
+
+    async fn sync_internal(&self, options: &SyncOptions) -> Result<(), WalletError> {
+        log::debug!("[SYNC] sync_internal");
+
+        let wallet_address_with_unspent_outputs = AddressWithUnspentOutputs {
+            address: self.address().await,
+            output_ids: self.ledger().await.unspent_outputs().keys().copied().collect(),
+        };
+
+        let address_to_sync = vec![
+            wallet_address_with_unspent_outputs,
+            AddressWithUnspentOutputs {
+                address: self.implicit_account_creation_address().await?,
+                output_ids: vec![],
+            },
+        ];
+
+        let (_addresses_with_unspent_outputs, spent_or_not_synced_output_ids, outputs_data) =
+            self.request_outputs_recursively(address_to_sync, options).await?;
+
+        // Request possible spent outputs
+        log::debug!("[SYNC] spent_or_not_synced_outputs: {spent_or_not_synced_output_ids:?}");
+        let spent_or_unsynced_output_metadata_responses = self
+            .client()
+            .get_outputs_metadata_ignore_not_found(&spent_or_not_synced_output_ids)
+            .await?;
+
+        // Add the output response to the output ids, the output response is optional, because an output could be
+        // pruned and then we can't get the metadata
+        let mut spent_or_unsynced_output_metadata: HashMap<OutputId, Option<OutputMetadata>> =
+            spent_or_not_synced_output_ids.into_iter().map(|o| (o, None)).collect();
+        for output_metadata_response in spent_or_unsynced_output_metadata_responses {
+            let output_id = output_metadata_response.output_id();
+            spent_or_unsynced_output_metadata.insert(*output_id, Some(output_metadata_response));
+        }
+
+        if options.sync_incoming_transactions {
+            let transaction_ids = outputs_data
+                .iter()
+                .map(|output| *output.output_id.transaction_id())
+                .collect();
+            // Request and store transaction payload for newly received unspent outputs
+            self.request_incoming_transaction_data(transaction_ids).await?;
+        }
+
+        if options.sync_native_token_foundries {
+            let native_token_foundry_ids = outputs_data
+                .iter()
+                .filter_map(|output| {
+                    output
+                        .output
+                        .native_token()
+                        .map(|native_token| FoundryId::from(*native_token.token_id()))
+                })
+                .collect::<HashSet<_>>();
+
+            // Request and store foundry outputs
+            self.request_and_store_foundry_outputs(native_token_foundry_ids).await?;
+        }
+
+        // Updates wallet with balances, output ids, outputs
+        self.update_after_sync(outputs_data, spent_or_unsynced_output_metadata)
+            .await
     }
 }

--- a/sdk/src/wallet/operations/syncing/outputs.rs
+++ b/sdk/src/wallet/operations/syncing/outputs.rs
@@ -4,7 +4,7 @@
 use instant::Instant;
 
 use crate::{
-    client::{secret::SecretManage, Client, Error as ClientError},
+    client::{secret::SecretManage, Client, ClientError},
     types::{
         api::core::OutputWithMetadataResponse,
         block::{
@@ -14,19 +14,15 @@ use crate::{
             payload::{signed_transaction::TransactionId, Payload, SignedTransactionPayload},
         },
     },
-    wallet::{build_transaction_from_payload_and_inputs, task, types::OutputData, Wallet},
+    wallet::{build_transaction_from_payload_and_inputs, task, types::OutputData, Wallet, WalletError},
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Convert OutputWithMetadataResponse to OutputData with the network_id added
     pub(crate) async fn output_response_to_output_data(
         &self,
         outputs_with_meta: Vec<OutputWithMetadataResponse>,
-    ) -> crate::wallet::Result<Vec<OutputData>> {
+    ) -> Result<Vec<OutputData>, WalletError> {
         log::debug!("[SYNC] convert output_responses");
         // store outputs with network_id
         let network_id = self.client().get_network_id().await?;
@@ -59,7 +55,7 @@ where
     pub(crate) async fn get_outputs(
         &self,
         output_ids: Vec<OutputId>,
-    ) -> crate::wallet::Result<Vec<OutputWithMetadataResponse>> {
+    ) -> Result<Vec<OutputWithMetadataResponse>, WalletError> {
         log::debug!("[SYNC] start get_outputs");
         let get_outputs_start_time = Instant::now();
         let mut outputs = Vec::new();
@@ -111,7 +107,7 @@ where
     pub(crate) async fn request_incoming_transaction_data(
         &self,
         mut transaction_ids: Vec<TransactionId>,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("[SYNC] request_incoming_transaction_data");
 
         let wallet_ledger = self.ledger().await;
@@ -164,10 +160,10 @@ where
                                         .into())
                                     }
                                 }
-                                Err(crate::client::Error::Node(crate::client::node_api::error::Error::NotFound(_))) => {
+                                Err(ClientError::Node(crate::client::node_api::error::Error::NotFound(_))) => {
                                     Ok((transaction_id, None))
                                 }
-                                Err(e) => Err(crate::wallet::Error::Client(e)),
+                                Err(e) => Err(WalletError::Client(e)),
                             }
                         }))
                         .await
@@ -198,7 +194,7 @@ where
 pub(crate) async fn get_inputs_for_transaction_payload(
     client: &Client,
     transaction_payload: &SignedTransactionPayload,
-) -> crate::wallet::Result<Vec<OutputWithMetadataResponse>> {
+) -> Result<Vec<OutputWithMetadataResponse>, WalletError> {
     let output_ids = transaction_payload
         .transaction()
         .inputs()

--- a/sdk/src/wallet/operations/transaction/account.rs
+++ b/sdk/src/wallet/operations/transaction/account.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::Address,
         output::{
@@ -16,21 +16,21 @@ use crate::{
     },
     wallet::{
         operations::transaction::{TransactionOptions, TransactionWithMetadata},
-        Error, Result, Wallet,
+        Wallet, WalletError,
     },
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Transitions an implicit account to an account.
     pub async fn implicit_account_transition(
         &self,
         output_id: &OutputId,
         key_source: impl Into<BlockIssuerKeySource> + Send,
-    ) -> Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let issuer_id = AccountId::from(output_id);
 
         self.sign_and_submit_transaction(
@@ -48,19 +48,19 @@ where
         &self,
         output_id: &OutputId,
         key_source: impl Into<BlockIssuerKeySource> + Send,
-    ) -> Result<PreparedTransactionData>
+    ) -> Result<PreparedTransactionData, WalletError>
     where
-        crate::wallet::Error: From<S::Error>,
+        WalletError: From<S::Error>,
     {
         let wallet_ledger = self.ledger().await;
         let implicit_account_data = wallet_ledger
             .unspent_outputs
             .get(output_id)
-            .ok_or(Error::ImplicitAccountNotFound)?;
+            .ok_or(WalletError::ImplicitAccountNotFound)?;
         let implicit_account = if implicit_account_data.output.is_implicit_account() {
             implicit_account_data.output.as_basic()
         } else {
-            return Err(Error::ImplicitAccountNotFound);
+            return Err(WalletError::ImplicitAccountNotFound);
         };
         let ed25519_address = *implicit_account
             .address()

--- a/sdk/src/wallet/operations/transaction/high_level/allot_mana.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/allot_mana.rs
@@ -2,24 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::mana::ManaAllotment,
     wallet::{
         operations::transaction::{TransactionOptions, TransactionWithMetadata},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     pub async fn allot_mana(
         &self,
         allotments: impl IntoIterator<Item = impl Into<ManaAllotment>> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared_transaction = self.prepare_allot_mana(allotments, options.clone()).await?;
 
@@ -30,7 +30,7 @@ where
         &self,
         allotments: impl IntoIterator<Item = impl Into<ManaAllotment>> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] prepare_allot_mana");
 
         let mut options = options.into().unwrap_or_default();

--- a/sdk/src/wallet/operations/transaction/high_level/burning_melting/mod.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/burning_melting/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     client::api::{input_selection::Burn, PreparedTransactionData},
-    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet},
+    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet, WalletError},
 };
 
 pub(crate) mod melt_native_token;
@@ -18,7 +18,7 @@ impl Wallet {
         &self,
         burn: impl Into<Burn> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared = self.prepare_burn(burn, options.clone()).await?;
 
@@ -35,7 +35,7 @@ impl Wallet {
         &self,
         burn: impl Into<Burn> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         let mut options = options.into().unwrap_or_default();
         options.burn = Some(burn.into());
 

--- a/sdk/src/wallet/operations/transaction/high_level/create_account.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/create_account.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::Bech32Address,
         output::{
@@ -14,7 +14,7 @@ use crate::{
     wallet::{
         operations::transaction::TransactionOptions,
         types::{OutputData, TransactionWithMetadata},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
@@ -33,8 +33,8 @@ pub struct CreateAccountParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Creates an account output.
     /// ```ignore
@@ -55,7 +55,7 @@ where
         &self,
         params: Option<CreateAccountParams>,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared_transaction = self.prepare_create_account_output(params, options.clone()).await?;
 
@@ -67,7 +67,7 @@ where
         &self,
         params: Option<CreateAccountParams>,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] prepare_create_account_output");
         let storage_score_params = self.client().get_storage_score_parameters().await?;
 

--- a/sdk/src/wallet/operations/transaction/high_level/delegation/create.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/delegation/create.rs
@@ -4,13 +4,13 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::{AccountAddress, Bech32Address},
         output::{unlock_condition::AddressUnlockCondition, DelegationId, DelegationOutputBuilder},
     },
     utils::serde::string,
-    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet},
+    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet, WalletError},
 };
 
 /// Params for `create_delegation_output()`
@@ -46,8 +46,8 @@ pub struct PreparedCreateDelegationTransaction {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Creates a delegation output.
     /// ```ignore
@@ -68,7 +68,7 @@ where
         &self,
         params: CreateDelegationParams,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<CreateDelegationTransaction> {
+    ) -> Result<CreateDelegationTransaction, WalletError> {
         let options = options.into();
         let prepared = self.prepare_create_delegation_output(params, options.clone()).await?;
 
@@ -85,7 +85,7 @@ where
         &self,
         params: CreateDelegationParams,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedCreateDelegationTransaction> {
+    ) -> Result<PreparedCreateDelegationTransaction, WalletError> {
         log::debug!("[TRANSACTION] prepare_create_delegation_output");
 
         let address = match params.address.as_ref() {

--- a/sdk/src/wallet/operations/transaction/high_level/minting/create_native_token.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/minting/create_native_token.rs
@@ -5,7 +5,7 @@ use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::AccountAddress,
         output::{
@@ -13,7 +13,7 @@ use crate::{
             FoundryOutputBuilder, Output, SimpleTokenScheme, TokenId, TokenScheme,
         },
     },
-    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet},
+    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet, WalletError},
 };
 
 /// Address and foundry data for `create_native_token()`
@@ -49,8 +49,8 @@ pub struct PreparedCreateNativeTokenTransaction {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Creates a new foundry output with minted native tokens.
     ///
@@ -74,7 +74,7 @@ where
         &self,
         params: CreateNativeTokenParams,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<CreateNativeTokenTransaction> {
+    ) -> Result<CreateNativeTokenTransaction, WalletError> {
         let options = options.into();
         let prepared = self.prepare_create_native_token(params, options.clone()).await?;
 
@@ -91,7 +91,7 @@ where
         &self,
         params: CreateNativeTokenParams,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedCreateNativeTokenTransaction> {
+    ) -> Result<PreparedCreateNativeTokenTransaction, WalletError> {
         log::debug!("[TRANSACTION] create_native_token");
         let protocol_parameters = self.client().get_protocol_parameters().await?;
         let storage_score_params = protocol_parameters.storage_score_parameters();
@@ -99,7 +99,7 @@ where
         let (account_id, account_output_data) = self
             .get_account_output(params.account_id)
             .await
-            .ok_or_else(|| crate::wallet::Error::MintingFailed("Missing account output".to_string()))?;
+            .ok_or_else(|| WalletError::MintingFailed("Missing account output".to_string()))?;
 
         let mut options = options.into();
         if let Some(options) = options.as_mut() {

--- a/sdk/src/wallet/operations/transaction/high_level/minting/mint_native_token.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/minting/mint_native_token.rs
@@ -4,15 +4,15 @@
 use primitive_types::U256;
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::output::{FoundryOutputBuilder, Output, SimpleTokenScheme, TokenId, TokenScheme},
-    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Error, Wallet},
+    wallet::{operations::transaction::TransactionOptions, types::TransactionWithMetadata, Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Mints additional native tokens.
     ///
@@ -34,7 +34,7 @@ where
         token_id: TokenId,
         mint_amount: impl Into<U256> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared = self
             .prepare_mint_native_token(token_id, mint_amount, options.clone())
@@ -50,7 +50,7 @@ where
         token_id: TokenId,
         mint_amount: impl Into<U256> + Send,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] mint_native_token");
 
         let mint_amount = mint_amount.into();
@@ -64,14 +64,14 @@ where
         });
 
         let existing_foundry_output = existing_foundry_output
-            .ok_or_else(|| Error::MintingFailed(format!("foundry output {token_id} is not available")))?
+            .ok_or_else(|| WalletError::MintingFailed(format!("foundry output {token_id} is not available")))?
             .clone();
 
         let existing_account_output = if let Output::Foundry(foundry_output) = &existing_foundry_output.output {
             let TokenScheme::Simple(token_scheme) = foundry_output.token_scheme();
             // Check if we can mint the provided amount without exceeding the maximum_supply
             if token_scheme.maximum_supply() - token_scheme.circulating_supply() < mint_amount {
-                return Err(Error::MintingFailed(format!(
+                return Err(WalletError::MintingFailed(format!(
                     "minting additional {mint_amount} tokens would exceed the maximum supply: {}",
                     token_scheme.maximum_supply()
                 )));
@@ -86,10 +86,12 @@ where
                 }
             });
             existing_account_output
-                .ok_or_else(|| Error::MintingFailed("account output is not available".to_string()))?
+                .ok_or_else(|| WalletError::MintingFailed("account output is not available".to_string()))?
                 .clone()
         } else {
-            return Err(Error::MintingFailed("account output is not available".to_string()));
+            return Err(WalletError::MintingFailed(
+                "account output is not available".to_string(),
+            ));
         };
 
         drop(wallet_ledger);

--- a/sdk/src/wallet/operations/transaction/high_level/minting/mint_nfts.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/minting/mint_nfts.rs
@@ -5,7 +5,7 @@ use getset::Getters;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::Bech32Address,
         output::{
@@ -17,7 +17,7 @@ use crate::{
     utils::ConvertTo,
     wallet::{
         operations::transaction::{TransactionOptions, TransactionWithMetadata},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
@@ -53,7 +53,7 @@ impl MintNftParams {
     }
 
     /// Set the address and try convert to [`Bech32Address`]
-    pub fn try_with_address(mut self, address: impl ConvertTo<Bech32Address>) -> crate::wallet::Result<Self> {
+    pub fn try_with_address(mut self, address: impl ConvertTo<Bech32Address>) -> Result<Self, WalletError> {
         self.address = Some(address.convert()?);
         Ok(self)
     }
@@ -65,7 +65,7 @@ impl MintNftParams {
     }
 
     /// Set the sender address and try convert to [`Bech32Address`]
-    pub fn try_with_sender(mut self, sender: impl ConvertTo<Bech32Address>) -> crate::wallet::Result<Self> {
+    pub fn try_with_sender(mut self, sender: impl ConvertTo<Bech32Address>) -> Result<Self, WalletError> {
         self.sender = Some(sender.convert()?);
         Ok(self)
     }
@@ -89,7 +89,7 @@ impl MintNftParams {
     }
 
     /// Set the issuer address and try convert to [`Bech32Address`]
-    pub fn try_with_issuer(mut self, issuer: impl ConvertTo<Bech32Address>) -> crate::wallet::Result<Self> {
+    pub fn try_with_issuer(mut self, issuer: impl ConvertTo<Bech32Address>) -> Result<Self, WalletError> {
         self.issuer = Some(issuer.convert()?);
         Ok(self)
     }
@@ -109,8 +109,8 @@ impl MintNftParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Mints NFTs.
     ///
@@ -138,7 +138,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata>
+    ) -> Result<TransactionWithMetadata, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -153,7 +153,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData>
+    ) -> Result<PreparedTransactionData, WalletError>
     where
         I::IntoIter: Send,
     {

--- a/sdk/src/wallet/operations/transaction/high_level/send.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/send.rs
@@ -5,7 +5,7 @@ use getset::Getters;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::{Bech32Address, ToBech32Ext},
         output::{
@@ -18,7 +18,7 @@ use crate::{
     wallet::{
         constants::DEFAULT_EXPIRATION_SLOTS,
         operations::transaction::{TransactionOptions, TransactionWithMetadata},
-        Error, Wallet,
+        Wallet, WalletError,
     },
 };
 
@@ -45,7 +45,7 @@ pub struct SendParams {
 }
 
 impl SendParams {
-    pub fn new(amount: u64, address: impl ConvertTo<Bech32Address>) -> Result<Self, crate::wallet::Error> {
+    pub fn new(amount: u64, address: impl ConvertTo<Bech32Address>) -> Result<Self, WalletError> {
         Ok(Self {
             amount,
             address: address.convert()?,
@@ -54,10 +54,7 @@ impl SendParams {
         })
     }
 
-    pub fn try_with_return_address(
-        mut self,
-        address: impl ConvertTo<Bech32Address>,
-    ) -> Result<Self, crate::wallet::Error> {
+    pub fn try_with_return_address(mut self, address: impl ConvertTo<Bech32Address>) -> Result<Self, WalletError> {
         self.return_address = Some(address.convert()?);
         Ok(self)
     }
@@ -75,8 +72,8 @@ impl SendParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Sends a certain amount of base coins to a single address.
     ///
@@ -88,7 +85,7 @@ where
         amount: u64,
         address: impl ConvertTo<Bech32Address>,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let params = [SendParams::new(amount, address)?];
         self.send_with_params(params, options).await
     }
@@ -114,7 +111,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata>
+    ) -> Result<TransactionWithMetadata, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -129,7 +126,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData>
+    ) -> Result<PreparedTransactionData, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -155,12 +152,12 @@ where
             let return_address = return_address
                 .map(|return_address| {
                     if return_address.hrp() != address.hrp() {
-                        Err(crate::client::Error::Bech32HrpMismatch {
+                        Err(ClientError::Bech32HrpMismatch {
                             provided: return_address.hrp().to_string(),
                             expected: address.hrp().to_string(),
                         })?;
                     }
-                    Ok::<_, Error>(return_address)
+                    Ok::<_, WalletError>(return_address)
                 })
                 .transpose()?
                 .unwrap_or_else(|| default_return_address.clone());
@@ -188,7 +185,7 @@ where
                     .finish_output()?;
 
                 if !options.as_ref().map(|o| o.allow_micro_amount).unwrap_or_default() {
-                    return Err(Error::InsufficientFunds {
+                    return Err(WalletError::InsufficientFunds {
                         available: amount,
                         required: output.amount(),
                     });

--- a/sdk/src/wallet/operations/transaction/high_level/send_native_tokens.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/send_native_tokens.rs
@@ -6,7 +6,7 @@ use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::{Bech32Address, ToBech32Ext},
         output::{
@@ -19,7 +19,7 @@ use crate::{
     wallet::{
         constants::DEFAULT_EXPIRATION_SLOTS,
         operations::transaction::{TransactionOptions, TransactionWithMetadata},
-        Error, Result, Wallet,
+        Wallet, WalletError,
     },
 };
 
@@ -45,7 +45,7 @@ pub struct SendNativeTokenParams {
 
 impl SendNativeTokenParams {
     /// Creates a new instance of [`SendNativeTokenParams`]
-    pub fn new(address: impl ConvertTo<Bech32Address>, native_token: (TokenId, U256)) -> Result<Self> {
+    pub fn new(address: impl ConvertTo<Bech32Address>, native_token: (TokenId, U256)) -> Result<Self, WalletError> {
         Ok(Self {
             address: address.convert()?,
             native_token,
@@ -55,7 +55,10 @@ impl SendNativeTokenParams {
     }
 
     /// Set the return address and try convert to [`Bech32Address`]
-    pub fn try_with_return_address(mut self, return_address: impl ConvertTo<Bech32Address>) -> Result<Self> {
+    pub fn try_with_return_address(
+        mut self,
+        return_address: impl ConvertTo<Bech32Address>,
+    ) -> Result<Self, WalletError> {
         self.return_address = Some(return_address.convert()?);
         Ok(self)
     }
@@ -75,8 +78,8 @@ impl SendNativeTokenParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Sends native tokens in basic outputs with a
     /// [`StorageDepositReturnUnlockCondition`](crate::types::block::output::unlock_condition::StorageDepositReturnUnlockCondition)
@@ -104,7 +107,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata>
+    ) -> Result<TransactionWithMetadata, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -119,7 +122,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData>
+    ) -> Result<PreparedTransactionData, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -143,12 +146,12 @@ where
             let return_address = return_address
                 .map(|addr| {
                     if address.hrp() != addr.hrp() {
-                        Err(crate::client::Error::Bech32HrpMismatch {
+                        Err(ClientError::Bech32HrpMismatch {
                             provided: addr.hrp().to_string(),
                             expected: address.hrp().to_string(),
                         })?;
                     }
-                    Ok::<_, Error>(addr)
+                    Ok::<_, WalletError>(addr)
                 })
                 .transpose()?
                 .unwrap_or_else(|| default_return_address.clone());

--- a/sdk/src/wallet/operations/transaction/high_level/send_nft.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/send_nft.rs
@@ -5,7 +5,7 @@ use getset::Getters;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         address::Bech32Address,
         output::{unlock_condition::AddressUnlockCondition, NftId, NftOutputBuilder, Output},
@@ -13,7 +13,7 @@ use crate::{
     utils::ConvertTo,
     wallet::{
         operations::transaction::{TransactionOptions, TransactionWithMetadata},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
@@ -31,10 +31,7 @@ pub struct SendNftParams {
 
 impl SendNftParams {
     /// Creates a new instance of [`SendNftParams`]
-    pub fn new(
-        address: impl ConvertTo<Bech32Address>,
-        nft_id: impl ConvertTo<NftId>,
-    ) -> Result<Self, crate::wallet::Error> {
+    pub fn new(address: impl ConvertTo<Bech32Address>, nft_id: impl ConvertTo<NftId>) -> Result<Self, WalletError> {
         Ok(Self {
             address: address.convert()?,
             nft_id: nft_id.convert()?,
@@ -44,8 +41,8 @@ impl SendNftParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Sends an NFT to the provided address.
     /// Calls [Wallet::prepare_transaction()](crate::wallet::Wallet::prepare_transaction) internally. The
@@ -69,7 +66,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata>
+    ) -> Result<TransactionWithMetadata, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -84,7 +81,7 @@ where
         &self,
         params: I,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData>
+    ) -> Result<PreparedTransactionData, WalletError>
     where
         I::IntoIter: Send,
     {
@@ -105,7 +102,7 @@ where
                     outputs.push(nft_builder.finish_output()?);
                 }
             } else {
-                return Err(crate::wallet::Error::NftNotFoundInUnspentOutputs);
+                return Err(WalletError::NftNotFoundInUnspentOutputs);
             };
         }
 

--- a/sdk/src/wallet/operations/transaction/high_level/staking/begin.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/staking/begin.rs
@@ -4,13 +4,13 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::{
         output::{feature::StakingFeature, AccountId, AccountOutputBuilder},
         slot::EpochIndex,
     },
     utils::serde::string,
-    wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet},
+    wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet, WalletError},
 };
 
 /// Parameters for beginning a staking period.
@@ -31,14 +31,14 @@ pub struct BeginStakingParams {
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     pub async fn begin_staking(
         &self,
         params: BeginStakingParams,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared = self.prepare_begin_staking(params, options.clone()).await?;
 
@@ -50,7 +50,7 @@ where
         &self,
         params: BeginStakingParams,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] prepare_begin_staking");
 
         let account_id = params.account_id;
@@ -59,14 +59,14 @@ where
             .await
             .unspent_account_output(&account_id)
             .cloned()
-            .ok_or_else(|| crate::wallet::Error::AccountNotFound)?;
+            .ok_or_else(|| WalletError::AccountNotFound)?;
 
         if account_output_data
             .output
             .features()
             .map_or(false, |f| f.staking().is_some())
         {
-            return Err(crate::wallet::Error::StakingFailed(format!(
+            return Err(WalletError::StakingFailed(format!(
                 "account id {account_id} already has a staking feature"
             )));
         }
@@ -75,7 +75,7 @@ where
 
         if let Some(staking_period) = params.staking_period {
             if staking_period < protocol_parameters.staking_unbonding_period() {
-                return Err(crate::wallet::Error::StakingFailed(format!(
+                return Err(WalletError::StakingFailed(format!(
                     "staking period {staking_period} is less than the minimum {}",
                     protocol_parameters.staking_unbonding_period()
                 )));

--- a/sdk/src/wallet/operations/transaction/high_level/staking/end.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/staking/end.rs
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::output::{AccountId, AccountOutputBuilder},
-    wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet},
+    wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     pub async fn end_staking(
         &self,
         account_id: AccountId,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared = self.prepare_end_staking(account_id, options.clone()).await?;
 
@@ -28,7 +28,7 @@ where
         &self,
         account_id: AccountId,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] prepare_end_staking");
 
         let account_output_data = self
@@ -36,13 +36,13 @@ where
             .await
             .unspent_account_output(&account_id)
             .cloned()
-            .ok_or_else(|| crate::wallet::Error::AccountNotFound)?;
+            .ok_or_else(|| WalletError::AccountNotFound)?;
 
         let staking_feature = account_output_data
             .output
             .features()
             .and_then(|f| f.staking())
-            .ok_or_else(|| crate::wallet::Error::StakingFailed(format!("account id {account_id} is not staking")))?;
+            .ok_or_else(|| WalletError::StakingFailed(format!("account id {account_id} is not staking")))?;
 
         let protocol_parameters = self.client().get_protocol_parameters().await?;
 
@@ -52,7 +52,7 @@ where
         if future_bounded_epoch <= staking_feature.end_epoch() {
             let end_epoch = protocol_parameters.epoch_index_of(slot_commitment_id.slot_index())
                 + (staking_feature.end_epoch() - future_bounded_epoch);
-            return Err(crate::wallet::Error::StakingFailed(format!(
+            return Err(WalletError::StakingFailed(format!(
                 "account id {account_id} cannot end staking until {end_epoch}"
             )));
         }

--- a/sdk/src/wallet/operations/transaction/high_level/staking/extend.rs
+++ b/sdk/src/wallet/operations/transaction/high_level/staking/extend.rs
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{api::PreparedTransactionData, secret::SecretManage},
+    client::{api::PreparedTransactionData, secret::SecretManage, ClientError},
     types::block::output::{feature::StakingFeature, AccountId, AccountOutputBuilder},
-    wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet},
+    wallet::{types::TransactionWithMetadata, TransactionOptions, Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     pub async fn extend_staking(
         &self,
         account_id: AccountId,
         additional_epochs: u32,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<TransactionWithMetadata> {
+    ) -> Result<TransactionWithMetadata, WalletError> {
         let options = options.into();
         let prepared = self
             .prepare_extend_staking(account_id, additional_epochs, options.clone())
@@ -32,7 +32,7 @@ where
         account_id: AccountId,
         additional_epochs: u32,
         options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] prepare_extend_staking");
 
         let account_output_data = self
@@ -40,7 +40,7 @@ where
             .await
             .unspent_account_output(&account_id)
             .cloned()
-            .ok_or_else(|| crate::wallet::Error::AccountNotFound)?;
+            .ok_or_else(|| WalletError::AccountNotFound)?;
 
         let protocol_parameters = self.client().get_protocol_parameters().await?;
 
@@ -52,7 +52,7 @@ where
             .output
             .features()
             .and_then(|f| f.staking())
-            .ok_or_else(|| crate::wallet::Error::StakingFailed(format!("account id {account_id} is not staking")))?;
+            .ok_or_else(|| WalletError::StakingFailed(format!("account id {account_id} is not staking")))?;
 
         let mut output_builder =
             AccountOutputBuilder::from(account_output_data.output.as_account()).with_account_id(account_id);
@@ -68,7 +68,7 @@ where
         // Otherwise, we'll have to claim the rewards
         } else {
             if additional_epochs < protocol_parameters.staking_unbonding_period() {
-                return Err(crate::wallet::Error::StakingFailed(format!(
+                return Err(WalletError::StakingFailed(format!(
                     "new staking period {additional_epochs} is less than the minimum {}",
                     protocol_parameters.staking_unbonding_period()
                 )));

--- a/sdk/src/wallet/operations/transaction/input_selection.rs
+++ b/sdk/src/wallet/operations/transaction/input_selection.rs
@@ -21,15 +21,11 @@ use crate::{
     },
     wallet::{
         operations::helpers::time::can_output_be_unlocked_forever_from_now_on, types::OutputData,
-        RemainderValueStrategy, TransactionOptions, Wallet,
+        RemainderValueStrategy, TransactionOptions, Wallet, WalletError,
     },
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Selects inputs for a transaction. Locking of the inputs only happens in `submit_and_store_transaction()`, so
     /// calling this multiple times before submitting can result in conflicting transactions.
     /// If this gets problematic we could add a bool in the TransactionOptions to lock them here already.
@@ -37,11 +33,11 @@ where
         &self,
         outputs: Vec<Output>,
         mut options: TransactionOptions,
-    ) -> crate::wallet::Result<PreparedTransactionData> {
+    ) -> Result<PreparedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] select_inputs");
         // Voting output needs to be requested before to prevent a deadlock
         #[cfg(feature = "participation")]
-        let voting_output = self.get_voting_output().await?;
+        let voting_output = self.get_voting_output().await;
         let protocol_parameters = self.client().get_protocol_parameters().await?;
         let creation_slot = self.client().get_slot_index().await?;
         let slot_commitment_id = self.client().get_issuance().await?.latest_commitment.id();
@@ -112,7 +108,7 @@ where
         // Check that no input got already locked
         for output_id in &options.required_inputs {
             if wallet_ledger.locked_outputs.contains(output_id) {
-                return Err(crate::wallet::Error::CustomInput(format!(
+                return Err(WalletError::CustomInput(format!(
                     "provided custom input {output_id} is already used in another transaction",
                 )));
             }
@@ -179,7 +175,7 @@ fn filter_inputs<'a>(
     slot_index: impl Into<SlotIndex> + Copy,
     committable_age_range: CommittableAgeRange,
     required_inputs: &BTreeSet<OutputId>,
-) -> crate::wallet::Result<Vec<InputSigningData>> {
+) -> Result<Vec<InputSigningData>, WalletError> {
     let mut available_outputs_signing_data = Vec::new();
 
     for output_data in available_outputs {

--- a/sdk/src/wallet/operations/transaction/prepare_output.rs
+++ b/sdk/src/wallet/operations/transaction/prepare_output.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    client::secret::SecretManage,
+    client::{secret::SecretManage, ClientError},
     types::block::{
         address::{Address, Bech32Address, Ed25519Address},
         output::{
@@ -23,15 +23,11 @@ use crate::{
     wallet::{
         operations::transaction::{RemainderValueStrategy, TransactionOptions},
         types::OutputData,
-        Wallet,
+        Wallet, WalletError,
     },
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Prepare a basic or NFT output for sending
     /// If the amount is below the minimum required storage deposit, by default the remaining amount will automatically
     /// be added with a StorageDepositReturn UnlockCondition, when setting the ReturnStrategy to `gift`, the full
@@ -42,7 +38,7 @@ where
         &self,
         params: OutputParams,
         transaction_options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<Output> {
+    ) -> Result<Output, WalletError> {
         log::debug!("[OUTPUT] prepare_output {params:?}");
         let transaction_options = transaction_options.into();
 
@@ -59,7 +55,7 @@ where
         if let Some(features) = params.features {
             if let Some(tag) = features.tag {
                 first_output_builder = first_output_builder.add_feature(TagFeature::new(
-                    prefix_hex::decode::<Vec<u8>>(tag).map_err(crate::client::Error::PrefixHex)?,
+                    prefix_hex::decode::<Vec<u8>>(tag).map_err(ClientError::PrefixHex)?,
                 )?);
             }
 
@@ -73,7 +69,7 @@ where
 
             if let Some(issuer) = features.issuer {
                 if let OutputBuilder::Basic(_) = first_output_builder {
-                    return Err(crate::wallet::Error::MissingParameter("nft_id"));
+                    return Err(WalletError::MissingParameter("nft_id"));
                 }
                 first_output_builder = first_output_builder.add_immutable_feature(IssuerFeature::new(issuer));
             }
@@ -177,7 +173,7 @@ where
         }
 
         if final_amount > available_base_coin {
-            return Err(crate::wallet::Error::InsufficientFunds {
+            return Err(WalletError::InsufficientFunds {
                 available: available_base_coin,
                 required: final_amount,
             });
@@ -216,7 +212,7 @@ where
                     }
                 } else {
                     // Would leave dust behind, so return what's required for a remainder
-                    return Err(crate::wallet::Error::InsufficientFunds {
+                    return Err(WalletError::InsufficientFunds {
                         available: available_base_coin,
                         required: available_base_coin + min_amount_basic_output - remaining_balance,
                     });
@@ -233,7 +229,7 @@ where
         recipient_address: Bech32Address,
         nft_id: Option<NftId>,
         params: StorageScoreParameters,
-    ) -> crate::wallet::Result<(OutputBuilder, Option<OutputData>)> {
+    ) -> Result<(OutputBuilder, Option<OutputData>), WalletError> {
         let (mut first_output_builder, existing_nft_output_data) = if let Some(nft_id) = &nft_id {
             if nft_id.is_null() {
                 // Mint a new NFT output
@@ -250,7 +246,7 @@ where
                     let nft_output = nft_output_data.output.as_nft();
                     NftOutputBuilder::from(nft_output).with_nft_id(*nft_id)
                 } else {
-                    return Err(crate::wallet::Error::NftNotFoundInUnspentOutputs);
+                    return Err(WalletError::NftNotFoundInUnspentOutputs);
                 };
                 // Remove potentially existing features and unlock conditions.
                 first_output_builder = first_output_builder.clear_features();
@@ -274,7 +270,7 @@ where
     async fn get_remainder_address(
         &self,
         transaction_options: impl Into<Option<TransactionOptions>> + Send,
-    ) -> crate::wallet::Result<Address> {
+    ) -> Result<Address, WalletError> {
         let transaction_options = transaction_options.into();
 
         Ok(if let Some(options) = &transaction_options {

--- a/sdk/src/wallet/operations/transaction/sign_transaction.rs
+++ b/sdk/src/wallet/operations/transaction/sign_transaction.rs
@@ -18,20 +18,21 @@ use crate::{
             transaction::validate_signed_transaction_payload_length, PreparedTransactionData, SignedTransactionData,
         },
         secret::SecretManage,
+        ClientError,
     },
-    wallet::{operations::transaction::SignedTransactionPayload, Wallet},
+    wallet::{operations::transaction::SignedTransactionPayload, Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Signs a transaction.
     pub async fn sign_transaction(
         &self,
         prepared_transaction_data: &PreparedTransactionData,
-    ) -> crate::wallet::Result<SignedTransactionData> {
+    ) -> Result<SignedTransactionData, WalletError> {
         log::debug!("[TRANSACTION] sign_transaction");
         log::debug!("[TRANSACTION] prepared_transaction_data {prepared_transaction_data:?}");
         #[cfg(feature = "events")]

--- a/sdk/src/wallet/operations/transaction/submit_transaction.rs
+++ b/sdk/src/wallet/operations/transaction/submit_transaction.rs
@@ -4,22 +4,22 @@
 #[cfg(feature = "events")]
 use crate::wallet::events::types::{TransactionProgressEvent, WalletEvent};
 use crate::{
-    client::secret::SecretManage,
+    client::{secret::SecretManage, ClientError},
     types::block::{output::AccountId, payload::Payload, BlockId},
-    wallet::{operations::transaction::SignedTransactionPayload, Wallet},
+    wallet::{operations::transaction::SignedTransactionPayload, Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Submits a signed transaction in a block.
     pub(crate) async fn submit_signed_transaction(
         &self,
         payload: SignedTransactionPayload,
         issuer_id: impl Into<Option<AccountId>> + Send,
-    ) -> crate::wallet::Result<BlockId> {
+    ) -> Result<BlockId, WalletError> {
         log::debug!("[TRANSACTION] submit_signed_transaction");
 
         #[cfg(feature = "events")]

--- a/sdk/src/wallet/operations/wait_for_tx_acceptance.rs
+++ b/sdk/src/wallet/operations/wait_for_tx_acceptance.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{secret::SecretManage, Error as ClientError},
+    client::{secret::SecretManage, ClientError},
     types::block::payload::signed_transaction::TransactionId,
-    wallet::{types::InclusionState, Error, Wallet},
+    wallet::{types::InclusionState, Wallet, WalletError},
 };
 
 impl<S: 'static + SecretManage> Wallet<S>
 where
-    Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
+    WalletError: From<S::Error>,
+    ClientError: From<S::Error>,
 {
     /// Checks the transaction state for a provided transaction id until it's accepted. Interval in milliseconds.
     pub async fn wait_for_transaction_acceptance(
@@ -18,7 +18,7 @@ where
         transaction_id: &TransactionId,
         interval: Option<u64>,
         max_attempts: Option<u64>,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("[wait_for_transaction_acceptance]");
 
         let transaction = self
@@ -27,7 +27,7 @@ where
             .transactions
             .get(transaction_id)
             .cloned()
-            .ok_or_else(|| Error::TransactionNotFound(*transaction_id))?;
+            .ok_or_else(|| WalletError::TransactionNotFound(*transaction_id))?;
 
         if matches!(
             transaction.inclusion_state,

--- a/sdk/src/wallet/storage/adapter/memory.rs
+++ b/sdk/src/wallet/storage/adapter/memory.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use tokio::sync::RwLock;
 
-use crate::client::storage::StorageAdapter;
+use crate::{client::storage::StorageAdapter, wallet::WalletError};
 
 /// A storage adapter that stores data in memory.
 #[derive(Debug, Default)]
@@ -14,18 +14,18 @@ pub struct Memory(Arc<RwLock<HashMap<String, Vec<u8>>>>);
 
 #[async_trait::async_trait]
 impl StorageAdapter for Memory {
-    type Error = crate::wallet::Error;
+    type Error = WalletError;
 
-    async fn get_bytes(&self, key: &str) -> crate::wallet::Result<Option<Vec<u8>>> {
+    async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, WalletError> {
         Ok(self.0.read().await.get(key).cloned())
     }
 
-    async fn set_bytes(&self, key: &str, record: &[u8]) -> crate::wallet::Result<()> {
+    async fn set_bytes(&self, key: &str, record: &[u8]) -> Result<(), WalletError> {
         self.0.write().await.insert(key.to_string(), record.to_owned());
         Ok(())
     }
 
-    async fn delete(&self, key: &str) -> crate::wallet::Result<()> {
+    async fn delete(&self, key: &str) -> Result<(), WalletError> {
         self.0.write().await.remove(key);
         Ok(())
     }

--- a/sdk/src/wallet/storage/adapter/mod.rs
+++ b/sdk/src/wallet/storage/adapter/mod.rs
@@ -9,39 +9,39 @@ pub mod rocksdb;
 
 use async_trait::async_trait;
 
-use crate::client::storage::StorageAdapter;
+use crate::{client::storage::StorageAdapter, wallet::WalletError};
 
 #[async_trait]
 pub(crate) trait DynStorageAdapter: std::fmt::Debug + Send + Sync {
-    async fn dyn_get_bytes(&self, key: &str) -> crate::wallet::Result<Option<Vec<u8>>>;
+    async fn dyn_get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, WalletError>;
 
-    async fn dyn_set_bytes(&self, key: &str, record: &[u8]) -> crate::wallet::Result<()>;
+    async fn dyn_set_bytes(&self, key: &str, record: &[u8]) -> Result<(), WalletError>;
 
     /// Removes a record from the storage.
-    async fn dyn_delete(&self, key: &str) -> crate::wallet::Result<()>;
+    async fn dyn_delete(&self, key: &str) -> Result<(), WalletError>;
 }
 
 #[async_trait]
 impl<T: StorageAdapter> DynStorageAdapter for T
 where
-    crate::wallet::Error: From<T::Error>,
+    WalletError: From<T::Error>,
 {
-    async fn dyn_get_bytes(&self, key: &str) -> crate::wallet::Result<Option<Vec<u8>>> {
+    async fn dyn_get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, WalletError> {
         Ok(self.get_bytes(key).await?)
     }
 
-    async fn dyn_set_bytes(&self, key: &str, record: &[u8]) -> crate::wallet::Result<()> {
+    async fn dyn_set_bytes(&self, key: &str, record: &[u8]) -> Result<(), WalletError> {
         Ok(self.set_bytes(key, record).await?)
     }
 
-    async fn dyn_delete(&self, key: &str) -> crate::wallet::Result<()> {
+    async fn dyn_delete(&self, key: &str) -> Result<(), WalletError> {
         Ok(self.delete(key).await?)
     }
 }
 
 #[async_trait]
 impl StorageAdapter for dyn DynStorageAdapter {
-    type Error = crate::wallet::Error;
+    type Error = WalletError;
 
     async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
         self.dyn_get_bytes(key).await

--- a/sdk/src/wallet/storage/adapter/rocksdb.rs
+++ b/sdk/src/wallet/storage/adapter/rocksdb.rs
@@ -6,7 +6,7 @@ use std::{path::Path, sync::Arc};
 use rocksdb::{DBCompressionType, Options, DB};
 use tokio::sync::Mutex;
 
-use crate::client::storage::StorageAdapter;
+use crate::{client::storage::StorageAdapter, wallet::WalletError};
 
 /// Key value storage adapter.
 #[derive(Clone, Debug)]
@@ -16,7 +16,7 @@ pub struct RocksdbStorageAdapter {
 
 impl RocksdbStorageAdapter {
     /// Initialises the storage adapter.
-    pub fn new(path: impl AsRef<Path>) -> crate::wallet::Result<Self> {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, WalletError> {
         let mut opts = Options::default();
         opts.set_compression_type(DBCompressionType::Lz4);
         opts.create_if_missing(true);
@@ -30,18 +30,18 @@ impl RocksdbStorageAdapter {
 
 #[async_trait::async_trait]
 impl StorageAdapter for RocksdbStorageAdapter {
-    type Error = crate::wallet::Error;
+    type Error = WalletError;
 
-    async fn get_bytes(&self, key: &str) -> crate::wallet::Result<Option<Vec<u8>>> {
+    async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, WalletError> {
         Ok(self.db.lock().await.get(key)?)
     }
 
-    async fn set_bytes(&self, key: &str, record: &[u8]) -> crate::wallet::Result<()> {
+    async fn set_bytes(&self, key: &str, record: &[u8]) -> Result<(), WalletError> {
         self.db.lock().await.put(key, record)?;
         Ok(())
     }
 
-    async fn delete(&self, key: &str) -> crate::wallet::Result<()> {
+    async fn delete(&self, key: &str) -> Result<(), WalletError> {
         self.db.lock().await.delete(key)?;
         Ok(())
     }

--- a/sdk/src/wallet/storage/adapter/wasm.rs
+++ b/sdk/src/wallet/storage/adapter/wasm.rs
@@ -14,7 +14,7 @@ pub struct WasmAdapter(LocalStorage);
 
 impl WasmAdapter {
     /// Initialises the storage adapter.
-    pub fn new() -> crate::wallet::Result<Self> {
+    pub fn new() -> Result<Self, WalletError> {
         Ok(Self(LocalStorage::new()))
     }
 }
@@ -22,23 +22,23 @@ impl WasmAdapter {
 #[async_trait::async_trait]
 impl StorageAdapter for WasmAdapter {
     /// Gets the record associated with the given key from the storage.
-    async fn get(&self, key: &str) -> crate::wallet::Result<String> {
+    async fn get(&self, key: &str) -> Result<String, WalletError> {
         self.0.get(key)
     }
 
     /// Saves or updates a record on the storage.
-    async fn set(&mut self, key: &str, record: String) -> crate::wallet::Result<()> {
+    async fn set(&mut self, key: &str, record: String) -> Result<(), WalletError> {
         self.0.set(key, record)
     }
 
     /// Batch writes records to the storage.
-    async fn batch_set(&mut self, records: HashMap<String, String>) -> crate::wallet::Result<()> {
+    async fn batch_set(&mut self, records: HashMap<String, String>) -> Result<(), WalletError> {
         records.into_iter().map(|s| self.set(s.0, s.1));
         Ok(())
     }
 
     /// Removes a record from the storage.
-    async fn remove(&mut self, key: &str) -> crate::wallet::Result<()> {
+    async fn remove(&mut self, key: &str) -> Result<(), WalletError> {
         self.0.delete(key)
     }
 }

--- a/sdk/src/wallet/storage/mod.rs
+++ b/sdk/src/wallet/storage/mod.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroizing;
 use self::adapter::DynStorageAdapter;
 pub(crate) use self::manager::StorageManager;
 pub use self::{kind::StorageKind, options::StorageOptions};
-use crate::client::storage::StorageAdapter;
+use crate::{client::storage::StorageAdapter, wallet::WalletError};
 
 #[derive(Debug)]
 pub struct Storage {
@@ -33,7 +33,7 @@ pub struct Storage {
 
 #[async_trait]
 impl StorageAdapter for Storage {
-    type Error = crate::wallet::Error;
+    type Error = WalletError;
 
     async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
         match self.inner.as_ref().get_bytes(key).await? {

--- a/sdk/src/wallet/storage/participation.rs
+++ b/sdk/src/wallet/storage/participation.rs
@@ -20,7 +20,7 @@ impl StorageManager {
     pub(crate) async fn insert_participation_event(
         &self,
         event_with_nodes: ParticipationEventWithNodes,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("insert_participation_event {}", event_with_nodes.id);
 
         let mut events = self
@@ -36,7 +36,7 @@ impl StorageManager {
         Ok(())
     }
 
-    pub(crate) async fn remove_participation_event(&self, id: &ParticipationEventId) -> crate::wallet::Result<()> {
+    pub(crate) async fn remove_participation_event(&self, id: &ParticipationEventId) -> Result<(), WalletError> {
         log::debug!("remove_participation_event {id}");
 
         let mut events = match self
@@ -57,7 +57,7 @@ impl StorageManager {
 
     pub(crate) async fn get_participation_events(
         &self,
-    ) -> crate::wallet::Result<HashMap<ParticipationEventId, ParticipationEventWithNodes>> {
+    ) -> Result<HashMap<ParticipationEventId, ParticipationEventWithNodes>, WalletError> {
         log::debug!("get_participation_events");
 
         Ok(self.storage.get(PARTICIPATION_EVENTS).await?.unwrap_or_default())
@@ -66,7 +66,7 @@ impl StorageManager {
     pub(crate) async fn set_cached_participation_output_status(
         &self,
         outputs_participation: &HashMap<OutputId, OutputStatusResponse>,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("set_cached_participation");
 
         self.storage
@@ -78,7 +78,7 @@ impl StorageManager {
 
     pub(crate) async fn get_cached_participation_output_status(
         &self,
-    ) -> crate::wallet::Result<HashMap<OutputId, OutputStatusResponse>> {
+    ) -> Result<HashMap<OutputId, OutputStatusResponse>, WalletError> {
         log::debug!("get_cached_participation");
 
         Ok(self

--- a/sdk/src/wallet/task.rs
+++ b/sdk/src/wallet/task.rs
@@ -11,7 +11,7 @@ where
 }
 
 #[cfg(target_family = "wasm")]
-pub(crate) async fn spawn<F>(future: F) -> Result<F::Output, WalletError>
+pub(crate) async fn spawn<F>(future: F) -> Result<F::Output, crate::wallet::WalletError>
 where
     F: futures::Future + 'static,
     F::Output: 'static,

--- a/sdk/src/wallet/task.rs
+++ b/sdk/src/wallet/task.rs
@@ -11,7 +11,7 @@ where
 }
 
 #[cfg(target_family = "wasm")]
-pub(crate) async fn spawn<F>(future: F) -> crate::wallet::Result<F::Output>
+pub(crate) async fn spawn<F>(future: F) -> Result<F::Output, WalletError>
 where
     F: futures::Future + 'static,
     F::Output: 'static,

--- a/sdk/src/wallet/types/mod.rs
+++ b/sdk/src/wallet/types/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 pub use self::balance::{Balance, BaseCoinBalance, NativeTokensBalance, RequiredStorageDeposit};
 use crate::{
-    client::secret::types::InputSigningData,
+    client::{secret::types::InputSigningData, ClientError},
     types::{
         block::{
             address::Bech32Address,
@@ -29,6 +29,7 @@ use crate::{
         },
         TryFromDto,
     },
+    wallet::WalletError,
 };
 
 /// An output with metadata
@@ -59,11 +60,11 @@ impl OutputData {
         wallet_bip_path: Option<Bip44>,
         commitment_slot_index: impl Into<SlotIndex>,
         committable_age_range: CommittableAgeRange,
-    ) -> crate::wallet::Result<Option<InputSigningData>> {
+    ) -> Result<Option<InputSigningData>, WalletError> {
         let required_address = self
             .output
             .required_address(commitment_slot_index.into(), committable_age_range)?
-            .ok_or(crate::client::Error::ExpirationDeadzone)?;
+            .ok_or(ClientError::ExpirationDeadzone)?;
 
         let chain = if let Some(required_ed25519) = required_address.backing_ed25519() {
             if let Some(backing_ed25519) = wallet_address.inner().backing_ed25519() {
@@ -163,12 +164,12 @@ impl TryFromDto<TransactionWithMetadataDto> for TransactionWithMetadata {
             timestamp: dto
                 .timestamp
                 .parse::<u128>()
-                .map_err(|e| PayloadError::InvalidTimestamp(e.to_string()))?,
+                .map_err(|e| PayloadError::Timestamp(e.to_string()))?,
             transaction_id: dto.transaction_id,
             network_id: dto
                 .network_id
                 .parse::<u64>()
-                .map_err(|e| PayloadError::InvalidNetworkId(e.to_string()))?,
+                .map_err(|e| PayloadError::NetworkId(e.to_string()))?,
             incoming: dto.incoming,
             note: dto.note,
             inputs: dto.inputs,
@@ -211,7 +212,7 @@ pub enum OutputKind {
 }
 
 impl FromStr for OutputKind {
-    type Err = crate::wallet::Error;
+    type Err = WalletError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kind = match s {
@@ -219,7 +220,7 @@ impl FromStr for OutputKind {
             "Basic" => Self::Basic,
             "Foundry" => Self::Foundry,
             "Nft" => Self::Nft,
-            _ => return Err(crate::wallet::Error::InvalidOutputKind(s.to_string())),
+            _ => return Err(WalletError::InvalidOutputKind(s.to_string())),
         };
         Ok(kind)
     }

--- a/sdk/src/wallet/update.rs
+++ b/sdk/src/wallet/update.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     wallet::{
         types::{InclusionState, OutputData, TransactionWithMetadata},
-        Wallet,
+        Wallet, WalletError,
     },
 };
 #[cfg(feature = "events")]
@@ -22,13 +22,9 @@ use crate::{
     wallet::events::types::{NewOutputEvent, SpentOutputEvent, TransactionInclusionEvent, WalletEvent},
 };
 
-impl<S: 'static + SecretManage> Wallet<S>
-where
-    crate::wallet::Error: From<S::Error>,
-    crate::client::Error: From<S::Error>,
-{
+impl<S: 'static + SecretManage> Wallet<S> {
     /// Update the wallet address with a possible new Bech32 HRP and clear the inaccessible incoming transactions.
-    pub(crate) async fn update_address_hrp(&self) -> crate::wallet::Result<()> {
+    pub(crate) async fn update_address_hrp(&self) -> Result<(), WalletError> {
         let bech32_hrp = self.client().get_bech32_hrp().await?;
         log::debug!("updating wallet with new bech32 hrp: {}", bech32_hrp);
 
@@ -51,7 +47,7 @@ where
     }
 
     /// Set the wallet alias.
-    pub async fn set_alias(&self, alias: &str) -> crate::wallet::Result<()> {
+    pub async fn set_alias(&self, alias: &str) -> Result<(), WalletError> {
         log::debug!("setting wallet alias to: {}", alias);
 
         *self.alias_mut().await = Some(alias.to_string());
@@ -64,7 +60,7 @@ where
         &self,
         unspent_outputs: Vec<OutputData>,
         spent_or_unsynced_output_metadata_map: HashMap<OutputId, Option<OutputMetadata>>,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("[SYNC] Update wallet ledger with new synced transactions");
 
         let network_id = self.client().get_network_id().await?;
@@ -163,7 +159,7 @@ where
         updated_transactions: Vec<TransactionWithMetadata>,
         spent_output_ids: Vec<OutputId>,
         output_ids_to_unlock: Vec<OutputId>,
-    ) -> crate::wallet::Result<()> {
+    ) -> Result<(), WalletError> {
         log::debug!("[SYNC] Update wallet with new synced transactions");
 
         let mut wallet_ledger = self.ledger_mut().await;

--- a/sdk/tests/client/addresses.rs
+++ b/sdk/tests/client/addresses.rs
@@ -11,7 +11,7 @@ use iota_sdk::{
         constants::{IOTA_BECH32_HRP, IOTA_COIN_TYPE, IOTA_TESTNET_BECH32_HRP, SHIMMER_BECH32_HRP, SHIMMER_COIN_TYPE},
         generate_mnemonic,
         secret::{GenerateAddressOptions, SecretManager},
-        Client, Result,
+        Client, ClientError,
     },
     types::block::{
         address::{Address, Hrp},
@@ -258,7 +258,7 @@ async fn address_generation() {
 }
 
 #[tokio::test]
-async fn search_address() -> Result<()> {
+async fn search_address() -> Result<(), ClientError> {
     let client = Client::builder()
         .with_protocol_parameters(iota_mainnet_protocol_parameters().clone())
         .finish()
@@ -322,7 +322,7 @@ async fn search_address() -> Result<()> {
             .await;
 
     match res {
-        Err(iota_sdk::client::Error::InputAddressNotFound { .. }) => {}
+        Err(iota_sdk::client::ClientError::InputAddressNotFound { .. }) => {}
         _ => panic!("should not have found search address range & public"),
     }
 

--- a/sdk/tests/client/error.rs
+++ b/sdk/tests/client/error.rs
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::{
-    client::{api::input_selection::Error as IsaError, Error},
+    client::{api::input_selection::Error as IsaError, ClientError},
     types::block::BlockError,
 };
 use pretty_assertions::assert_eq;
 
 #[test]
 fn stringified_error() {
-    let error = Error::InvalidAmount("0".into());
+    let error = ClientError::InvalidAmount("0".into());
     assert_eq!(
         &serde_json::to_string(&error).unwrap(),
         "{\"type\":\"invalidAmount\",\"error\":\"invalid amount in API response: 0\"}"
     );
 
-    let error = Error::TimeNotSynced {
+    let error = ClientError::TimeNotSynced {
         current_time: 0,
         tangle_time: 10000,
     };
@@ -24,13 +24,13 @@ fn stringified_error() {
         "{\"type\":\"timeNotSynced\",\"error\":\"local time 0 doesn't match the tangle time: 10000\"}"
     );
 
-    let error = Error::PlaceholderSecretManager;
+    let error = ClientError::PlaceholderSecretManager;
     assert_eq!(
         &serde_json::to_string(&error).unwrap(),
         "{\"type\":\"placeholderSecretManager\",\"error\":\"placeholderSecretManager can't be used for address generation or signing\"}"
     );
 
-    let error = Error::InputSelection(IsaError::InsufficientAmount {
+    let error = ClientError::InputSelection(IsaError::InsufficientAmount {
         found: 0,
         required: 100,
     });
@@ -39,7 +39,7 @@ fn stringified_error() {
         "{\"type\":\"inputSelection\",\"error\":\"insufficient amount: found 0, required 100\"}"
     );
 
-    let error = Error::InputSelection(IsaError::Block(BlockError::UnsupportedAddressKind(6)));
+    let error = ClientError::InputSelection(IsaError::Block(BlockError::UnsupportedAddressKind(6)));
     assert_eq!(
         &serde_json::to_string(&error).unwrap(),
         "{\"type\":\"inputSelection\",\"error\":\"unsupported address kind: 6\"}"

--- a/sdk/tests/client/mnemonic.rs
+++ b/sdk/tests/client/mnemonic.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crypto::keys::bip39::Mnemonic;
-use iota_sdk::client::{Client, Result};
+use iota_sdk::client::{Client, ClientError};
 
 #[tokio::test]
-async fn mnemonic() -> Result<()> {
+async fn mnemonic() -> Result<(), ClientError> {
     let mnemonic = Client::generate_mnemonic()?;
     assert!(Client::mnemonic_to_hex_seed(mnemonic).is_ok());
     assert!(Client::mnemonic_to_hex_seed(Mnemonic::from("until fire hat mountain zoo grocery real deny advance change marble taste goat ivory wheat bubble panic banner tattoo client ticket action race rocket".to_owned())).is_ok());

--- a/sdk/tests/client/node_api/indexer.rs
+++ b/sdk/tests/client/node_api/indexer.rs
@@ -23,7 +23,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn get_alias_output_id_test() -> Result<()> {
+// async fn get_alias_output_id_test() -> Result<(), ClientError> {
 //     let (client, secret_manager) = create_client_and_secret_manager_with_funds(None).await?;
 //     let protocol_parameters = client.get_protocol_parameters().await?;
 
@@ -55,7 +55,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn get_nft_output_id_test() -> Result<()> {
+// async fn get_nft_output_id_test() -> Result<(), ClientError> {
 //     let (client, secret_manager) = create_client_and_secret_manager_with_funds(None).await?;
 //     let protocol_parameters = client.get_protocol_parameters().await?;
 
@@ -85,7 +85,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn get_foundry_output_id_test() -> Result<()> {
+// async fn get_foundry_output_id_test() -> Result<(), ClientError> {
 //     let (client, secret_manager) = create_client_and_secret_manager_with_funds(None).await?;
 //     let protocol_parameters = client.get_protocol_parameters().await?;
 

--- a/sdk/tests/client/node_api/mod.rs
+++ b/sdk/tests/client/node_api/mod.rs
@@ -108,7 +108,7 @@ pub async fn setup_transaction_block(client: &Client) -> (BlockId, TransactionId
 // TODO uncomment
 
 // // helper function to get the output id for the first alias output
-// fn get_alias_output_id(payload: &Payload) -> Result<OutputId> {
+// fn get_alias_output_id(payload: &Payload) -> Result<OutputId, ClientError> {
 //     match payload {
 //         Payload::Transaction(tx_payload) => {
 //             for (index, output) in tx_payload.transaction().as_regular().outputs().iter().enumerate() {
@@ -123,7 +123,7 @@ pub async fn setup_transaction_block(client: &Client) -> (BlockId, TransactionId
 // }
 
 // // helper function to get the output id for the first foundry output
-// fn get_foundry_output_id(payload: &Payload) -> Result<OutputId> {
+// fn get_foundry_output_id(payload: &Payload) -> Result<OutputId, ClientError> {
 //     match payload {
 //         Payload::Transaction(tx_payload) => {
 //             for (index, output) in tx_payload.transaction().as_regular().outputs().iter().enumerate() {
@@ -138,7 +138,7 @@ pub async fn setup_transaction_block(client: &Client) -> (BlockId, TransactionId
 // }
 
 // // helper function to get the output id for the first NFT output
-// fn get_nft_output_id(payload: &Payload) -> Result<OutputId> {
+// fn get_nft_output_id(payload: &Payload) -> Result<OutputId, ClientError> {
 //     match payload {
 //         Payload::Transaction(tx_payload) => {
 //             for (index, output) in tx_payload.transaction().as_regular().outputs().iter().enumerate() {

--- a/sdk/tests/client/secret_manager/mnemonic.rs
+++ b/sdk/tests/client/secret_manager/mnemonic.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::client::{
-    api::GetAddressesOptions, constants::SHIMMER_TESTNET_BECH32_HRP, secret::SecretManager, Result,
+    api::GetAddressesOptions, constants::SHIMMER_TESTNET_BECH32_HRP, secret::SecretManager, ClientError,
 };
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
-async fn mnemonic_secret_manager() -> Result<()> {
+async fn mnemonic_secret_manager() -> Result<(), ClientError> {
     let dto = r#"{"mnemonic": "acoustic trophy damage hint search taste love bicycle foster cradle brown govern endless depend situate athlete pudding blame question genius transfer van random vast"}"#;
     let secret_manager: SecretManager = dto.parse()?;
 

--- a/sdk/tests/client/secret_manager/private_key.rs
+++ b/sdk/tests/client/secret_manager/private_key.rs
@@ -5,12 +5,12 @@ use iota_sdk::client::{
     api::GetAddressesOptions,
     constants::SHIMMER_TESTNET_BECH32_HRP,
     secret::{private_key::PrivateKeySecretManager, SecretManager},
-    Result,
+    ClientError,
 };
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
-async fn private_key_secret_manager_hex() -> Result<()> {
+async fn private_key_secret_manager_hex() -> Result<(), ClientError> {
     let dto = r#"{"privateKey": "0x9e845b327c44e28bdd206c7c9eff09c40680bc2512add57280baf5b064d7e6f6"}"#;
     let secret_manager: SecretManager = dto.parse()?;
 
@@ -64,7 +64,7 @@ async fn private_key_secret_manager_hex() -> Result<()> {
 }
 
 #[tokio::test]
-async fn private_key_secret_manager_bs58() -> Result<()> {
+async fn private_key_secret_manager_bs58() -> Result<(), ClientError> {
     let secret_manager = SecretManager::from(PrivateKeySecretManager::try_from_b58(
         "BfnURR6WSXJA6RyBr3WqGU99UzrVbWk9GSQgJqKtTRxZ",
     )?);

--- a/sdk/tests/client/secret_manager/stronghold.rs
+++ b/sdk/tests/client/secret_manager/stronghold.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::client::{
-    api::GetAddressesOptions, constants::SHIMMER_TESTNET_BECH32_HRP, secret::SecretManager, Result,
+    api::GetAddressesOptions, constants::SHIMMER_TESTNET_BECH32_HRP, secret::SecretManager, ClientError,
 };
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
-async fn stronghold_secret_manager() -> Result<()> {
+async fn stronghold_secret_manager() -> Result<(), ClientError> {
     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
     let dto = r#"{"stronghold": {"password": "some_hopefully_secure_password", "snapshotPath": "snapshot_test_dir/test.stronghold"}}"#;
@@ -52,7 +52,7 @@ async fn stronghold_secret_manager() -> Result<()> {
 }
 
 #[tokio::test]
-async fn stronghold_mnemonic_missing() -> Result<()> {
+async fn stronghold_mnemonic_missing() -> Result<(), ClientError> {
     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
     // Cleanup of a possibly failed run
@@ -73,7 +73,7 @@ async fn stronghold_mnemonic_missing() -> Result<()> {
         .unwrap_err();
 
     match error {
-        iota_sdk::client::Error::Stronghold(iota_sdk::client::stronghold::Error::MnemonicMissing) => {}
+        iota_sdk::client::ClientError::Stronghold(iota_sdk::client::stronghold::Error::MnemonicMissing) => {}
         _ => panic!("expected StrongholdMnemonicMissing error"),
     }
 

--- a/sdk/tests/types/address/bech32.rs
+++ b/sdk/tests/types/address/bech32.rs
@@ -37,7 +37,7 @@ fn ctors() {
 fn hrp_from_str() {
     Hrp::from_str("rms").unwrap();
 
-    assert!(matches!(Hrp::from_str("中國"), Err(AddressError::InvalidBech32Hrp(_))));
+    assert!(matches!(Hrp::from_str("中國"), Err(AddressError::Bech32Hrp(_))));
 }
 
 #[test]

--- a/sdk/tests/types/address/mod.rs
+++ b/sdk/tests/types/address/mod.rs
@@ -26,9 +26,9 @@ const ED25519_ADDRESS_INVALID: &str = "0x52fdfc072182654f163f5f0f9a621d729566c74
 
 #[test]
 fn invalid_bech32() {
-    let address = Address::try_from_bech32(ED25519_ADDRESS_INVALID);
+    let address = Address::try_from_bech32(ED25519_ADDRESS_INVALID).unwrap_err();
 
-    assert!(matches!(address, Err(AddressError::InvalidAddress)));
+    assert!(matches!(address, AddressError::Bech32Encoding(_)));
 }
 
 #[test]

--- a/sdk/tests/types/output/feature/metadata.rs
+++ b/sdk/tests/types/output/feature/metadata.rs
@@ -47,7 +47,7 @@ fn serde_roundtrip() {
 fn unpack_invalid_order() {
     assert!(matches!(
         MetadataFeature::unpack_bytes_verified([3, 1, 99, 0, 0, 1, 98, 0, 0, 1, 97, 0, 0], &()),
-        Err(UnpackError::Packable(FeatureError::InvalidMetadataFeature(error_msg))) if &error_msg == "unordered map"
+        Err(UnpackError::Packable(FeatureError::MetadataFeature(error_msg))) if &error_msg == "unordered map"
     ));
 }
 
@@ -55,6 +55,6 @@ fn unpack_invalid_order() {
 fn unpack_invalid_length() {
     assert!(matches!(
         MetadataFeature::unpack_bytes_verified([vec![1, 1, 33, 0, 32], vec![0u8; 8192]].concat(), &()),
-        Err(UnpackError::Packable(FeatureError::InvalidMetadataFeature(len))) if &len == "Out of bounds byte length: 8197"
+        Err(UnpackError::Packable(FeatureError::MetadataFeature(len))) if &len == "Out of bounds byte length: 8197"
     ));
 }

--- a/sdk/tests/types/tagged_data_payload.rs
+++ b/sdk/tests/types/tagged_data_payload.rs
@@ -59,7 +59,7 @@ fn new_valid_tag_length_min() {
 fn new_invalid_tag_length_more_than_max() {
     assert!(matches!(
         TaggedDataPayload::new(rand_bytes(65), [0x42, 0xff, 0x84, 0xa2, 0x42, 0xff, 0x84, 0xa2]),
-        Err(PayloadError::InvalidTagLength(TryIntoBoundedU8Error::Invalid(65)))
+        Err(PayloadError::TagLength(TryIntoBoundedU8Error::Invalid(65)))
     ));
 }
 
@@ -68,7 +68,7 @@ fn new_invalid_data_length_more_than_max() {
     assert!(matches!(
         // TODO https://github.com/iotaledger/iota-sdk/issues/1226
         TaggedDataPayload::new(rand_bytes(32), [0u8; Block::LENGTH_MAX + 42]),
-        Err(PayloadError::InvalidTaggedDataLength(TryIntoBoundedU32Error::Invalid(l))) if l == Block::LENGTH_MAX as u32 + 42
+        Err(PayloadError::TaggedDataLength(TryIntoBoundedU32Error::Invalid(l))) if l == Block::LENGTH_MAX as u32 + 42
     ));
 }
 
@@ -111,7 +111,7 @@ fn unpack_invalid_tag_length_more_than_max() {
             ],
             &()
         ),
-        Err(UnpackError::Packable(PayloadError::InvalidTagLength(
+        Err(UnpackError::Packable(PayloadError::TagLength(
             TryIntoBoundedU8Error::Invalid(65)
         )))
     ));
@@ -121,7 +121,7 @@ fn unpack_invalid_tag_length_more_than_max() {
 fn unpack_invalid_data_length_more_than_max() {
     assert!(matches!(
         TaggedDataPayload::unpack_bytes_verified([0x02, 0x00, 0x00, 0x35, 0x82, 0x00, 0x00], &()),
-        Err(UnpackError::Packable(PayloadError::InvalidTaggedDataLength(
+        Err(UnpackError::Packable(PayloadError::TaggedDataLength(
             TryIntoBoundedU32Error::Invalid(33333)
         )))
     ));

--- a/sdk/tests/types/transaction.rs
+++ b/sdk/tests/types/transaction.rs
@@ -143,7 +143,7 @@ fn build_invalid_payload_kind() {
         .add_mana_allotment(rand_mana_allotment(protocol_parameters))
         .finish_with_params(protocol_parameters);
 
-    assert!(matches!(transaction, Err(PayloadError::InvalidPayloadKind(1))));
+    assert!(matches!(transaction, Err(PayloadError::Kind(1))));
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn build_invalid_input_count_low() {
 
     assert!(matches!(
         transaction,
-        Err(PayloadError::InvalidInputCount(TryIntoBoundedU16Error::Invalid(0)))
+        Err(PayloadError::InputCount(TryIntoBoundedU16Error::Invalid(0)))
     ));
 }
 
@@ -191,7 +191,7 @@ fn build_invalid_input_count_high() {
 
     assert!(matches!(
         transaction,
-        Err(PayloadError::InvalidInputCount(TryIntoBoundedU16Error::Invalid(129)))
+        Err(PayloadError::InputCount(TryIntoBoundedU16Error::Invalid(129)))
     ));
 }
 
@@ -208,7 +208,7 @@ fn build_invalid_output_count_low() {
 
     assert!(matches!(
         transaction,
-        Err(PayloadError::InvalidOutputCount(TryIntoBoundedU16Error::Invalid(0)))
+        Err(PayloadError::OutputCount(TryIntoBoundedU16Error::Invalid(0)))
     ));
 }
 
@@ -234,7 +234,7 @@ fn build_invalid_output_count_high() {
 
     assert!(matches!(
         transaction,
-        Err(PayloadError::InvalidOutputCount(TryIntoBoundedU16Error::Invalid(129)))
+        Err(PayloadError::OutputCount(TryIntoBoundedU16Error::Invalid(129)))
     ));
 }
 
@@ -293,7 +293,7 @@ fn build_invalid_accumulated_output() {
         .add_mana_allotment(rand_mana_allotment(protocol_parameters))
         .finish_with_params(protocol_parameters);
 
-    assert!(matches!(transaction, Err(PayloadError::InvalidTransactionAmountSum(_))));
+    assert!(matches!(transaction, Err(PayloadError::TransactionAmountSum(_))));
 }
 
 #[test]

--- a/sdk/tests/types/unlock/account.rs
+++ b/sdk/tests/types/unlock/account.rs
@@ -24,7 +24,7 @@ fn new_valid_max_index() {
 fn new_invalid_more_than_max_index() {
     assert!(matches!(
         AccountUnlock::new(128),
-        Err(UnlockError::InvalidAccountIndex(InvalidBoundedU16(128)))
+        Err(UnlockError::AccountIndex(InvalidBoundedU16(128)))
     ));
 }
 
@@ -37,7 +37,7 @@ fn try_from_valid() {
 fn try_from_invalid() {
     assert!(matches!(
         AccountUnlock::try_from(128),
-        Err(UnlockError::InvalidAccountIndex(InvalidBoundedU16(128)))
+        Err(UnlockError::AccountIndex(InvalidBoundedU16(128)))
     ));
 }
 

--- a/sdk/tests/types/unlock/mod.rs
+++ b/sdk/tests/types/unlock/mod.rs
@@ -26,7 +26,7 @@ fn kind() {
 fn new_invalid_first_reference() {
     assert!(matches!(
         Unlocks::new([ReferenceUnlock::new(42).unwrap().into()]),
-        Err(UnlockError::InvalidUnlockReference(0)),
+        Err(UnlockError::Reference(0)),
     ));
 }
 
@@ -37,7 +37,7 @@ fn new_invalid_self_reference() {
             SignatureUnlock::from(rand_signature()).into(),
             ReferenceUnlock::new(1).unwrap().into()
         ]),
-        Err(UnlockError::InvalidUnlockReference(1)),
+        Err(UnlockError::Reference(1)),
     ));
 }
 
@@ -49,7 +49,7 @@ fn new_invalid_future_reference() {
             ReferenceUnlock::new(2).unwrap().into(),
             SignatureUnlock::from(rand_signature()).into(),
         ]),
-        Err(UnlockError::InvalidUnlockReference(1)),
+        Err(UnlockError::Reference(1)),
     ));
 }
 
@@ -61,7 +61,7 @@ fn new_invalid_reference_reference() {
             ReferenceUnlock::new(0).unwrap().into(),
             ReferenceUnlock::new(1).unwrap().into()
         ]),
-        Err(UnlockError::InvalidUnlockReference(2)),
+        Err(UnlockError::Reference(2)),
     ));
 }
 
@@ -79,7 +79,7 @@ fn new_invalid_duplicate_signature() {
             SignatureUnlock::from(rand_signature()).into(),
             ReferenceUnlock::new(3).unwrap().into()
         ]),
-        Err(UnlockError::DuplicateSignatureUnlock(5)),
+        Err(UnlockError::DuplicateSignature(5)),
     ));
 }
 
@@ -87,7 +87,7 @@ fn new_invalid_duplicate_signature() {
 fn new_invalid_too_many_blocks() {
     assert!(matches!(
         Unlocks::new(vec![ReferenceUnlock::new(0).unwrap().into(); 300]),
-        Err(UnlockError::InvalidUnlockCount(TryIntoBoundedU16Error::Invalid(300))),
+        Err(UnlockError::Count(TryIntoBoundedU16Error::Invalid(300))),
     ));
 }
 
@@ -150,7 +150,7 @@ fn invalid_account_0() {
             AccountUnlock::new(0).unwrap().into(),
             SignatureUnlock::from(rand_signature()).into(),
         ]),
-        Err(UnlockError::InvalidUnlockAccount(0)),
+        Err(UnlockError::Account(0)),
     ));
 }
 
@@ -161,7 +161,7 @@ fn invalid_account_index() {
             SignatureUnlock::from(rand_signature()).into(),
             AccountUnlock::new(2).unwrap().into(),
         ]),
-        Err(UnlockError::InvalidUnlockAccount(1)),
+        Err(UnlockError::Account(1)),
     ));
 }
 
@@ -172,7 +172,7 @@ fn invalid_nft_0() {
             NftUnlock::new(0).unwrap().into(),
             SignatureUnlock::from(rand_signature()).into(),
         ]),
-        Err(UnlockError::InvalidUnlockNft(0)),
+        Err(UnlockError::Nft(0)),
     ));
 }
 
@@ -183,6 +183,6 @@ fn invalid_nft_index() {
             SignatureUnlock::from(rand_signature()).into(),
             NftUnlock::new(2).unwrap().into(),
         ]),
-        Err(UnlockError::InvalidUnlockNft(1)),
+        Err(UnlockError::Nft(1)),
     ));
 }

--- a/sdk/tests/types/unlock/nft.rs
+++ b/sdk/tests/types/unlock/nft.rs
@@ -24,7 +24,7 @@ fn new_valid_max_index() {
 fn new_invalid_more_than_max_index() {
     assert!(matches!(
         NftUnlock::new(128),
-        Err(UnlockError::InvalidNftIndex(InvalidBoundedU16(128)))
+        Err(UnlockError::NftIndex(InvalidBoundedU16(128)))
     ));
 }
 
@@ -37,7 +37,7 @@ fn try_from_valid() {
 fn try_from_invalid() {
     assert!(matches!(
         NftUnlock::try_from(128),
-        Err(UnlockError::InvalidNftIndex(InvalidBoundedU16(128)))
+        Err(UnlockError::NftIndex(InvalidBoundedU16(128)))
     ));
 }
 

--- a/sdk/tests/types/unlock/reference.rs
+++ b/sdk/tests/types/unlock/reference.rs
@@ -24,7 +24,7 @@ fn new_valid_max_index() {
 fn new_invalid_more_than_max_index() {
     assert!(matches!(
         ReferenceUnlock::new(128),
-        Err(UnlockError::InvalidReferenceIndex(InvalidBoundedU16(128)))
+        Err(UnlockError::ReferenceIndex(InvalidBoundedU16(128)))
     ));
 }
 
@@ -37,7 +37,7 @@ fn try_from_valid() {
 fn try_from_invalid() {
     assert!(matches!(
         ReferenceUnlock::try_from(128),
-        Err(UnlockError::InvalidReferenceIndex(InvalidBoundedU16(128)))
+        Err(UnlockError::ReferenceIndex(InvalidBoundedU16(128)))
     ));
 }
 
@@ -61,8 +61,8 @@ fn pack_unpack_valid() {
 fn pack_unpack_invalid_index() {
     assert!(matches!(
         ReferenceUnlock::unpack_bytes_verified([0x2a, 0x2a], &()),
-        Err(UnpackError::Packable(UnlockError::InvalidReferenceIndex(
-            InvalidBoundedU16(10794)
-        )))
+        Err(UnpackError::Packable(UnlockError::ReferenceIndex(InvalidBoundedU16(
+            10794
+        ))))
     ));
 }

--- a/sdk/tests/types/unlock/signature.rs
+++ b/sdk/tests/types/unlock/signature.rs
@@ -46,6 +46,6 @@ fn pack_unpack_invalid_kind() {
             ],
             &()
         ),
-        Err(UnpackError::Packable(SignatureError::InvalidSignatureKind(1)))
+        Err(UnpackError::Packable(SignatureError::Kind(1)))
     ));
 }

--- a/sdk/tests/wallet/backup_restore.rs
+++ b/sdk/tests/wallet/backup_restore.rs
@@ -21,7 +21,7 @@
 
 // // Backup and restore with Stronghold
 // #[tokio::test]
-// async fn backup_and_restore() -> Result<()> {
+// async fn backup_and_restore() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/backup_and_restore";
@@ -128,7 +128,7 @@
 
 // // Backup and restore with Stronghold and MnemonicSecretManager
 // #[tokio::test]
-// async fn backup_and_restore_mnemonic_secret_manager() -> Result<()> {
+// async fn backup_and_restore_mnemonic_secret_manager() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/backup_and_restore_mnemonic_secret_manager";
@@ -208,7 +208,7 @@
 
 // // Backup and restore with Stronghold
 // #[tokio::test]
-// async fn backup_and_restore_different_coin_type() -> Result<()> {
+// async fn backup_and_restore_different_coin_type() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/backup_and_restore_different_coin_type";
@@ -290,7 +290,7 @@
 
 // // Backup and restore with Stronghold
 // #[tokio::test]
-// async fn backup_and_restore_same_coin_type() -> Result<()> {
+// async fn backup_and_restore_same_coin_type() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/backup_and_restore_same_coin_type";
@@ -371,7 +371,7 @@
 
 // // Backup and restore with Stronghold
 // #[tokio::test]
-// async fn backup_and_restore_different_coin_type_dont_ignore() -> Result<()> {
+// async fn backup_and_restore_different_coin_type_dont_ignore() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/backup_and_restore_different_coin_type_dont_ignore";
@@ -455,7 +455,7 @@
 // }
 
 // #[tokio::test]
-// async fn backup_and_restore_bech32_hrp_mismatch() -> Result<()> {
+// async fn backup_and_restore_bech32_hrp_mismatch() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/backup_and_restore_bech32_hrp_mismatch";
@@ -537,7 +537,7 @@
 
 // // Restore a Stronghold snapshot without secret manager data
 // #[tokio::test]
-// async fn restore_no_secret_manager_data() -> Result<()> {
+// async fn restore_no_secret_manager_data() -> Result<(), WalletError> {
 //     iota_stronghold::engine::snapshot::try_set_encrypt_work_factor(0).unwrap();
 
 //     let storage_path = "test-storage/restore_no_secret_manager_data";

--- a/sdk/tests/wallet/balance.rs
+++ b/sdk/tests/wallet/balance.rs
@@ -260,7 +260,7 @@ async fn balance_transfer() -> Result<(), Box<dyn std::error::Error>> {
 // #[ignore]
 // #[tokio::test]
 // #[cfg(feature = "participation")]
-// async fn balance_voting_power() -> Result<()> {
+// async fn balance_voting_power() -> Result<(), WalletError> {
 //     let storage_path = "test-storage/balance_voting_power";
 //     setup(storage_path)?;
 

--- a/sdk/tests/wallet/bech32_hrp_validation.rs
+++ b/sdk/tests/wallet/bech32_hrp_validation.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use iota_sdk::{
-    client::Error as ClientError,
+    client::ClientError,
     types::block::address::{Bech32Address, ToBech32Ext},
-    wallet::{Error, OutputParams, SendParams},
+    wallet::{OutputParams, SendParams, WalletError},
 };
 use pretty_assertions::assert_eq;
 
@@ -32,7 +32,7 @@ async fn bech32_hrp_send_amount() -> Result<(), Box<dyn std::error::Error>> {
     let bech32_hrp = wallet.client().get_bech32_hrp().await?;
 
     match error {
-        Error::Client(error) => match error {
+        WalletError::Client(error) => match error {
             ClientError::Bech32HrpMismatch { provided, expected } => {
                 assert_eq!(provided, "wronghrp");
                 assert_eq!(expected, bech32_hrp.to_string());
@@ -71,7 +71,7 @@ async fn bech32_hrp_prepare_output() -> Result<(), Box<dyn std::error::Error>> {
     let bech32_hrp = wallet.client().get_bech32_hrp().await?;
 
     match error {
-        Error::Client(error) => match error {
+        WalletError::Client(error) => match error {
             ClientError::Bech32HrpMismatch { provided, expected } => {
                 assert_eq!(provided, "wronghrp");
                 assert_eq!(expected, bech32_hrp.to_string());

--- a/sdk/tests/wallet/claim_outputs.rs
+++ b/sdk/tests/wallet/claim_outputs.rs
@@ -540,7 +540,10 @@ async fn claim_basic_micro_output_error() -> Result<(), Box<dyn std::error::Erro
     let result = wallet_1
         .claim_outputs(wallet_1.claimable_outputs(OutputsToClaim::MicroTransactions).await?)
         .await;
-    assert!(matches!(result, Err(iota_sdk::wallet::Error::InsufficientFunds { .. })));
+    assert!(matches!(
+        result,
+        Err(iota_sdk::wallet::WalletError::InsufficientFunds { .. })
+    ));
 
     tear_down(storage_path_0)?;
     tear_down(storage_path_1)?;

--- a/sdk/tests/wallet/core.rs
+++ b/sdk/tests/wallet/core.rs
@@ -6,7 +6,7 @@ use crypto::keys::bip39::Mnemonic;
 use iota_sdk::{
     client::constants::SHIMMER_COIN_TYPE,
     client::node_manager::node::{Node, NodeDto},
-    wallet::Error,
+    wallet::WalletError,
 };
 use iota_sdk::{
     client::{
@@ -100,7 +100,7 @@ async fn changed_bip_path() -> Result<(), Box<dyn std::error::Error>> {
 
     // Building the wallet with another coin type needs to return an error, because a different coin type was used in
     // the existing account
-    assert!(matches!(result, Err(Error::BipPathMismatch {
+    assert!(matches!(result, Err(WalletError::BipPathMismatch {
         new_bip_path: Some(new_bip_path),
         old_bip_path: Some(old_bip_path),
     }) if new_bip_path == Bip44::new(IOTA_COIN_TYPE) && old_bip_path == Bip44::new(SHIMMER_COIN_TYPE)));

--- a/sdk/tests/wallet/error.rs
+++ b/sdk/tests/wallet/error.rs
@@ -1,27 +1,27 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk::wallet::Error;
+use iota_sdk::wallet::WalletError;
 use pretty_assertions::assert_eq;
 
 #[test]
 fn stringified_error() {
     // testing a unit-type-like error
-    let error = Error::MissingBipPath;
+    let error = WalletError::MissingBipPath;
     assert_eq!(
         &serde_json::to_string(&error).unwrap(),
         "{\"type\":\"missingBipPath\",\"error\":\"missing BIP path\"}"
     );
 
     // testing a tuple-like error
-    let error = Error::InvalidMnemonic("nilly willy".to_string());
+    let error = WalletError::InvalidMnemonic("nilly willy".to_string());
     assert_eq!(
         serde_json::to_string(&error).unwrap(),
         "{\"type\":\"invalidMnemonic\",\"error\":\"invalid mnemonic: nilly willy\"}"
     );
 
     // testing a struct-like error
-    let error = Error::NoOutputsToConsolidate {
+    let error = WalletError::NoOutputsToConsolidate {
         available_outputs: 0,
         consolidation_threshold: 0,
     };

--- a/sdk/tests/wallet/migrate_stronghold_snapshot_v2_to_v3.rs
+++ b/sdk/tests/wallet/migrate_stronghold_snapshot_v2_to_v3.rs
@@ -10,11 +10,11 @@ use iota_sdk::{
         secret::{stronghold::StrongholdSecretManager, SecretManager},
         storage::StorageAdapter,
         stronghold::{Error as StrongholdError, StrongholdAdapter},
-        Error as ClientError,
+        ClientError,
     },
     crypto::keys::bip44::Bip44,
     types::block::protocol::iota_mainnet_protocol_parameters,
-    wallet::{ClientOptions, Error as WalletError, Wallet},
+    wallet::{ClientOptions, Wallet, WalletError},
 };
 use pretty_assertions::assert_eq;
 

--- a/sdk/tests/wallet/output_preparation.rs
+++ b/sdk/tests/wallet/output_preparation.rs
@@ -224,7 +224,7 @@ async fn output_preparation() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .unwrap_err();
     match error {
-        iota_sdk::wallet::Error::NftNotFoundInUnspentOutputs => {}
+        iota_sdk::wallet::WalletError::NftNotFoundInUnspentOutputs => {}
         _ => panic!("should return NftNotFoundInUnspentOutputs error"),
     }
 
@@ -308,7 +308,7 @@ async fn output_preparation() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .unwrap_err();
     match error {
-        iota_sdk::wallet::Error::MissingParameter(_) => {}
+        iota_sdk::wallet::WalletError::MissingParameter(_) => {}
         _ => panic!("should return MissingParameter error"),
     }
 
@@ -693,7 +693,7 @@ async fn prepare_output_remainder_dust() -> Result<(), Box<dyn std::error::Error
         )
         .await;
     assert!(
-        matches!(result, Err(iota_sdk::wallet::Error::InsufficientFunds{available, required}) if available == balance.base_coin().available() && required == 85199)
+        matches!(result, Err(iota_sdk::wallet::WalletError::InsufficientFunds{available, required}) if available == balance.base_coin().available() && required == 85199)
     );
 
     let output = wallet_0

--- a/sdk/tests/wallet/syncing.rs
+++ b/sdk/tests/wallet/syncing.rs
@@ -14,7 +14,7 @@
 
 // #[tokio::test]
 // #[cfg(feature = "rocksdb")]
-// async fn updated_default_sync_options() -> Result<()> {
+// async fn updated_default_sync_options() -> Result<(), WalletError> {
 //     let storage_path = "test-storage/updated_default_sync_options";
 //     setup(storage_path)?;
 
@@ -42,7 +42,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn sync_only_most_basic_outputs() -> Result<()> {
+// async fn sync_only_most_basic_outputs() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/sync_only_most_basic_outputs_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/sync_only_most_basic_outputs_1";
@@ -145,7 +145,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn sync_incoming_transactions() -> Result<()> {
+// async fn sync_incoming_transactions() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/sync_incoming_transactions_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/sync_incoming_transactions_1";
@@ -193,7 +193,7 @@
 // #[ignore]
 // #[tokio::test]
 // #[cfg(feature = "storage")]
-// async fn background_syncing() -> Result<()> {
+// async fn background_syncing() -> Result<(), WalletError> {
 //     let storage_path = "test-storage/background_syncing";
 //     setup(storage_path)?;
 

--- a/sdk/tests/wallet/transactions.rs
+++ b/sdk/tests/wallet/transactions.rs
@@ -8,7 +8,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn send_amount() -> Result<()> {
+// async fn send_amount() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/send_amount_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/send_amount_1";
@@ -36,7 +36,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn send_amount_127_outputs() -> Result<()> {
+// async fn send_amount_127_outputs() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/send_amount_127_outputs_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/send_amount_127_outputs_1";
@@ -74,7 +74,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn send_amount_custom_input() -> Result<()> {
+// async fn send_amount_custom_input() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/send_amount_custom_input_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/send_amount_custom_input_1";
@@ -121,7 +121,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn send_nft() -> Result<()> {
+// async fn send_nft() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/send_nft_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/send_nft_1";
@@ -164,7 +164,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn send_with_note() -> Result<()> {
+// async fn send_with_note() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/send_with_note_0";
 //     setup(storage_path_0)?;
 //     let storage_path_1 = "test-storage/send_with_note_1";
@@ -193,7 +193,7 @@
 
 // #[ignore]
 // #[tokio::test]
-// async fn conflicting_transaction() -> Result<()> {
+// async fn conflicting_transaction() -> Result<(), WalletError> {
 //     let storage_path_0 = "test-storage/conflicting_transaction_0";
 //     let storage_path_1 = "test-storage/conflicting_transaction_1";
 //     setup(storage_path_0)?;
@@ -265,7 +265,7 @@
 // #[tokio::test]
 // #[cfg(all(feature = "ledger_nano", feature = "events"))]
 // #[ignore = "requires ledger nano instance"]
-// async fn prepare_transaction_ledger() -> Result<()> {
+// async fn prepare_transaction_ledger() -> Result<(), WalletError> {
 //     use iota_sdk::wallet::events::{types::TransactionProgressEvent, WalletEvent, WalletEventType};
 
 //     let storage_path_0 = "test-storage/wallet_address_generation_ledger_0";


### PR DESCRIPTION
# Description of change

Accomplishes three things:
1. Remove result type defs (#2063)
2. Move errors to their own files (#2096)
3. Renames error variants to avoid verbosity (#2099)