### PR TITLE
feat: Add `computeDelegationId` util to JS bindings

### DIFF
--- a/bindings/nodejs/lib/utils/utils.ts
+++ b/bindings/nodejs/lib/utils/utils.ts
@@ -26,6 +26,7 @@ import {
 import {
     AccountId,
     BlockId,
+    DelegationId,
     FoundryId,
     NftId,
     TokenId,
@@ -83,7 +84,7 @@ export class Utils {
      * @param outputId The output ID as hex-encoded string.
      * @returns The delegation ID.
      */
-    static computeDelegationId(outputId: OutputId): AccountId {
+    static computeDelegationId(outputId: OutputId): DelegationId {
         return callUtilsMethod({
             name: 'blake2b256Hash',
             data: {

--- a/bindings/nodejs/lib/utils/utils.ts
+++ b/bindings/nodejs/lib/utils/utils.ts
@@ -78,6 +78,21 @@ export class Utils {
     }
 
     /**
+     * Compute the delegation ID from a given delegation output ID.
+     *
+     * @param outputId The output ID as hex-encoded string.
+     * @returns The delegation ID.
+     */
+    static computeDelegationId(outputId: OutputId): AccountId {
+        return callUtilsMethod({
+            name: 'blake2b256Hash',
+            data: {
+                bytes: outputId,
+            },
+        });
+    }
+
+    /**
      * Compute the Foundry ID.
      *
      * @param accountId The account ID associated with the Foundry.

--- a/bindings/nodejs/tests/utils/utils.spec.ts
+++ b/bindings/nodejs/tests/utils/utils.spec.ts
@@ -39,13 +39,24 @@ describe('Utils methods', () => {
         expect(isAddressValid).toBeTruthy();
     });
 
-    it('hash output id', () => {
+    it('compute account id', () => {
         const outputId =
             '0x0000000000000000000000000000000000000000000000000000000000000000000000000000';
 
         const accountId = Utils.computeAccountId(outputId);
 
         expect(accountId).toBe(
+            '0x0ebc2867a240719a70faacdfc3840e857fa450b37d95297ac4f166c2f70c3345',
+        );
+    });
+
+    it('compute delegation id', () => {
+        const outputId =
+            '0x0000000000000000000000000000000000000000000000000000000000000000000000000000';
+
+        const delegationId = Utils.computeDelegationId(outputId);
+
+        expect(delegationId).toBe(
             '0x0ebc2867a240719a70faacdfc3840e857fa450b37d95297ac4f166c2f70c3345',
         );
     });

--- a/bindings/wasm/tests/utilityMethods.spec.ts
+++ b/bindings/wasm/tests/utilityMethods.spec.ts
@@ -48,13 +48,24 @@ describe('Utils methods', () => {
         expect(isAddressValid).toBeTruthy();
     });
 
-    it('hash output id', async () => {
+    it('compute account id', () => {
         const outputId =
             '0x0000000000000000000000000000000000000000000000000000000000000000000000000000';
 
         const accountId = Utils.computeAccountId(outputId);
 
         expect(accountId).toBe(
+            '0x0ebc2867a240719a70faacdfc3840e857fa450b37d95297ac4f166c2f70c3345',
+        );
+    });
+
+    it('compute delegation id', () => {
+        const outputId =
+            '0x0000000000000000000000000000000000000000000000000000000000000000000000000000';
+
+        const delegationId = Utils.computeDelegationId(outputId);
+
+        expect(delegationId).toBe(
             '0x0ebc2867a240719a70faacdfc3840e857fa450b37d95297ac4f166c2f70c3345',
         );
     });


### PR DESCRIPTION
# Description of change

Simply adds `computeDelegationId` to both NodeJS and wasm bindings

## Links to any relevant issues

Closes https://github.com/iotaledger/iota-sdk/issues/2168

## Type of change

- Enhancement

## How the change has been tested

Running the tests and in Firefly

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
