### PR TITLE
fix: Sync typescript unlock condition types

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## Unreleased - 2024-04-04
+
+### Fixed
+
+- Updated the TypeScript types for Unlock Conditions to match their Rust equivalent.;
+
 ## 2.0.0-alpha.3 - 2024-04-03
 
 ### Fixed

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## Unreleased - 2024-04-04
+## 2.0.0-alpha.4 - 2024-04-DD
 
-### Fixed
+### Changed
 
-- Updated the TypeScript types for Unlock Conditions to match their Rust equivalent.;
+- Renamed `{TimelockUnlockCondition, ExpirationUnlockCondition}::slotIndex to slot`;
 
 ## 2.0.0-alpha.3 - 2024-04-03
 

--- a/bindings/nodejs/lib/types/block/output/unlock-condition.ts
+++ b/bindings/nodejs/lib/types/block/output/unlock-condition.ts
@@ -149,11 +149,11 @@ class TimelockUnlockCondition extends UnlockCondition {
     /**
      * Slot index starting from which the output can be consumed.
      */
-    readonly slotIndex: SlotIndex;
+    readonly slot: SlotIndex;
 
-    constructor(slotIndex: SlotIndex) {
+    constructor(slot: SlotIndex) {
         super(UnlockConditionType.Timelock);
-        this.slotIndex = slotIndex;
+        this.slot = slot;
     }
 }
 
@@ -172,16 +172,16 @@ class ExpirationUnlockCondition extends UnlockCondition {
     /**
      * Before this slot index, the Address Unlock Condition is allowed to unlock the output, after that only the address defined in Return Address can.
      */
-    readonly slotIndex: SlotIndex;
+    readonly slot: SlotIndex;
 
     /**
      * @param returnAddress The address that can unlock the expired output.
-     * @param slotIndex The slot index timestamp marking the end of the claim period.
+     * @param slot The slot index timestamp marking the end of the claim period.
      */
-    constructor(returnAddress: Address, slotIndex: SlotIndex) {
+    constructor(returnAddress: Address, slot: SlotIndex) {
         super(UnlockConditionType.Expiration);
         this.returnAddress = returnAddress;
-        this.slotIndex = slotIndex;
+        this.slot = slot;
     }
 }
 


### PR DESCRIPTION
Sync typescript unlock condition types.

Rust uses `slot` not `slotIndex`, you can see this for instance in `TimelockUnlockConditionDto`.