### PR TITLE
Don't set with_minimum_amount for accounts when they have a staking feature

### DIFF
--- a/sdk/src/client/api/block_builder/transaction_builder/transition.rs
+++ b/sdk/src/client/api/block_builder/transaction_builder/transition.rs
@@ -172,7 +172,11 @@ impl TransactionBuilder {
             .with_features(features);
         match new_amount {
             Some(amount) => builder = builder.with_amount(amount),
-            None => builder = builder.with_minimum_amount(self.protocol_parameters.storage_score_parameters()),
+            None => {
+                if input.features().staking().is_none() {
+                    builder = builder.with_minimum_amount(self.protocol_parameters.storage_score_parameters());
+                }
+            }
         }
 
         // Block issuers cannot move their mana elsewhere.


### PR DESCRIPTION
# Description of change

Don't set with_minimum_amount for accounts when they have a staking feature, as this would result in an invalid transition

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Sending txs with the cli wallet