### PR TITLE
Remove delegation and implicit accounts amounts from available balance

### DIFF
--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -35,7 +35,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
 
         let mut balance = Balance::default();
         let mut total_storage_cost = 0;
-        let mut delegation_implicit_accounts_amount = 0;
+        let mut locked_amount = 0;
         let mut total_native_tokens = NativeTokensBuilder::default();
 
         #[cfg(feature = "participation")]
@@ -272,7 +272,6 @@ impl<S: 'static + SecretManage> Wallet<S> {
         // for `available` get locked_outputs, sum outputs amount and subtract from total_amount
         log::debug!("[BALANCE] locked outputs: {:#?}", wallet_ledger.locked_outputs);
 
-        let mut locked_amount = 0;
         let mut locked_mana = DecayedMana::default();
         let mut locked_native_tokens = NativeTokensBuilder::default();
 
@@ -346,18 +345,13 @@ impl<S: 'static + SecretManage> Wallet<S> {
 
         #[cfg(not(feature = "participation"))]
         {
-            balance.base_coin.available = balance
-                .base_coin
-                .total
-                .saturating_sub(delegation_implicit_accounts_amount)
-                .saturating_sub(locked_amount);
+            balance.base_coin.available = balance.base_coin.total.saturating_sub(locked_amount);
         }
         #[cfg(feature = "participation")]
         {
             balance.base_coin.available = balance
                 .base_coin
                 .total
-                .saturating_sub(delegation_implicit_accounts_amount)
                 .saturating_sub(locked_amount)
                 .saturating_sub(balance.base_coin.voting_power);
         }

--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -138,7 +138,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
 
                         // Add amount
                         balance.base_coin.total += output.amount();
-                        if address_unlock_cond.address().kind() == ImplicitAccountCreationAddress::KIND {
+                        if address_unlock_cond.address().is_implicit_account_creation() {
                             locked_amount += output.amount();
                         }
                         // Add decayed mana

--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -114,7 +114,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
                 Output::Delegation(delegation) => {
                     // Add amount
                     balance.base_coin.total += delegation.amount();
-                    delegation_implicit_accounts_amount += delegation.amount();
+                    locked_amount += delegation.amount();
                     // Add mana rewards
                     reward_outputs.insert(*output_id);
                     // Add storage deposit
@@ -139,7 +139,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
                         // Add amount
                         balance.base_coin.total += output.amount();
                         if address_unlock_cond.address().kind() == ImplicitAccountCreationAddress::KIND {
-                            delegation_implicit_accounts_amount += output.amount();
+                            locked_amount += output.amount();
                         }
                         // Add decayed mana
                         balance.mana.total += output.decayed_mana(

--- a/sdk/src/wallet/operations/balance.rs
+++ b/sdk/src/wallet/operations/balance.rs
@@ -7,11 +7,8 @@ use primitive_types::U256;
 
 use crate::{
     client::secret::SecretManage,
-    types::block::{
-        address::ImplicitAccountCreationAddress,
-        output::{
-            unlock_condition::UnlockCondition, DecayedMana, FoundryId, MinimumOutputAmount, NativeTokensBuilder, Output,
-        },
+    types::block::output::{
+        unlock_condition::UnlockCondition, DecayedMana, FoundryId, MinimumOutputAmount, NativeTokensBuilder, Output,
     },
     wallet::{
         operations::{helpers::time::can_output_be_unlocked_from_now_on, output_claiming::OutputsToClaim},


### PR DESCRIPTION
# Description of change

Remove delegation and implicit accounts amounts from available balance

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/2170

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

With the cli wallet, balance before output with implicit account creation address:
```
    base_coin: BaseCoinBalance {
        total: 2000000000,
        available: 1999968300,
```
After an output with implicit account creation address got added
```
    base_coin: BaseCoinBalance {
        total: 3000000000,
        available: 1999968300,
```