### PR TITLE
Rename inputs_from_transaction_id to get_transaction_inputs

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -409,8 +409,8 @@ required-features = ["client"]
 # High Level examples
 
 [[example]]
-name = "inputs_from_transaction_id"
-path = "examples/client/high_level/inputs_from_transaction_id.rs"
+name = "get_transaction_inputs"
+path = "examples/client/high_level/get_transaction_inputs.rs"
 required-features = ["client"]
 
 [[example]]

--- a/sdk/examples/client/high_level/get_transaction_inputs.rs
+++ b/sdk/examples/client/high_level/get_transaction_inputs.rs
@@ -7,7 +7,7 @@
 //!
 //! Rename `.env.example` to `.env` first, then run the command:
 //! ```sh
-//! cargo run --release --example inputs_from_transaction_id <TRANSACTION_ID>
+//! cargo run --release --example get_transaction_inputs <TRANSACTION_ID>
 //! ```
 
 use iota_sdk::{client::Client, types::block::payload::signed_transaction::TransactionId};
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("missing example argument: TRANSACTION ID")
         .parse::<TransactionId>()?;
 
-    let inputs = client.inputs_from_transaction_id(&transaction_id).await?;
+    let inputs = client.get_transaction_inputs(&transaction_id).await?;
 
     println!("Transaction inputs:\n{:#?}", inputs);
 

--- a/sdk/src/client/api/high_level.rs
+++ b/sdk/src/client/api/high_level.rs
@@ -28,7 +28,7 @@ use crate::{
 
 impl Client {
     /// Get the inputs of a transaction for the given transaction id.
-    pub async fn inputs_from_transaction_id(
+    pub async fn get_transaction_inputs(
         &self,
         transaction_id: &TransactionId,
     ) -> Result<Vec<OutputWithMetadataResponse>> {

--- a/sdk/tests/client/high_level.rs
+++ b/sdk/tests/client/high_level.rs
@@ -8,10 +8,10 @@ use crate::client::{common::setup_client_with_node_health_ignored, node_api::set
 
 #[ignore]
 #[tokio::test]
-async fn test_find_inputs_from_transaction_id() {
+async fn test_find_get_transaction_inputs() {
     let client = setup_client_with_node_health_ignored().await;
     let (_block_id, transaction_id) = setup_transaction_block(&client).await;
-    let inputs = client.inputs_from_transaction_id(&transaction_id).await.unwrap();
+    let inputs = client.get_transaction_inputs(&transaction_id).await.unwrap();
 
     assert_eq!(inputs.len(), 1);
 }

--- a/sdk/tests/client/high_level.rs
+++ b/sdk/tests/client/high_level.rs
@@ -8,7 +8,7 @@ use crate::client::{common::setup_client_with_node_health_ignored, node_api::set
 
 #[ignore]
 #[tokio::test]
-async fn test_find_get_transaction_inputs() {
+async fn test_get_transaction_inputs() {
     let client = setup_client_with_node_health_ignored().await;
     let (_block_id, transaction_id) = setup_transaction_block(&client).await;
     let inputs = client.get_transaction_inputs(&transaction_id).await.unwrap();


### PR DESCRIPTION
# Description of change

Rename inputs_from_transaction_id to get_transaction_inputs 

## Links to any relevant issues

Closes #2082 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

cargo clippy
