### PR TITLE
Fix an infinite loop with auto allotment

### DIFF
--- a/sdk/src/client/api/block_builder/transaction_builder/mod.rs
+++ b/sdk/src/client/api/block_builder/transaction_builder/mod.rs
@@ -210,7 +210,7 @@ pub(crate) struct MinManaAllotment {
     required_allotment: Option<u64>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct Remainders {
     address: Option<Address>,
     data: Vec<RemainderData>,
@@ -544,11 +544,6 @@ impl TransactionBuilder {
             .unwrap()
             .expect("expiration unlockable outputs already filtered out");
         self.selected_inputs.insert(required_address, input);
-
-        // Remove the cached allotment value because it's no longer valid
-        if let Some(MinManaAllotment { required_allotment, .. }) = self.min_mana_allotment.as_mut() {
-            *required_allotment = None;
-        }
 
         Ok(added_output)
     }

--- a/sdk/src/client/api/block_builder/transaction_builder/requirement/mana.rs
+++ b/sdk/src/client/api/block_builder/transaction_builder/requirement/mana.rs
@@ -66,7 +66,7 @@ impl TransactionBuilder {
         // Remainders can only be calculated when the input mana is >= the output mana
         let (input_mana, output_mana) = self.mana_sums(false)?;
         if input_mana >= output_mana {
-            self.update_remainders()?;
+            should_recalculate |= self.update_remainders()?;
         }
 
         should_recalculate |= self.get_inputs_for_mana_balance()?;
@@ -89,7 +89,7 @@ impl TransactionBuilder {
             return Ok(None);
         };
 
-        if required_allotment.is_none() && !self.selected_inputs.is_empty() && self.all_outputs().next().is_some() {
+        if !self.selected_inputs.is_empty() && self.all_outputs().next().is_some() {
             let inputs = self
                 .selected_inputs
                 .sorted_iter()
@@ -301,7 +301,10 @@ impl TransactionBuilder {
 
     pub(crate) fn mana_sums(&mut self, include_remainders: bool) -> Result<(u64, u64), TransactionBuilderError> {
         let allotments_sum = if let Some(MinManaAllotment { issuer_id, .. }) = self.min_mana_allotment {
-            let required_allotment = self.required_allotment()?.unwrap_or_default();
+            let mut required_allotment = self.min_mana_allotment.and_then(|a| a.required_allotment);
+            if required_allotment.is_none() {
+                required_allotment = self.required_allotment()?;
+            }
             self.mana_allotments
                 .iter()
                 .filter_map(|(id, value)| (id != &issuer_id).then_some(value))
@@ -311,7 +314,7 @@ impl TransactionBuilder {
                     .get(&issuer_id)
                     .copied()
                     .unwrap_or_default()
-                    .max(required_allotment)
+                    .max(required_allotment.unwrap_or_default())
         } else {
             self.mana_allotments.values().sum::<u64>()
         };

--- a/sdk/src/client/api/block_builder/transaction_builder/requirement/mana.rs
+++ b/sdk/src/client/api/block_builder/transaction_builder/requirement/mana.rs
@@ -61,8 +61,6 @@ impl TransactionBuilder {
             }
 
             should_recalculate |= self.reduce_account_output()?;
-        } else {
-            should_recalculate = true;
         }
 
         // Remainders can only be calculated when the input mana is >= the output mana


### PR DESCRIPTION
# Description of change

There is a problem when auto allotting when there are only accounts available which will not provide enough mana, where the allotment will loop forever. This is because we always re-check when the transaction cannot be built due to missing inputs or outputs. However, we should only re-check when new inputs are selected.