### PR TITLE
Use release flag for napi

### DIFF
--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 2.0.0-alpha.4 - 2024-04-DD
+## 2.0.0-alpha.4 - 2024-04-04
 
 ### Changed
 

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk",
-    "version": "2.0.0-alpha.3",
+    "version": "2.0.0-alpha.4",
     "description": "Node.js binding to the IOTA SDK library",
     "main": "out/index.js",
     "types": "out/index.d.ts",
@@ -12,7 +12,7 @@
         "format-check": "prettier --ignore-path .eslintignore -c \"{,*/**/}*.{ts,js,json}\"",
         "prebuild-x64": "prebuild --runtime napi --target 6 --prepack scripts/build.js --strip --arch x64",
         "prebuild-macos-arm64": "prebuild --runtime napi --target 6 --prepack 'yarn run napi-build-macos-arm64' --strip --arch arm64",
-        "napi-build-macos-arm64": "napi build --cargo-flags=--profile=production --target aarch64-apple-darwin",
+        "napi-build-macos-arm64": "napi build --release --target aarch64-apple-darwin",
         "prebuild-linux-arm64": "prebuild --runtime napi --target 6 --prepack 'yarn run napi-build-linux-arm64' --strip --arch arm64",
         "napi-build-linux-arm64": "napi build --cargo-flags=--profile=production --target aarch64-unknown-linux-gnu",
         "prebuild-windows-arm64": "prebuild --runtime napi --target 6 --prepack 'yarn run napi-build-windows-arm64' --strip --arch arm64",


### PR DESCRIPTION
# Description of change

Use release flag for napi as something in the build process changed which doesn't properly work with the cargo flags anymore

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Building it
