### PR TITLE
Update getCommittee epoch query parameter

### DIFF
--- a/bindings/core/src/method/client.rs
+++ b/bindings/core/src/method/client.rs
@@ -187,10 +187,9 @@ pub enum ClientMethod {
     },
     /// Return the information of committee members at the given epoch index. If epoch index is not provided, the
     /// current committee members are returned.
-    #[serde(rename_all = "camelCase")]
     GetCommittee {
         /// The epoch index to query.
-        epoch_index: Option<EpochIndex>,
+        epoch: Option<EpochIndex>,
     },
     /// Get issuance
     GetIssuance,

--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -196,7 +196,7 @@ pub(crate) async fn call_client_method_internal(
             Response::Validators(client.get_validators(page_size, cursor).await?)
         }
         ClientMethod::GetValidator { account_id } => Response::Validator(client.get_validator(&account_id).await?),
-        ClientMethod::GetCommittee { epoch_index } => Response::Committee(client.get_committee(epoch_index).await?),
+        ClientMethod::GetCommittee { epoch } => Response::Committee(client.get_committee(epoch).await?),
         ClientMethod::GetIssuance => Response::Issuance(client.get_issuance().await?),
         ClientMethod::PostBlockRaw { block_bytes } => Response::BlockId(
             client

--- a/bindings/nodejs/lib/client/client.ts
+++ b/bindings/nodejs/lib/client/client.ts
@@ -252,13 +252,13 @@ export class Client {
     /**
      * Returns the information of committee members at the given epoch index. If epoch index is not provided, the
      * current committee members are returned.
-     * GET /api/core/v3/committee/?epochIndex
+     * GET /api/core/v3/committee/?epoch
      */
-    async getCommittee(epochIndex?: EpochIndex): Promise<CommitteeResponse> {
+    async getCommittee(epoch?: EpochIndex): Promise<CommitteeResponse> {
         const response = await this.methodHandler.callMethod({
             name: 'getCommittee',
             data: {
-                epochIndex,
+                epoch,
             },
         });
 

--- a/bindings/nodejs/lib/types/client/bridge/client.ts
+++ b/bindings/nodejs/lib/types/client/bridge/client.ts
@@ -104,7 +104,7 @@ export interface __GetValidatorMethod__ {
 export interface __GetCommitteeMethod__ {
     name: 'getCommittee';
     data: {
-        epochIndex?: EpochIndex;
+        epoch?: EpochIndex;
     };
 }
 

--- a/bindings/python/iota_sdk/client/_node_core_api.py
+++ b/bindings/python/iota_sdk/client/_node_core_api.py
@@ -144,13 +144,13 @@ class NodeCoreAPI(metaclass=ABCMeta):
     # Committee routes.
 
     def get_committee(
-            self, epoch_index: Optional[EpochIndex] = None) -> CommitteeResponse:
+            self, epoch: Optional[EpochIndex] = None) -> CommitteeResponse:
         """Returns the information of committee members at the given epoch index. If epoch index is not provided, the
         current committee members are returned.
-        GET /api/core/v3/committee/?epochIndex
+        GET /api/core/v3/committee/?epoch
         """
         return CommitteeResponse.from_dict(self._call_method('getCommittee', {
-            'epochIndex': epoch_index
+            'epoch': epoch
         }))
 
     # Block routes.

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -167,13 +167,13 @@ impl Client {
 
     /// Returns the information of committee members at the given epoch index. If epoch index is not provided, the
     /// current committee members are returned.
-    /// GET /api/core/v3/committee/?epochIndex
+    /// GET /api/core/v3/committee/?epoch
     pub async fn get_committee(
         &self,
-        epoch_index: impl Into<Option<EpochIndex>> + Send,
+        epoch: impl Into<Option<EpochIndex>> + Send,
     ) -> Result<CommitteeResponse, ClientError> {
         const PATH: &str = "api/core/v3/committee";
-        let query = query_tuples_to_query_string([epoch_index.into().map(|i| ("epochIndex", i.to_string()))]);
+        let query = query_tuples_to_query_string([epoch.into().map(|i| ("epoch", i.to_string()))]);
 
         self.get_request(PATH, query.as_deref(), false).await
     }


### PR DESCRIPTION
# Description of change

Change it from `epochIndex` to `epoch`

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

```Rust
    let committee_response = client.get_committee(None).await?;
    let committee_response2 = client.get_committee(committee_response.epoch - 1).await?;
```
