### PR TITLE
Fix RestrictedAddress discriminator usage

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-alpha.2 - 2024-MM-DD
+
+### Fixed
+
+- `RestrictedAddress` discriminator usage;
+
 ## 2.0.0-alpha.1 - 2024-03-22
 
 Initial alpha release of the Nodejs 2.0 bindings.

--- a/bindings/nodejs/lib/types/block/address.ts
+++ b/bindings/nodejs/lib/types/block/address.ts
@@ -206,6 +206,7 @@ class RestrictedAddress extends Address {
      */
     @Type(() => Address, {
         discriminator: RestrictedAddressDiscriminator,
+        keepDiscriminatorProperty: true,
     })
     readonly address: Address;
     /**

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-alpha.2 - 2024-MM-DD
+
+Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.
+
 ## 2.0.0-alpha.1 - 2024-03-26
 
 Initial alpha release of the wasm 2.0 bindings.

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0-alpha.2 - 2024-MM-DD
 
-Same changes as https://github.com/iotaledger/iota-sdk/blob/develop/bindings/nodejs/CHANGELOG.md.
+Same changes as https://github.com/iotaledger/iota-sdk/blob/2.0/bindings/nodejs/CHANGELOG.md.
 
 ## 2.0.0-alpha.1 - 2024-03-26
 


### PR DESCRIPTION
# Description of change

Fix RestrictedAddress discriminator usage

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Nodejs example that runs `RestrictedAddress.parse(address)` twice with the same input
