### PR TITLE
Fix restore_from_stronghold_snapshot() with same source and target path

### DIFF
--- a/.github/actions/private-tangle/setup/action.yml
+++ b/.github/actions/private-tangle/setup/action.yml
@@ -27,6 +27,11 @@ runs:
         go-version-file: "iota-core/go.mod"
         cache: false
 
+    - name: Unblock port 8084
+      shell: bash
+      run: |
+        sudo kill -9 `sudo lsof -t -i:8084`
+
     - name: Setup private tangle
       shell: bash
       # setup-go sets the PATH for the correct version, but sudo uses a different PATH by default

--- a/.github/actions/private-tangle/setup/action.yml
+++ b/.github/actions/private-tangle/setup/action.yml
@@ -27,10 +27,10 @@ runs:
         go-version-file: "iota-core/go.mod"
         cache: false
 
-    - name: Unblock port 8084
+    - name: Replace port 8084 by 8087 as it's already used by Mono
       shell: bash
-      run: |
-        sudo kill -9 `sudo lsof -t -i:8084`
+      run: sed -i 's#8084#8087#g' docker-compose.yml
+      working-directory: iota-core/tools/docker-network
 
     - name: Setup private tangle
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,7 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2810,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-alpha.8 - 2024-04-22
+
+### Fixed
+
+- `Wallet::restoreFromStrongholdSnapshot()` with same source and target path;
+
 ## 2.0.0-alpha.7 - 2024-04-19
 
 ### Fixed

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk",
-    "version": "2.0.0-alpha.7",
+    "version": "2.0.0-alpha.8",
     "description": "Node.js binding to the IOTA SDK library",
     "main": "out/index.js",
     "types": "out/index.d.ts",

--- a/sdk/src/wallet/core/operations/stronghold_backup/mod.rs
+++ b/sdk/src/wallet/core/operations/stronghold_backup/mod.rs
@@ -134,7 +134,7 @@ impl Wallet {
                 .map_err(|_| WalletError::Backup("invalid secret_manager"))?;
 
             // Copy Stronghold file so the seed is available in the new location
-            if backup_path != new_snapshot_path {
+            if backup_path.canonicalize()? != new_snapshot_path.canonicalize()? {
                 fs::copy(backup_path, new_snapshot_path)?;
             }
 
@@ -146,7 +146,7 @@ impl Wallet {
         } else {
             // If no secret manager data was in the backup, just copy the Stronghold file so the seed is available in
             // the new location.
-            if backup_path != new_snapshot_path {
+            if backup_path.canonicalize()? != new_snapshot_path.canonicalize()? {
                 fs::copy(backup_path, new_snapshot_path)?;
             }
         }
@@ -298,7 +298,7 @@ impl Wallet<StrongholdSecretManager> {
                 .map_err(|_| WalletError::Backup("invalid secret_manager"))?;
 
             // Copy Stronghold file so the seed is available in the new location
-            if backup_path != new_snapshot_path {
+            if backup_path.canonicalize()? != new_snapshot_path.canonicalize()? {
                 fs::copy(backup_path, new_snapshot_path)?;
             }
 

--- a/sdk/src/wallet/core/operations/stronghold_backup/mod.rs
+++ b/sdk/src/wallet/core/operations/stronghold_backup/mod.rs
@@ -134,7 +134,9 @@ impl Wallet {
                 .map_err(|_| WalletError::Backup("invalid secret_manager"))?;
 
             // Copy Stronghold file so the seed is available in the new location
-            fs::copy(backup_path, new_snapshot_path)?;
+            if backup_path != new_snapshot_path {
+                fs::copy(backup_path, new_snapshot_path)?;
+            }
 
             if let SecretManager::Stronghold(stronghold) = &restored_secret_manager {
                 // Set password to restored secret manager
@@ -144,7 +146,9 @@ impl Wallet {
         } else {
             // If no secret manager data was in the backup, just copy the Stronghold file so the seed is available in
             // the new location.
-            fs::copy(backup_path, new_snapshot_path)?;
+            if backup_path != new_snapshot_path {
+                fs::copy(backup_path, new_snapshot_path)?;
+            }
         }
 
         if ignore_if_bip_path_mismatch.is_none() {
@@ -294,7 +298,9 @@ impl Wallet<StrongholdSecretManager> {
                 .map_err(|_| WalletError::Backup("invalid secret_manager"))?;
 
             // Copy Stronghold file so the seed is available in the new location
-            fs::copy(backup_path, new_snapshot_path)?;
+            if backup_path != new_snapshot_path {
+                fs::copy(backup_path, new_snapshot_path)?;
+            }
 
             // Set password to restored secret manager
             restored_secret_manager.set_password(stronghold_password).await?;


### PR DESCRIPTION
# Description of change

Fix restore_from_stronghold_snapshot() for the case when source and target path are the same. Without this change std::fs::copy() truncates the backup file, resulting in `Error: Stronghold(Client(ClientDataNotPresent))` 

Port 8084 seems to be used by Mono https://github.com/actions/runner-images/issues/2820, so replaced this port for the dashboard

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added test
