### PR TITLE
Fix wasm compilation, bump wasm-bindgen

### DIFF
--- a/.github/workflows/bindings-wasm-publish.yml
+++ b/.github/workflows/bindings-wasm-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@v0.2.0
         with:
-          version: "0.2.91"
+          version: "0.2.92"
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/bindings-wasm.yml
+++ b/.github/workflows/bindings-wasm.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         uses: jetli/wasm-bindgen-action@v0.2.0
         with:
-          version: "0.2.91"
+          version: "0.2.92"
 
       - name: Set Up Node.js ${{ matrix.node }} and Yarn Cache
         uses: actions/setup-node@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1928,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,9 +3547,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "serde",
@@ -3559,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -3586,9 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3596,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3609,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-logger"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -28,7 +28,7 @@ js-sys = { version = "0.3.68", default-features = false, features = [] }
 log = { version = "0.4.20", default-features = false }
 serde_json = { version = "1.0.113", default-features = false }
 tokio = { version = "1.36.0", default-features = false, features = ["sync"] }
-wasm-bindgen = { version = "0.2.91", default-features = false, features = [
+wasm-bindgen = { version = "0.2.92", default-features = false, features = [
     "spans",
     "std",
     "serde-serialize",

--- a/sdk/src/client/core.rs
+++ b/sdk/src/client/core.rs
@@ -62,12 +62,13 @@ pub struct ClientInner {
     pub(crate) request_pool: RequestPool,
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[derive(Default)]
 pub(crate) struct SyncHandle(pub(crate) Option<tokio::task::JoinHandle<()>>);
 
+#[cfg(not(target_family = "wasm"))]
 impl Drop for SyncHandle {
     fn drop(&mut self) {
-        #[cfg(not(target_family = "wasm"))]
         if let Some(sync_handle) = self.0.take() {
             sync_handle.abort();
         }


### PR DESCRIPTION
# Description of change

Fix wasm compilation that broke with the latest rust version, see https://github.com/iotaledger/iota-sdk/actions/runs/8689172617/job/23826349127?pr=2220

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Compiled it