### PR TITLE
CLI: improve wallet creation

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -73,6 +73,9 @@ pub struct InitParameters {
     /// Set the Bech32-encoded wallet address.
     #[arg(short, long)]
     pub address: Option<String>,
+    /// Set the wallet alias name.
+    #[arg(short = 'l', long)]
+    pub alias: Option<String>,
 }
 
 impl Default for InitParameters {
@@ -84,6 +87,7 @@ impl Default for InitParameters {
             node_url: DEFAULT_NODE_URL.to_string(),
             bip_path: Some(Bip44::new(SHIMMER_COIN_TYPE)),
             address: None,
+            alias: None,
         }
     }
 }
@@ -400,11 +404,12 @@ pub async fn init_command(
     secret_manager: SecretManager,
     init_params: InitParameters,
 ) -> Result<Wallet, Error> {
-    let alias = if get_decision("Do you want to assign an alias to your wallet?")? {
-        Some(get_alias("New wallet alias").await?)
-    } else {
-        None
-    };
+    let mut alias = init_params.alias;
+    if alias.is_none() {
+        if get_decision("Do you want to assign an alias to your wallet?")? {
+            alias.replace(get_alias("New wallet alias").await?);
+        }
+    }
 
     Ok(Wallet::builder()
         .with_secret_manager(secret_manager)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -7,7 +7,7 @@ use clap::{builder::BoolishValueParser, Args, CommandFactory, Parser, Subcommand
 use eyre::{bail, Error};
 use iota_sdk::{
     client::{
-        constants::{IOTA_COIN_TYPE, SHIMMER_COIN_TYPE},
+        constants::SHIMMER_COIN_TYPE,
         secret::{ledger_nano::LedgerSecretManager, stronghold::StrongholdSecretManager, SecretManager},
         stronghold::StrongholdAdapter,
         utils::Password,
@@ -20,9 +20,9 @@ use log::LevelFilter;
 
 use crate::{
     helper::{
-        check_file_exists, enter_address, enter_alias, enter_bip_path, enter_decision, enter_or_generate_mnemonic,
-        enter_password, generate_mnemonic, import_mnemonic, parse_bip_path, select_or_enter_bip_path,
-        select_secret_manager, BipPathChoice, SecretManagerChoice,
+        check_file_exists, enter_address, enter_alias, enter_decision, enter_or_generate_mnemonic, enter_password,
+        generate_mnemonic, import_mnemonic, parse_bip_path, select_or_enter_bip_path, select_secret_manager,
+        SecretManagerChoice,
     },
     println_log_error, println_log_info,
 };
@@ -395,11 +395,7 @@ pub async fn init_command(storage_path: &Path, init_params: InitParameters) -> R
     let mut bip_path = init_params.bip_path;
     if bip_path.is_none() {
         if forced || enter_decision("Do you want to set the bip path of the new wallet?")? {
-            bip_path.replace(match select_or_enter_bip_path()? {
-                BipPathChoice::Iota => Bip44::new(IOTA_COIN_TYPE),
-                BipPathChoice::Shimmer => Bip44::new(SHIMMER_COIN_TYPE),
-                BipPathChoice::Custom => enter_bip_path()?,
-            });
+            bip_path.replace(select_or_enter_bip_path()?);
         }
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -404,7 +404,7 @@ pub async fn init_command(
     if bip_path.is_none() {
         if forced || get_decision("Do you want to set the bip path of the new wallet?")? {
             bip_path.replace(
-                get_bip_path("Set bip path (format=<coin_type>/<account_index>/<change_address>/<address_index>)")
+                get_bip_path("Set bip path (<coin_type>/<account_index>/<change_address>/<address_index>)")
                     .await?,
             );
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -404,8 +404,7 @@ pub async fn init_command(
     if bip_path.is_none() {
         if forced || get_decision("Do you want to set the bip path of the new wallet?")? {
             bip_path.replace(
-                get_bip_path("Set bip path (<coin_type>/<account_index>/<change_address>/<address_index>)")
-                    .await?,
+                get_bip_path("Set bip path (<coin_type>/<account_index>/<change_address>/<address_index>)").await?,
             );
         }
     }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -324,7 +324,7 @@ pub async fn new_wallet(cli: Cli) -> Result<Option<Wallet>, Error> {
 
             let snapshot_path = Path::new(&init_params.stronghold_snapshot_path);
             if !snapshot_path.exists() {
-                if enter_decision("Create a new wallet with default parameters?")? {
+                if enter_decision("Create a new wallet with default parameters?", "yes")? {
                     Some(init_command(storage_path, init_params).await?)
                 } else {
                     Cli::print_help()?;
@@ -385,7 +385,7 @@ pub async fn init_command(storage_path: &Path, init_params: InitParameters) -> R
     let mut address = init_params.address.map(|s| Bech32Address::from_str(&s)).transpose()?;
     let mut forced = false;
     if address.is_none() {
-        if enter_decision("Do you want to set the address of the new wallet?")? {
+        if enter_decision("Do you want to set the address of the new wallet?", "no")? {
             address.replace(enter_address()?);
         } else {
             forced = true;
@@ -394,14 +394,14 @@ pub async fn init_command(storage_path: &Path, init_params: InitParameters) -> R
 
     let mut bip_path = init_params.bip_path;
     if bip_path.is_none() {
-        if forced || enter_decision("Do you want to set the bip path of the new wallet?")? {
+        if forced || enter_decision("Do you want to set the bip path of the new wallet?", "yes")? {
             bip_path.replace(select_or_enter_bip_path()?);
         }
     }
 
     let mut alias = init_params.alias;
     if alias.is_none() {
-        if enter_decision("Do you want to set an alias for the new wallet?")? {
+        if enter_decision("Do you want to set an alias for the new wallet?", "yes")? {
             alias.replace(enter_alias()?);
         }
     }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -230,20 +230,7 @@ pub async fn new_wallet(cli: Cli) -> Result<Option<Wallet>, Error> {
                 let secret_manager = create_secret_manager(&init_parameters).await?;
                 let secret_manager_variant = secret_manager.to_string();
                 let wallet = init_command(storage_path, secret_manager, init_parameters).await?;
-                println_log_info!("Created new wallet with '{}' secret manager.", secret_manager_variant);
-                println_log_info!(
-                    "Wallet parameters:\naddress={}\nbip_path={:?}\nalias={:?}",
-                    wallet.address().await,
-                    wallet.bip_path().await,
-                    wallet.alias().await,
-                );
-                println_log_info!(
-                    "Network parameters:\nname={}\nid={}\nbech32_hrp={}",
-                    wallet.client().get_network_name().await?,
-                    wallet.client().get_network_id().await?,
-                    wallet.client().get_bech32_hrp().await?,
-                );
-
+                print_create_wallet_summary(&wallet, &secret_manager_variant).await?;
                 Some(wallet)
             }
             CliCommand::MigrateStrongholdSnapshotV2ToV3 { path } => {
@@ -345,19 +332,7 @@ pub async fn new_wallet(cli: Cli) -> Result<Option<Wallet>, Error> {
                     let secret_manager = create_secret_manager(&init_params).await?;
                     let secret_manager_variant = secret_manager.to_string();
                     let wallet = init_command(storage_path, secret_manager, init_params).await?;
-                    println_log_info!("Created new wallet with '{}' secret manager.", secret_manager_variant);
-                    println_log_info!(
-                        "Wallet parameters:\naddress={}\nbip_path={:?}\nalias={:?}",
-                        wallet.address().await,
-                        wallet.bip_path().await,
-                        wallet.alias().await,
-                    );
-                    println_log_info!(
-                        "Network parameters:\nname={}\nid={}\nbech32_hrp={}",
-                        wallet.client().get_network_name().await?,
-                        wallet.client().get_network_id().await?,
-                        wallet.client().get_bech32_hrp().await?,
-                    );
+                    print_create_wallet_summary(&wallet, &secret_manager_variant).await?;
                     Some(wallet)
                 } else {
                     Cli::print_help()?;
@@ -373,6 +348,16 @@ pub async fn new_wallet(cli: Cli) -> Result<Option<Wallet>, Error> {
             }
         }
     })
+}
+
+async fn print_create_wallet_summary(wallet: &Wallet, secret_manager_variant: &str) -> Result<(), Error> {
+    println_log_info!("Created new wallet with the following parameters:",);
+    println_log_info!("Secret manager: {secret_manager_variant}");
+    println_log_info!("Wallet address: {}", wallet.address().await);
+    println_log_info!("Wallet bip path: {:?}", wallet.bip_path().await);
+    println_log_info!("Wallet alias: {:?}", wallet.alias().await);
+    println_log_info!("Network name: {}", wallet.client().get_network_name().await?);
+    Ok(())
 }
 
 pub async fn backup_to_stronghold_snapshot_command(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -68,8 +68,7 @@ pub struct InitParameters {
     #[arg(short, long, value_name = "URL", env = "NODE_URL", default_value = DEFAULT_NODE_URL)]
     pub node_url: String,
     /// Set the BIP path. If not provided a bip path has to be provided interactively on first launch.
-    /// The expected format is: `a/b/c/d` where `a` = coin type, `b` = account index, `c` = address index, `d` =
-    /// internal.
+    /// The expected format is: `<coin_type>/<account_index>/<address_index>/<change>`.
     #[arg(short, long, value_parser = parse_bip_path)]
     pub bip_path: Option<Bip44>,
     /// Set the Bech32-encoded wallet address.

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -68,7 +68,7 @@ pub struct InitParameters {
     #[arg(short, long, value_name = "URL", env = "NODE_URL", default_value = DEFAULT_NODE_URL)]
     pub node_url: String,
     /// Set the BIP path. If not provided a bip path has to be provided interactively on first launch.
-    /// The expected format is: `<coin_type>/<account_index>/<address_index>/<change>`.
+    /// The expected format is: `<coin_type>/<account_index>/<change_address>/<address_index>`.
     #[arg(short, long, value_parser = parse_bip_path)]
     pub bip_path: Option<Bip44>,
     /// Set the Bech32-encoded wallet address.
@@ -412,7 +412,7 @@ pub async fn init_command(
 
     let mut alias = init_params.alias;
     if alias.is_none() {
-        if get_decision("Do you want to set an alias of the new wallet?")? {
+        if get_decision("Do you want to set an alias for the new wallet?")? {
             alias.replace(get_alias("Set wallet alias").await?);
         }
     }

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -73,9 +73,7 @@ pub fn enter_address() -> Result<Bech32Address, Error> {
 
 pub fn parse_bip_path(input: &str) -> Result<Bip44, Error> {
     if input.is_empty() || !input.is_ascii() {
-        return Err(eyre!(
-            "invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`"
-        ));
+        bail!("invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`");
     }
 
     let mut segments = Vec::with_capacity(4);
@@ -83,15 +81,13 @@ pub fn parse_bip_path(input: &str) -> Result<Bip44, Error> {
         match segment.parse::<u32>() {
             Ok(s) => segments.push(s),
             Err(err) => {
-                return Err(eyre!("invalid BIP path segment. {i}/`{segment}`: {err}"));
+                bail!("invalid BIP path segment. {i}/`{segment}`: {err}");
             }
         }
     }
 
     if segments.len() != 4 {
-        return Err(eyre!(
-            "invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`"
-        ));
+        bail!("invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`");
     }
 
     let bip_path = Bip44::new(segments[0])

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -38,11 +38,11 @@ pub fn enter_password(prompt: &str, confirmation: bool) -> Result<Password, Erro
     Ok(password.interact()?.into())
 }
 
-pub fn enter_decision(prompt: &str) -> Result<bool, Error> {
+pub fn enter_decision(prompt: &str, default: &str) -> Result<bool, Error> {
     loop {
         let input = Input::<String>::new()
             .with_prompt(prompt)
-            .default("yes".into())
+            .default(default.to_string())
             .interact_text()?;
 
         match input.to_lowercase().as_str() {

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -77,7 +77,6 @@ pub fn enter_bip_path() -> Result<Bip44, Error> {
                 println_log_error!("{s}");
             }
         }
-        // println_log_error!("Invalid input, please enter a valid bip path.");
     }
 }
 
@@ -446,7 +445,7 @@ impl FromStr for BipPathChoice {
 }
 
 pub fn select_or_enter_bip_path() -> Result<BipPathChoice, Error> {
-    let choices = ["4218/0/0/0", "4219/0/0/0", "Custom"];
+    let choices = ["IOTA (4218/0/0/0)", "Shimmer (4219/0/0/0)", "Custom"];
 
     Ok(Select::with_theme(&ColorfulTheme::default())
         .with_prompt("Select bip path")

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -99,7 +99,8 @@ pub fn parse_bip_path(arg: &str) -> Result<Bip44, String> {
 
     if bip_path_enc.len() != 4 {
         return Err(
-            "invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`".to_string(),
+            "invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`"
+                .to_string(),
         );
     }
 

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -55,7 +55,7 @@ pub async fn get_alias(prompt: &str) -> Result<String, Error> {
     loop {
         let input = Input::<String>::new().with_prompt(prompt).interact_text()?;
         if input.is_empty() || !input.is_ascii() {
-            println_log_error!("Invalid input, please choose a non-empty alias consisting of ASCII characters.");
+            println_log_error!("Invalid input, please enter a valid alias (non-empty, ASCII).");
         } else {
             return Ok(input);
         }
@@ -66,7 +66,7 @@ pub async fn get_address(prompt: &str) -> Result<Bech32Address, Error> {
     loop {
         let input = Input::<String>::new().with_prompt(prompt).interact_text()?;
         if input.is_empty() || !input.is_ascii() {
-            println_log_error!("Invalid input, please choose a non-empty address consisting of ASCII characters.");
+            println_log_error!("Invalid input, please enter a valid Bech32 address.");
         } else {
             return Ok(Bech32Address::from_str(&input)?);
         }
@@ -77,9 +77,11 @@ pub async fn get_bip_path(prompt: &str) -> Result<Bip44, Error> {
     loop {
         let input = Input::<String>::new().with_prompt(prompt).interact_text()?;
         if input.is_empty() || !input.is_ascii() {
-            println_log_error!("Invalid input, please choose a non-empty address consisting of ASCII characters.");
+            println_log_error!(
+                "Invalid input, please enter a valid bip path (<coin_type>/<account_index>/<change_address>/<address_index>."
+            );
         } else {
-            return Ok(parse_bip_path(&input).expect("todo"));
+            return Ok(parse_bip_path(&input).map_err(|err| eyre!(err))?);
         }
     }
 }

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -78,7 +78,7 @@ pub async fn get_bip_path(prompt: &str) -> Result<Bip44, Error> {
         let input = Input::<String>::new().with_prompt(prompt).interact_text()?;
         if input.is_empty() || !input.is_ascii() {
             println_log_error!(
-                "Invalid input, please enter a valid bip path (<coin_type>/<account_index>/<change_address>/<address_index>."
+                "Invalid input, please enter a valid bip path (<coin_type>/<account_index>/<change_address>/<address_index>)."
             );
         } else {
             return Ok(parse_bip_path(&input).map_err(|err| eyre!(err))?);
@@ -99,7 +99,7 @@ pub fn parse_bip_path(arg: &str) -> Result<Bip44, String> {
 
     if bip_path_enc.len() != 4 {
         return Err(
-            "invalid BIP path format. Expected: `coin_type/account_index/change_address/address_index`".to_string(),
+            "invalid BIP path format. Expected: `<coin_type>/<account_index>/<change_address>/<address_index>`".to_string(),
         );
     }
 

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -35,7 +35,7 @@ use rustyline::{error::ReadlineError, history::MemHistory, Config, Editor};
 
 use self::completer::WalletCommandHelper;
 use crate::{
-    helper::{bytes_from_hex_or_file, get_password, to_utc_date_time},
+    helper::{bytes_from_hex_or_file, enter_password, to_utc_date_time},
     println_log_error, println_log_info,
 };
 
@@ -1411,7 +1411,7 @@ async fn ensure_password(wallet: &Wallet) -> Result<(), Error> {
     if matches!(*wallet.secret_manager().read().await, SecretManager::Stronghold(_))
         && !wallet.is_stronghold_password_available().await?
     {
-        let password = get_password("Stronghold password", false)?;
+        let password = enter_password("Stronghold password", false)?;
         wallet.set_stronghold_password(password).await?;
     }
 


### PR DESCRIPTION
# Description of change

This PR suggests the changes:
* allow to specify `alias` in the `InitParameters`, because that just seems right to allow that;
* removes the default bip path in `InitParameters`, because defaulting to a certain network could be confusing for some users;
* after the wallet has been successfully created, more information is printed and logged as a summary, because that not only helps us debugging from user provided log files, but also tells the user whether the wallet is how s/he wanted it to be created.

## Links to any relevant issues

Fixes #2052 

