### PR TITLE
Fix staking amount

### DIFF
--- a/sdk/src/client/api/block_builder/transaction_builder/transition.rs
+++ b/sdk/src/client/api/block_builder/transaction_builder/transition.rs
@@ -69,6 +69,8 @@ impl TransactionBuilder {
             .cloned()
             .collect::<Vec<_>>();
 
+        let mut new_amount = None;
+
         if let Some(change) = self.transitions.as_ref().and_then(|t| t.accounts.get(&account_id)) {
             match change {
                 AccountChange::BeginStaking {
@@ -83,6 +85,7 @@ impl TransactionBuilder {
                         self.protocol_parameters
                             .past_bounded_slot(self.latest_slot_commitment_id),
                     );
+                    new_amount = Some(*staked_amount);
                     features.push(
                         StakingFeature::new(
                             *staked_amount,
@@ -101,6 +104,7 @@ impl TransactionBuilder {
                             .protocol_parameters
                             .future_bounded_epoch(self.latest_slot_commitment_id);
                         let staking_feature = feature.as_staking();
+                        new_amount = Some(staking_feature.staked_amount());
                         // Just extend the end epoch if it's still possible
                         if future_bounded_epoch <= staking_feature.end_epoch() {
                             *feature = StakingFeature::new(
@@ -144,11 +148,14 @@ impl TransactionBuilder {
         }
 
         let mut builder = AccountOutputBuilder::from(input)
-            .with_minimum_amount(self.protocol_parameters.storage_score_parameters())
             .with_mana(0)
             .with_account_id(account_id)
             .with_foundry_counter(u32::max(highest_foundry_serial_number, input.foundry_counter()))
             .with_features(features);
+        match new_amount {
+            Some(amount) => builder = builder.with_amount(amount),
+            None => builder = builder.with_minimum_amount(self.protocol_parameters.storage_score_parameters()),
+        }
 
         // Block issuers cannot move their mana elsewhere.
         if input.is_block_issuer() {


### PR DESCRIPTION
# Description of change

Fix staking amount when start staking and also don't set the account output amount to min amount when extending staking

## Links to any relevant issues

Fixes https://github.com/iotaledger/iota-sdk/issues/2236

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Staked the full amount with the cli
```
Balance {
    base_coin: BaseCoinBalance {
        total: 2000000000,
...
Wallet "wallet": begin-staking 0xac7470df11783cdc153689da2a0bd138c99dc351f530099538afadb4b5a89b14 2000000000 2
Stronghold password: [hidden]
Begin staking for 0xac7470df11783cdc153689da2a0bd138c99dc351f530099538afadb4b5a89b14.
Begin staking transaction sent:
TransactionId { id: "0xb4c36cb18b6085e8c21dc494a05273f62fe1489ba764a8d6892538c8d02d00f4c9270100", slot_index: SlotIndex(75721) }
Some(BlockId { id: "0xf9ed06be0122e4328c19207d987a15e8ac663e40c1aebac2692c0d891f0bd058c9270100", slot_index: SlotIndex(75721) })
```
