### PR TITLE
Fix get_output_mana_rewards, clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "iota-sdk-python"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 dependencies = [
  "futures",
  "iota-sdk-bindings-core",

--- a/bindings/core/src/method/client.rs
+++ b/bindings/core/src/method/client.rs
@@ -169,7 +169,7 @@ pub enum ClientMethod {
         /// epoch - 1 is also used as the last epoch for which rewards are fetched. Callers that do not build
         /// transactions with the returned values may omit this value in which case it defaults to the latest committed
         /// slot, which is good enough to, e.g. display estimated rewards to users.
-        slot_index: Option<SlotIndex>,
+        slot: Option<SlotIndex>,
     },
     /// Returns information of all registered validators and if they are active, ordered by their holding stake.
     #[serde(rename_all = "camelCase")]

--- a/bindings/core/src/method_handler/client.rs
+++ b/bindings/core/src/method_handler/client.rs
@@ -189,8 +189,8 @@ pub(crate) async fn call_client_method_internal(
         ClientMethod::GetAccountCongestion { account_id, work_score } => {
             Response::Congestion(client.get_account_congestion(&account_id, work_score).await?)
         }
-        ClientMethod::GetOutputManaRewards { output_id, slot_index } => {
-            Response::ManaRewards(client.get_output_mana_rewards(&output_id, slot_index).await?)
+        ClientMethod::GetOutputManaRewards { output_id, slot } => {
+            Response::ManaRewards(client.get_output_mana_rewards(&output_id, slot).await?)
         }
         ClientMethod::GetValidators { page_size, cursor } => {
             Response::Validators(client.get_validators(page_size, cursor).await?)

--- a/bindings/nodejs/CHANGELOG.md
+++ b/bindings/nodejs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.1 - 2024-05-08
+
+### Fixed
+
+- `Client::getOutputManaRewards()` slot query parameter;
+
 ## 2.0.0-alpha.9 - 2024-05-02
 
 ### Added

--- a/bindings/nodejs/lib/client/client.ts
+++ b/bindings/nodejs/lib/client/client.ts
@@ -198,13 +198,13 @@ export class Client {
      */
     async getOutputManaRewards(
         outputId: OutputId,
-        slotIndex?: SlotIndex,
+        slot?: SlotIndex,
     ): Promise<ManaRewardsResponse> {
         const response = await this.methodHandler.callMethod({
             name: 'getOutputManaRewards',
             data: {
                 outputId,
-                slotIndex,
+                slot,
             },
         });
 

--- a/bindings/nodejs/lib/types/client/bridge/client.ts
+++ b/bindings/nodejs/lib/types/client/bridge/client.ts
@@ -78,7 +78,7 @@ export interface __GetOutputManaRewardsMethod__ {
     name: 'getOutputManaRewards';
     data: {
         outputId: OutputId;
-        slotIndex?: SlotIndex;
+        slot?: SlotIndex;
     };
 }
 

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk",
-    "version": "2.0.0-alpha.9",
+    "version": "2.0.0-beta.1",
     "description": "Node.js binding to the IOTA SDK library",
     "main": "out/index.js",
     "types": "out/index.d.ts",

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.1 - 2024-05-08
+
+### Fixed
+
+- `Client::get_output_mana_rewards()` slot query parameter;
+
 ## 2.0.0-alpha.1 - 2024-05-07
 
 Initial alpha release of the Python 2.0 bindings.

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-sdk-python"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "Python bindings for the IOTA SDK library"

--- a/bindings/python/iota_sdk/client/_node_core_api.py
+++ b/bindings/python/iota_sdk/client/_node_core_api.py
@@ -107,7 +107,7 @@ class NodeCoreAPI(metaclass=ABCMeta):
     # Rewards routes.
 
     def get_output_mana_rewards(
-            self, output_id: OutputId, slot_index: Optional[SlotIndex] = None) -> ManaRewardsResponse:
+            self, output_id: OutputId, slot: Optional[SlotIndex] = None) -> ManaRewardsResponse:
         """Returns the total available Mana rewards of an account or delegation output decayed up to `epochEnd` index
         provided in the response.
         Note that rewards for an epoch only become available at the beginning of the next epoch. If the end epoch of a
@@ -118,7 +118,7 @@ class NodeCoreAPI(metaclass=ABCMeta):
         """
         return ManaRewardsResponse.from_dict(self._call_method('getOutputManaRewards', {
             'outputId': output_id,
-            'slotIndex': slot_index
+            'slot': slot
         }))
 
     # Validators routes.

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -22,7 +22,7 @@ def get_py_version_cfgs():
 
 setup(
     name="iota_sdk",
-    version="2.0.0-alpha.1",
+    version="2.0.0-beta.1",
     classifiers=[
         "License :: SPDX-License-Identifier ::  Apache-2.0",
         "Intended Audience :: Developers",

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.1 - 2024-05-08
+
+Same changes as https://github.com/iotaledger/iota-sdk/blob/2.0/bindings/nodejs/CHANGELOG.md.
+
 ## 2.0.0-alpha.3 - 2024-04-19
 
 Same changes as https://github.com/iotaledger/iota-sdk/blob/2.0/bindings/nodejs/CHANGELOG.md.

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iota/sdk-wasm",
-    "version": "2.0.0-alpha.3",
+    "version": "2.0.0-beta.1",
     "description": "WebAssembly bindings for the IOTA SDK library",
     "repository": {
         "type": "git",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -393,17 +393,13 @@ pub async fn init_command(storage_path: &Path, init_params: InitParameters) -> R
     }
 
     let mut bip_path = init_params.bip_path;
-    if bip_path.is_none() {
-        if forced || enter_decision("Do you want to set the bip path of the new wallet?", "yes")? {
-            bip_path.replace(select_or_enter_bip_path()?);
-        }
+    if bip_path.is_none() && forced || enter_decision("Do you want to set the bip path of the new wallet?", "yes")? {
+        bip_path.replace(select_or_enter_bip_path()?);
     }
 
     let mut alias = init_params.alias;
-    if alias.is_none() {
-        if enter_decision("Do you want to set an alias for the new wallet?", "yes")? {
-            alias.replace(enter_alias()?);
-        }
+    if alias.is_none() && enter_decision("Do you want to set an alias for the new wallet?", "yes")? {
+        alias.replace(enter_alias()?);
     }
 
     let wallet = Wallet::builder()

--- a/cli/src/helper.rs
+++ b/cli/src/helper.rs
@@ -4,7 +4,7 @@
 use core::str::FromStr;
 use std::path::Path;
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use dialoguer::{console::Term, theme::ColorfulTheme, Input, Select};
 use eyre::{bail, eyre, Error};
 use iota_sdk::{
@@ -342,10 +342,7 @@ pub fn to_utc_date_time(ts_millis: u128) -> Result<DateTime<Utc>, Error> {
     let secs_int = i64::try_from(secs).map_err(|e| eyre!("Failed to convert timestamp to i64: {e}"))?;
     let nanos = u32::try_from(millis * 1000000).map_err(|e| eyre!("Failed to convert timestamp to u32: {e}"))?;
 
-    let naive_time = NaiveDateTime::from_timestamp_opt(secs_int, nanos)
-        .ok_or(eyre!("Failed to convert timestamp to NaiveDateTime"))?;
-
-    Ok(naive_time.and_utc())
+    DateTime::from_timestamp(secs_int, nanos).ok_or(eyre!("Failed to convert timestamp to DateTime"))
 }
 
 pub async fn check_file_exists(path: &Path) -> Result<(), Error> {
@@ -409,7 +406,6 @@ pub fn select_or_enter_bip_path() -> Result<Bip44, Error> {
             .items(&choices)
             .default(0)
             .interact_on(&Term::stderr())?
-            .into()
         {
             0 => Bip44::new(IOTA_COIN_TYPE),
             1 => Bip44::new(SHIMMER_COIN_TYPE),

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.1 - 2024-05-08
+
+### Fixed
+
+- `Client::get_output_mana_rewards()` slot query parameter;
+
 ## 2.0.0-alpha.1 - 2024-04-29
 
 Initial alpha release of the 2.0 SDK.

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota-sdk"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "The IOTA SDK provides developers with a seamless experience to develop on IOTA by providing account abstractions and clients to interact with node APIs."

--- a/sdk/src/client/api/block_builder/transaction_builder/context_inputs.rs
+++ b/sdk/src/client/api/block_builder/transaction_builder/context_inputs.rs
@@ -11,6 +11,8 @@ use crate::{
 };
 
 impl TransactionBuilder {
+    // Clippy's suggestion greatly degrades readability.
+    #[allow(clippy::useless_let_if_seq)]
     pub(crate) fn fulfill_context_inputs_requirements(&mut self, input: &InputSigningData) {
         match &input.output {
             // Transitioning an issuer account requires a BlockIssuanceCreditContextInput.

--- a/sdk/src/client/node_api/core/routes.rs
+++ b/sdk/src/client/node_api/core/routes.rs
@@ -146,10 +146,10 @@ impl Client {
     pub async fn get_output_mana_rewards(
         &self,
         output_id: &OutputId,
-        slot_index: impl Into<Option<SlotIndex>> + Send,
+        slot: impl Into<Option<SlotIndex>> + Send,
     ) -> Result<ManaRewardsResponse, ClientError> {
         let path = &format!("api/core/v3/rewards/{output_id}");
-        let query = query_tuples_to_query_string([slot_index.into().map(|i| ("slotIndex", i.to_string()))]);
+        let query = query_tuples_to_query_string([slot.into().map(|i| ("slot", i.to_string()))]);
 
         self.get_request(path, query.as_deref(), false).await
     }

--- a/sdk/src/wallet/core/operations/background_syncing.rs
+++ b/sdk/src/wallet/core/operations/background_syncing.rs
@@ -56,7 +56,7 @@ where
             loop {
                 log::debug!("[background_syncing]: syncing wallet");
 
-                if let Err(err) = wallet.sync(options.clone()).await {
+                if let Err(err) = wallet.sync(options).await {
                     log::debug!("[background_syncing] error: {}", err)
                 }
 

--- a/sdk/src/wallet/operations/syncing/addresses/output_ids/account_foundry.rs
+++ b/sdk/src/wallet/operations/syncing/addresses/output_ids/account_foundry.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-
 use crate::{
     client::{
         node_api::indexer::query_parameters::{AccountOutputQueryParameters, FoundryOutputQueryParameters},

--- a/sdk/src/wallet/operations/syncing/addresses/output_ids/mod.rs
+++ b/sdk/src/wallet/operations/syncing/addresses/output_ids/mod.rs
@@ -112,7 +112,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
                 tasks.push(
                     async {
                         let bech32_address = address.clone();
-                        let sync_options = sync_options.clone();
+                        let sync_options = *sync_options;
                         let wallet = self.clone();
                         tokio::spawn(async move {
                             wallet
@@ -260,7 +260,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
                 let mut tasks = Vec::new();
                 for address in addresses_chunk {
                     let wallet = self.clone();
-                    let sync_options = options.clone();
+                    let sync_options = *options;
                     tasks.push(async move {
                         tokio::spawn(async move {
                             let output_ids = wallet

--- a/sdk/src/wallet/operations/syncing/mod.rs
+++ b/sdk/src/wallet/operations/syncing/mod.rs
@@ -41,7 +41,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
 
     // Get the default sync options we use when none are provided.
     pub async fn default_sync_options(&self) -> SyncOptions {
-        self.default_sync_options.lock().await.clone()
+        *self.default_sync_options.lock().await
     }
 
     // First request all outputs directly related to the wallet address, then for each nft and account output we got,

--- a/sdk/src/wallet/operations/syncing/outputs.rs
+++ b/sdk/src/wallet/operations/syncing/outputs.rs
@@ -71,7 +71,7 @@ impl<S: 'static + SecretManage> Wallet<S> {
         let mut wallet_ledger = self.ledger_mut().await;
 
         for output_id in output_ids {
-            match wallet_ledger.outputs.get_mut(&output_id) {
+            match wallet_ledger.outputs.get_mut(output_id) {
                 // set unspent if not already
                 Some(output_data) => {
                     if output_data.is_spent() {


### PR DESCRIPTION
# Description of change

Fix get_output_mana_rewards, the slot query param was wrong (`slotIndex` instead of `slot`, clippy

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```JS
        const commitment = await client.getOutputManaRewards(
            '0x980709653c07932d28dfeda348243e92de5d1bb7ca9cffbfac069c214ef271a9000000000300',
            300000,
        );
        console.log(commitment);
```