### PR TITLE
Fix block issuer key from bytes conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cli-wallet"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 2.0.0-beta.2 - 2024-05-14
+
+### Changed
+
+- Set `SyncOptions::account::basic_outputs` to true;
+
+### Fixed
+
+- Hash public key in `add-block-issuer-key` and `remove-block-issuer-key`;
+
 ## 2.0.0-beta.1 - 2024-05-08
 
 ### Fixed

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-wallet"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 homepage = "https://iota.org"

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -26,9 +26,9 @@ use iota_sdk::{
     },
     utils::ConvertTo,
     wallet::{
-        types::OutputData, BeginStakingParams, ConsolidationParams, CreateDelegationParams, CreateNativeTokenParams,
-        MintNftParams, ModifyAccountBlockIssuerKey, OutputsToClaim, ReturnStrategy, SendManaParams,
-        SendNativeTokenParams, SendNftParams, SendParams, SyncOptions, Wallet, WalletError,
+        types::OutputData, AccountSyncOptions, BeginStakingParams, ConsolidationParams, CreateDelegationParams,
+        CreateNativeTokenParams, MintNftParams, ModifyAccountBlockIssuerKey, OutputsToClaim, ReturnStrategy,
+        SendManaParams, SendNativeTokenParams, SendNftParams, SendParams, SyncOptions, Wallet, WalletError,
     },
     U256,
 };
@@ -752,7 +752,17 @@ pub async fn create_native_token_command(
             .wait_for_transaction_acceptance(&transaction.transaction_id, None, None)
             .await?;
         // Sync wallet after the transaction got confirmed, so the account output is available
-        wallet.sync(None).await?;
+        wallet
+            .sync(Some(SyncOptions {
+                sync_native_token_foundries: true,
+                sync_implicit_accounts: true,
+                account: AccountSyncOptions {
+                    basic_outputs: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }))
+            .await?;
     }
 
     let params = CreateNativeTokenParams {
@@ -1200,6 +1210,10 @@ pub async fn sync_command(wallet: &Wallet) -> Result<(), Error> {
         .sync(Some(SyncOptions {
             sync_native_token_foundries: true,
             sync_implicit_accounts: true,
+            account: AccountSyncOptions {
+                basic_outputs: true,
+                ..Default::default()
+            },
             ..Default::default()
         }))
         .await?;

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -10,6 +10,7 @@ use colored::Colorize;
 use eyre::Error;
 use iota_sdk::{
     client::{api::options::TransactionOptions, request_funds_from_faucet, secret::SecretManager},
+    crypto::signatures::ed25519::PublicKey,
     types::block::{
         address::{AccountAddress, Bech32Address, ToBech32Ext},
         mana::ManaAllotment,
@@ -942,10 +943,10 @@ pub async fn implicit_accounts_command(wallet: &Wallet) -> Result<(), Error> {
 
 // `add-block-issuer-key` command
 pub async fn add_block_issuer_key(wallet: &Wallet, account_id: AccountId, issuer_key: &str) -> Result<(), Error> {
-    let issuer_key: [u8; Ed25519PublicKeyHashBlockIssuerKey::LENGTH] = prefix_hex::decode(issuer_key)?;
+    let public_key = PublicKey::try_from_bytes(prefix_hex::decode(issuer_key)?)?;
     let params = ModifyAccountBlockIssuerKey {
         account_id,
-        keys_to_add: vec![Ed25519PublicKeyHashBlockIssuerKey::new(issuer_key).into()],
+        keys_to_add: vec![Ed25519PublicKeyHashBlockIssuerKey::from_public_key(public_key).into()],
         keys_to_remove: vec![],
     };
 
@@ -962,11 +963,11 @@ pub async fn add_block_issuer_key(wallet: &Wallet, account_id: AccountId, issuer
 
 // `remove-block-issuer-key` command
 pub async fn remove_block_issuer_key(wallet: &Wallet, account_id: AccountId, issuer_key: &str) -> Result<(), Error> {
-    let issuer_key: [u8; Ed25519PublicKeyHashBlockIssuerKey::LENGTH] = prefix_hex::decode(issuer_key)?;
+    let public_key = PublicKey::try_from_bytes(prefix_hex::decode(issuer_key)?)?;
     let params = ModifyAccountBlockIssuerKey {
         account_id,
         keys_to_add: vec![],
-        keys_to_remove: vec![Ed25519PublicKeyHashBlockIssuerKey::new(issuer_key).into()],
+        keys_to_remove: vec![Ed25519PublicKeyHashBlockIssuerKey::from_public_key(public_key).into()],
     };
 
     let transaction = wallet.modify_account_output_block_issuer_keys(params, None).await?;


### PR DESCRIPTION
# Description of change

Allow inputting an Ed25519 Public Key and use the hash of it as the block issuer key.

## Links to any relevant issues

n/a

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
